### PR TITLE
Support finding MPI using find_package(MPI) for local compilation

### DIFF
--- a/cmake/dca_mpi.cmake
+++ b/cmake/dca_mpi.cmake
@@ -21,4 +21,13 @@ check_cxx_source_compiles(
 if (CXX_SUPPORTS_MPI)
   set(DCA_HAVE_MPI TRUE CACHE INTERNAL "")
   dca_add_haves_define(DCA_HAVE_MPI)
+else()
+  # if MPICC is not the default compiler, try finding MPI
+  # using the usual CMake find_package mechanism
+  find_package(MPI QUIET)
+  if (MPI_FOUND)
+    set(DCA_HAVE_MPI TRUE CACHE INTERNAL "")
+    dca_add_haves_define(DCA_HAVE_MPI)
+    include_directories(${MPI_C_INCLUDE_PATH})
+  endif()
 endif()

--- a/cmake/dca_testing.cmake
+++ b/cmake/dca_testing.cmake
@@ -118,7 +118,7 @@ function(dca_add_gtest name)
     add_test(NAME ${name}
              COMMAND ${TEST_RUNNER} ${MPIEXEC_NUMPROC_FLAG} ${DCA_ADD_GTEST_MPI_NUMPROC}
                      ${MPIEXEC_PREFLAGS} "$<TARGET_FILE:${name}>")
-
+                 target_link_libraries(${name} ${MPI_C_LIBRARIES})
   else()
     if (TEST_RUNNER)
       add_test(NAME ${name}

--- a/src/parallel/mpi_concurrency/CMakeLists.txt
+++ b/src/parallel/mpi_concurrency/CMakeLists.txt
@@ -7,3 +7,7 @@ if(DCA_HAVE_CUDA)
   target_link_libraries(parallel_mpi_concurrency PRIVATE kernel_test)
   target_compile_definitions(parallel_mpi_concurrency PRIVATE DCA_HAVE_CUDA)
 endif()
+
+# if find_package(MPI) was used we need this, otherwise it does nothing
+target_link_libraries(parallel_mpi_concurrency PUBLIC ${MPI_C_LIBRARIES})
+


### PR DESCRIPTION
This just adds a find_package(MPI) if the compiler has not already got MPI support and then adds include dirs and link libs to the build (which would be added by the MPI compiler if it was used)