### PR TITLE
Fix cluster solver check

### DIFF
--- a/applications/cluster_solver_check/cluster_solver_check.cpp
+++ b/applications/cluster_solver_check/cluster_solver_check.cpp
@@ -115,14 +115,14 @@ int main(int argc, char** argv) {
   // If enabled, perform statistical test.
   double p_val = -1.;
   if (perform_statistical_test) {
-    const auto G_qmc(dca::math::util::cutFrequency(qmc_solver.local_G_k_w(), tested_frequencies));
+    auto G_qmc(dca::math::util::cutFrequency(qmc_solver.local_G_k_w(), tested_frequencies));
 
     using KDmn = dca::func::dmn_0<dca::phys::domains::cluster_domain<
         double, Lattice::DIMENSION, dca::phys::domains::CLUSTER, dca::phys::domains::MOMENTUM_SPACE,
         dca::phys::domains::BRILLOUIN_ZONE>>;
 
     dca::func::function<double, dca::math::util::CovarianceDomain<KDmn>> covariance;
-    concurrency.computeCovariance(G_qmc, G_ed, covariance);
+    concurrency.computeCovarianceAndAvg(G_qmc, covariance);
 
     if (concurrency.id() == concurrency.first()) {
       dca::math::StatisticalTesting test(G_qmc, G_ed, covariance, false);

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
@@ -115,7 +115,7 @@ public:
                          const func::function<std::complex<Scalar>, Domain>& f_estimated,
                          func::function<Scalar, CovDomain>& cov) const;
 
-  // Computes the covariance of f relatively to its sample average. Then moves the average into f.
+  // Computes the covariance of f with respect to its sample average. Then moves the average into f.
   // In/Out: f
   // Out: cov
   template <typename ScalarOrComplex, typename Scalar, class Domain, class CovDomain>

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
@@ -115,6 +115,13 @@ public:
                          const func::function<std::complex<Scalar>, Domain>& f_estimated,
                          func::function<Scalar, CovDomain>& cov) const;
 
+  // Computes the covariance of f relatively to its sample average. Then moves the average into f.
+  // In/Out: f
+  // Out: cov
+  template <typename ScalarOrComplex, typename Scalar, class Domain, class CovDomain>
+  void computeCovarianceAndAvg(func::function<ScalarOrComplex, Domain>& f,
+                               func::function<Scalar, CovDomain>& cov) const;
+
   // Returns the normalized momenta of the desired orders. The momenta is the averaged across the
   // entries of f.
   // The normalized momenta of order i is defined as \lambda_i = <(f - <f>)^i> / \sigma^i
@@ -444,6 +451,15 @@ void MPICollectiveSum::computeCovariance(const func::function<std::complex<Scala
           (f(i).imag() - f_estimated(i).imag()) * (f(j).real() - f_estimated(j).imag());
     }
   sum_and_average(cov, 1);
+}
+
+template <typename ScalarOrComplex, typename Scalar, class Domain, class CovDomain>
+void MPICollectiveSum::computeCovarianceAndAvg(func::function<ScalarOrComplex, Domain>& f,
+                                               func::function<Scalar, CovDomain>& cov) const {
+  auto f_avg = f;
+  sum_and_average(f_avg);
+  computeCovariance(f, f_avg, cov);
+  f = std::move(f_avg);
 }
 
 template <typename Scalar, class Domain>

