### PR TITLE
Link external libs at the end.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ if (DCA_HAVE_CUDA)
     ${DCA_CUDA_LIBS})
 endif()
 
-# The BLAS and LAPACK librearies in DCA_EXTERNAL_LIBS should be linked after MAGMA.
+# The BLAS and LAPACK libraries in DCA_EXTERNAL_LIBS should be linked after MAGMA.
 list(APPEND DCA_LIBS ${DCA_EXTERNAL_LIBS})
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,19 +141,21 @@ set(DCA_LIBS
   symmetrization
   coarsegraining
   ${DCA_CONCURRENCY_LIB}
-  ${DCA_EXTERNAL_LIBS}
   ${DCA_THREADING_LIBS}
 )
 
 if (DCA_HAVE_CUDA)
   list(APPEND DCA_CUDA_LIBS
-    cuda_utils) 
+    cuda_utils)
   list(APPEND DCA_LIBS
     ctaux_walker_kernels
     lapack_kernels
     blas_kernels
     ${DCA_CUDA_LIBS})
 endif()
+
+# The BLAS and LAPACK librearies in DCA_EXTERNAL_LIBS should be linked after MAGMA.
+list(APPEND DCA_LIBS ${DCA_EXTERNAL_LIBS})
 
 ################################################################################
 # Testing


### PR DESCRIPTION
With this reorder I am able to build on my laptop, as MAGMA requires the linear algebra libraries in the DCA_EXTERNAL_LIBS list. 