### PR TITLE
[WIP] Unstable tests need to be removed from normal testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,8 @@ option(DCA_WITH_TESTS_FAST "Build DCA++'s fast tests." OFF)
 option(DCA_WITH_TESTS_EXTENSIVE "Build DCA++'s extensive tests." OFF)
 option(DCA_WITH_TESTS_PERFORMANCE "Build DCA++'s performance tests. (Only in Release mode.)" OFF)
 option(DCA_WITH_TESTS_VALIDATION  "Build DCA++'s validation tests." OFF)
+option(DCA_WITH_TESTS_UNSTABLE "Build DCA++'s unstable statistical tests." OFF)
+
 
 set(TEST_RUNNER "" CACHE STRING "Command for executing (MPI) programs.")
 set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "Flag used by TEST_RUNNER to specify the number of processes.")

--- a/cmake/dca_testing.cmake
+++ b/cmake/dca_testing.cmake
@@ -23,7 +23,7 @@ include(CMakeParseArguments)
 # MPI or CUDA may be given to indicate that the test requires these libraries. MPI_NUMPROC is the
 # number of MPI processes to use for a test with MPI, the default value is 1.
 function(dca_add_gtest name)
-  set(options FAST EXTENSIVE VALIDATION PERFORMANCE GTEST_MAIN MPI CUDA)
+  set(options FAST EXTENSIVE UNSTABLE VALIDATION PERFORMANCE GTEST_MAIN MPI CUDA)
   set(oneValueArgs MPI_NUMPROC)
   set(multiValueArgs INCLUDE_DIRS SOURCES LIBS)
   cmake_parse_arguments(DCA_ADD_GTEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -37,7 +37,7 @@ function(dca_add_gtest name)
       (DCA_ADD_GTEST_VALIDATION AND DCA_ADD_GTEST_PERFORMANCE))
     message(FATAL_ERROR "Incorrect use of dca_add_gtest.\n
                          dca_add_gtest(name\n
-                                       [FAST | EXTENSIVE | VALIDATION | PERFORMANCE]\n
+                                       [FAST | EXTENSIVE | VALIDATION | PERFORMANCE | UNSTABLE]\n
                                        [GTEST_MAIN]\n
                                        [MPI [MPI_NUMPROC procs]]\n
                                        [CUDA]\n
@@ -66,6 +66,11 @@ function(dca_add_gtest name)
       return()
     endif()
 
+  elseif (DCA_ADD_GTEST_UNSTABLE)
+    if (NOT DCA_WITH_TESTS_UNSTABLE)
+      return()
+    endif()
+    
   else()  # Default is FAST.
     if (NOT DCA_WITH_TESTS_FAST)
       return()

--- a/test/integration/statistical_tests/real_materials/CMakeLists.txt
+++ b/test/integration/statistical_tests/real_materials/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TEST_LIBRARIES ${DCA_LIBS} ${DCA_CUDA_LIBS} statistical_testing)
 #target_compile_definitions(NiO_fullDCA PRIVATE TEST_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/")
 
 dca_add_gtest(NiO_stattest
-    EXTENSIVE
+    UNSTABLE
     PTHREADS
     # Run with more ranks for better error detection.
     MPI MPI_NUMPROC 1


### PR DESCRIPTION
For purposes of have clean CI for master and PR's

This PR adds a new category of tests UNSTABLE result, NiO Stats does
not run without -DDCA_WITH_TESTS_UNSTABLE=ON

This is a crude way to handle this issue, feel free to file an issue for improvement.