--- a/test/integration/statistical_tests/square_lattice/ctaux_square_lattice_validation_stattest.cpp
+++ b/test/integration/statistical_tests/square_lattice/ctaux_square_lattice_validation_stattest.cpp
@@ -49,10 +49,7 @@ TEST(CtauxSquareLatticeValidationTest, GreensFunction) {
   using dca::func::function;
   function<double, SigmaCutDomain> G_k_w_sample =
       cutFrequency(qmc_solver.local_G_k_w(), n_frequencies);
-
-  auto G_k_w_avg(G_k_w_sample);
-  dca_test_env->concurrency.sum_and_average(G_k_w_avg);
-  G_k_w_avg.set_name("G_k_w");
+  G_k_w_sample.set_name("G_k_w");
 
   // read the expected result
   function<double, SigmaCutDomain> G_k_w_expected;
@@ -71,12 +68,12 @@ TEST(CtauxSquareLatticeValidationTest, GreensFunction) {
 
   // compute covariance and average ctin result.
   function<double, CovarianceDomain> G_k_w_covariance("G_k_w_covariance");
-  dca_test_env->concurrency.computeCovariance(G_k_w_sample, G_k_w_avg, G_k_w_covariance);
+  dca_test_env->concurrency.computeCovarianceAndAvg(G_k_w_sample, G_k_w_covariance);
 
   //   compute p-value
   if (id == dca_test_env->concurrency.first()) {
     // read the stored reference data
-    dca::math::StatisticalTesting test(G_k_w_avg, G_k_w_expected, G_k_w_covariance, 1);
+    dca::math::StatisticalTesting test(G_k_w_sample, G_k_w_expected, G_k_w_covariance, 1);
     double p_value = test.computePValue(false, number_of_samples);
     test.printInfo("ctaux_square_testinfo.out", true);
     double p_value_default = 0.05;

--- a/test/unit/parallel/mpi_concurrency/mpi_collective_sum_test.cpp
+++ b/test/unit/parallel/mpi_concurrency/mpi_collective_sum_test.cpp
@@ -205,6 +205,7 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceScalar) {
   using CovarianceDomain = dca::func::dmn_variadic<FunctionDomain, FunctionDomain>;
 
   dca::func::function<double, CovarianceDomain> covariance_test("test");
+  dca::func::function<double, CovarianceDomain> covariance_test2("test2");
   dca::func::function<double, CovarianceDomain> covariance_expected("expected");
 
   dca::func::function<double, FunctionDomain> f("f");
@@ -219,6 +220,10 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceScalar) {
 
   sum_interface_.computeCovariance(f, f_mean, covariance_test);
 
+  sum_interface_.computeCovarianceAndAvg(f, covariance_test2);
+  for (int i = 0; i < f_mean.size(); ++i)
+    EXPECT_DOUBLE_EQ(f_mean(i), f(i));
+
   covariance_expected(0, 0) = covariance_expected(0, 1) = covariance_expected(0, 2) =
       covariance_expected(0, 3) = 0;
   covariance_expected(1, 1) = 5.25;
@@ -232,8 +237,10 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceScalar) {
     for (int j = i + 1; j < f.size(); j++)
       covariance_expected(j, i) = covariance_expected(i, j);
 
-  for (int i = 0; i < covariance_test.size(); i++)
+  for (int i = 0; i < covariance_test.size(); i++) {
     EXPECT_DOUBLE_EQ(covariance_expected(i), covariance_test(i));
+    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance_test2(i));
+  }
 }
 
 TEST_F(MPICollectiveSumTest, ComputeCovarianceComplex) {
@@ -242,6 +249,7 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceComplex) {
                                                    dca::func::dmn_0<dca::func::dmn<4, int>>>;
 
   dca::func::function<double, CovarianceDomain> covariance_test("test");
+  dca::func::function<double, CovarianceDomain> covariance_test2("test2");
   dca::func::function<double, CovarianceDomain> covariance_expected("expected");
 
   dca::func::function<std::complex<double>, FunctionDomain> f("f");
@@ -256,6 +264,12 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceComplex) {
   f_mean /= size_;  // f_mean contains the mean of f
 
   sum_interface_.computeCovariance(f, f_mean, covariance_test);
+  sum_interface_.computeCovarianceAndAvg(f, covariance_test2);
+
+  for (int i = 0; i < f_mean.size(); ++i) {
+    EXPECT_DOUBLE_EQ(f_mean(i).real(), f(i).real());
+    EXPECT_DOUBLE_EQ(f_mean(i).imag(), f(i).imag());
+  }
 
   covariance_expected(0, 0) = covariance_expected(0, 1) = covariance_expected(0, 2) =
       covariance_expected(0, 3) = 0;
@@ -270,8 +284,10 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceComplex) {
     for (int j = i + 1; j < 2 * f.size(); j++)
       covariance_expected(j, i) = covariance_expected(i, j);
 
-  for (int i = 0; i < covariance_test.size(); i++)
+  for (int i = 0; i < covariance_test.size(); i++) {
     EXPECT_DOUBLE_EQ(covariance_expected(i), covariance_test(i));
+    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance_test2(i));
+  }
 }
 
 TEST_F(MPICollectiveSumTest, AvgNormalizedMomenta) {

--- a/test/unit/parallel/mpi_concurrency/mpi_collective_sum_test.cpp
+++ b/test/unit/parallel/mpi_concurrency/mpi_collective_sum_test.cpp
@@ -204,8 +204,11 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceScalar) {
   using FunctionDomain = dca::func::dmn_0<dca::func::dmn<4, int>>;
   using CovarianceDomain = dca::func::dmn_variadic<FunctionDomain, FunctionDomain>;
 
-  dca::func::function<double, CovarianceDomain> covariance_test("test");
-  dca::func::function<double, CovarianceDomain> covariance_test2("test2");
+  // Stores the covariance computed with computeCovariance.
+  dca::func::function<double, CovarianceDomain> covariance("cov");
+  // Stores the covariance computed with computeCovarianceAndAvg.
+  dca::func::function<double, CovarianceDomain> covariance2("cov2");
+
   dca::func::function<double, CovarianceDomain> covariance_expected("expected");
 
   dca::func::function<double, FunctionDomain> f("f");
@@ -218,9 +221,9 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceScalar) {
   sum_interface_.sum(f_mean);
   f_mean /= size_;  // f_mean contains the mean of f
 
-  sum_interface_.computeCovariance(f, f_mean, covariance_test);
+  sum_interface_.computeCovariance(f, f_mean, covariance);
 
-  sum_interface_.computeCovarianceAndAvg(f, covariance_test2);
+  sum_interface_.computeCovarianceAndAvg(f, covariance2);
   for (int i = 0; i < f_mean.size(); ++i)
     EXPECT_DOUBLE_EQ(f_mean(i), f(i));
 
@@ -237,9 +240,9 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceScalar) {
     for (int j = i + 1; j < f.size(); j++)
       covariance_expected(j, i) = covariance_expected(i, j);
 
-  for (int i = 0; i < covariance_test.size(); i++) {
-    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance_test(i));
-    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance_test2(i));
+  for (int i = 0; i < covariance.size(); i++) {
+    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance(i));
+    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance2(i));
   }
 }
 
@@ -248,8 +251,11 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceComplex) {
   using CovarianceDomain = dca::func::dmn_variadic<dca::func::dmn_0<dca::func::dmn<4, int>>,
                                                    dca::func::dmn_0<dca::func::dmn<4, int>>>;
 
-  dca::func::function<double, CovarianceDomain> covariance_test("test");
-  dca::func::function<double, CovarianceDomain> covariance_test2("test2");
+  // Stores the covariance computed with computeCovariance.
+  dca::func::function<double, CovarianceDomain> covariance("cov");
+  // Stores the covariance computed with computeCovarianceAndAvg.
+  dca::func::function<double, CovarianceDomain> covariance2("cov2");
+
   dca::func::function<double, CovarianceDomain> covariance_expected("expected");
 
   dca::func::function<std::complex<double>, FunctionDomain> f("f");
@@ -263,8 +269,8 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceComplex) {
   sum_interface_.sum(f_mean);
   f_mean /= size_;  // f_mean contains the mean of f
 
-  sum_interface_.computeCovariance(f, f_mean, covariance_test);
-  sum_interface_.computeCovarianceAndAvg(f, covariance_test2);
+  sum_interface_.computeCovariance(f, f_mean, covariance);
+  sum_interface_.computeCovarianceAndAvg(f, covariance2);
 
   for (int i = 0; i < f_mean.size(); ++i) {
     EXPECT_DOUBLE_EQ(f_mean(i).real(), f(i).real());
@@ -284,9 +290,9 @@ TEST_F(MPICollectiveSumTest, ComputeCovarianceComplex) {
     for (int j = i + 1; j < 2 * f.size(); j++)
       covariance_expected(j, i) = covariance_expected(i, j);
 
-  for (int i = 0; i < covariance_test.size(); i++) {
-    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance_test(i));
-    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance_test2(i));
+  for (int i = 0; i < covariance.size(); i++) {
+    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance(i));
+    EXPECT_DOUBLE_EQ(covariance_expected(i), covariance2(i));
   }
 }
 


### PR DESCRIPTION
The covariance matrix should be computed against the sample average, not the expected value, as it was done in the statistical validation test. This PR fix this issue in the cluster_solver_check application.