### PR TITLE
Created domains for momentum and frequency exchange.

### DIFF
--- a/include/dca/phys/domains/cluster/momentum_exchange_domain.hpp
+++ b/include/dca/phys/domains/cluster/momentum_exchange_domain.hpp
@@ -59,27 +59,17 @@ public:
   static void write(Writer& writer);
 
 private:
+  static void initialize(bool compute_all_transfers, int transfer_index, int cluster_size);
+
+private:
   static std::vector<int> elements_;
   static bool initialized_;
 };
-std::vector<int> MomentumExchangeDomain::elements_;
-bool MomentumExchangeDomain::initialized_ = false;
 
 template <class Parameters>
 void MomentumExchangeDomain::initialize(const Parameters& parameters) {
-  if (parameters.compute_all_transfers()) {
-    const int size = Parameters::KClusterDmn::dmn_size();
-    elements_.resize(size);
-    int idx_value = 0;
-    for (int& elem : elements_)
-      elem = idx_value++;
-  }
-
-  else {
-    elements_ = std::vector<int>{parameters.get_four_point_momentum_transfer_index()};
-  }
-
-  initialized_ = true;
+  initialize(parameters.compute_all_transfers(), parameters.get_four_point_momentum_transfer_index(),
+             Parameters::KClusterDmn::dmn_size());
 }
 
 template <class Writer>

--- a/include/dca/phys/domains/cluster/momentum_exchange_domain.hpp
+++ b/include/dca/phys/domains/cluster/momentum_exchange_domain.hpp
@@ -1,0 +1,92 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.txt for citation guidelines if you use this code for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// The domain contained in this file describes the momentum exchange inside a two particle Green's
+// Function.
+
+#ifndef DCA_PHYS_DOMAINS_CLUSTER_CLUSTER_CLUSTER_DOMAIN_HPP
+#define DCA_PHYS_DOMAINS_CLUSTER_CLUSTER_CLUSTER_DOMAIN_HPP
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+namespace dca {
+namespace phys {
+namespace domains {
+// dca::phys::domains::
+
+class MomentumExchangeDomain {
+public:
+  using scalar_type = int;
+  using element_type = int;
+
+  // Initialize size and elements.
+  template <class Parameters>
+  static void initialize(const Parameters& parameters);
+
+  // Returns the number of computed momentum exchanges.
+  // Precondition: the domain is initialized.
+  static int get_size() {
+    assert(initialized_);
+    return elements_.size();
+  }
+
+  // Contains all indices relative to the exchanged momentum inside the two particle
+  // computation.
+  // Precondition: the domain is initialized.
+  static inline const std::vector<int>& get_elements() {
+    assert(initialized_);
+    return elements_;
+  }
+
+  static const std::string& get_name() {
+    const static std::string name = "Momentum exchange domain.";
+    return name;
+  }
+
+  template <class Writer>
+  static void write(Writer& writer);
+
+private:
+  static std::vector<int> elements_;
+  static bool initialized_;
+};
+std::vector<int> MomentumExchangeDomain::elements_;
+bool MomentumExchangeDomain::initialized_ = false;
+
+template <class Parameters>
+void MomentumExchangeDomain::initialize(const Parameters& parameters) {
+  if (parameters.compute_all_transfers()) {
+    const int size = Parameters::KClusterDmn::dmn_size();
+    elements_.resize(size);
+    int idx_value = 0;
+    for (int& elem : elements_)
+      elem = idx_value++;
+  }
+
+  else {
+    elements_ = std::vector<int>{parameters.get_four_point_momentum_transfer_index()};
+  }
+
+  initialized_ = true;
+}
+
+template <class Writer>
+void MomentumExchangeDomain::write(Writer& writer) {
+  writer.open_group(get_name());
+  writer.execute("element_indices_", elements_);
+  writer.close_group();
+}
+
+}  // domains
+}  // phys
+}  // dca
+
+#endif  // DCA_PHYS_DOMAINS_CLUSTER_CLUSTER_CLUSTER_DOMAIN_HPP

--- a/include/dca/phys/domains/cluster/momentum_exchange_domain.hpp
+++ b/include/dca/phys/domains/cluster/momentum_exchange_domain.hpp
@@ -51,6 +51,10 @@ public:
     return name;
   }
 
+  static bool isInitialized() {
+    return initialized_;
+  }
+
   template <class Writer>
   static void write(Writer& writer);
 

--- a/include/dca/phys/domains/time_and_frequency/frequency_exchange_domain.hpp
+++ b/include/dca/phys/domains/time_and_frequency/frequency_exchange_domain.hpp
@@ -1,0 +1,112 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.txt for citation guidelines if you use this code for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// The domain contained in this file describes the frequency exchange inside a two particle Green's
+// Function.
+
+#ifndef DCA_PHYS_DOMAINS_TIME_AND_FREQUENCY_FREQUENCY_EXCHANGE_DOMAIN_HPP
+#define DCA_PHYS_DOMAINS_TIME_AND_FREQUENCY_FREQUENCY_EXCHANGE_DOMAIN_HPP
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+namespace dca {
+namespace phys {
+namespace domains {
+// dca::phys::domains::
+
+class FrequencyExchangeDomain {
+public:
+  using scalar_type = int;
+  using element_type = int;
+
+  // Initializes size and elements.
+  template <class Parameters>
+  static void initialize(const Parameters& parameters);
+
+  // Returns the number of computed frequency exchanges.
+  // Precondition: the domain is initialized.
+  static int get_size() {
+    assert(initialized_);
+    return elements_.size();
+  }
+
+  // Contains all indices relative to the exchanged frequencies inside the two particle
+  // computation.
+  // Precondition: the domain is initialized.
+  static const std::vector<int>& get_elements() {
+    assert(initialized_);
+    return elements_;
+  }
+
+  // Returns the number of additional frequencies to store in G1.
+  static int extensionSize();
+
+  static bool isInitialized() {
+    return initialized_;
+  }
+
+  static const std::string& get_name() {
+    const static std::string name = "Frequency exchange domain.";
+    return name;
+  }
+
+  template <class Writer>
+  static void write(Writer& writer);
+
+private:
+  static std::vector<int> elements_;
+  static bool initialized_;
+};
+std::vector<int> FrequencyExchangeDomain::elements_;
+bool FrequencyExchangeDomain::initialized_ = false;
+
+template <class Parameters>
+void FrequencyExchangeDomain::initialize(const Parameters& parameters) {
+  if (parameters.compute_all_transfers()) {
+    assert(parameters.get_four_point_frequency_transfer() > 0);
+    elements_.resize(parameters.get_four_point_frequency_transfer() + 1);
+    int idx_value = 0;
+    for (int& elem : elements_)
+      elem = idx_value++;
+  }
+
+  else {
+    elements_ = std::vector<int>{parameters.get_four_point_frequency_transfer()};
+  }
+
+  initialized_ = true;
+}
+
+int FrequencyExchangeDomain::extensionSize() {
+  auto compute_extension = [] {
+    if (!initialized_)
+      throw(std::logic_error("The frequency exchange domain was not initialized."));
+    int size = 0;
+    for (auto el : elements_)
+      size = std::max(size, std::abs(el));
+    return size;
+  };
+  static int extension_size = compute_extension();
+  return extension_size;
+}
+
+template <class Writer>
+void FrequencyExchangeDomain::write(Writer& writer) {
+  writer.open_group(get_name());
+  writer.execute("element_indices", elements_);
+  writer.close_group();
+}
+
+}  // domains
+}  // phys
+}  // dca
+
+#endif  // DCA_PHYS_DOMAINS_TIME_AND_FREQUENCY_FREQUENCY_EXCHANGE_DOMAIN_HPP

--- a/include/dca/phys/domains/time_and_frequency/frequency_exchange_domain.hpp
+++ b/include/dca/phys/domains/time_and_frequency/frequency_exchange_domain.hpp
@@ -14,7 +14,6 @@
 #define DCA_PHYS_DOMAINS_TIME_AND_FREQUENCY_FREQUENCY_EXCHANGE_DOMAIN_HPP
 
 #include <cassert>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -66,35 +65,17 @@ public:
   static void write(Writer& writer);
 
 private:
+  static void initialize(bool compute_all_transfers, int frequency_transfer);
+
+private:
   static std::vector<int> elements_;
   static int extension_size_;
   static bool initialized_;
 };
-std::vector<int> FrequencyExchangeDomain::elements_;
-bool FrequencyExchangeDomain::initialized_ = false;
-int FrequencyExchangeDomain::extension_size_ = -1;
 
 template <class Parameters>
 void FrequencyExchangeDomain::initialize(const Parameters& parameters) {
-  if (parameters.compute_all_transfers()) {
-    if (parameters.get_four_point_frequency_transfer() < 0)
-      throw(std::logic_error("get_four_point_frequency_transfer() must be non-negative."));
-    elements_.resize(parameters.get_four_point_frequency_transfer() + 1);
-    int idx_value = 0;
-    for (int& elem : elements_)
-      elem = idx_value++;
-  }
-
-  else {
-    elements_ = std::vector<int>{parameters.get_four_point_frequency_transfer()};
-  }
-
-  // Compute the extension size.
-  extension_size_ = 0;
-  for (auto el : elements_)
-    extension_size_ = std::max(extension_size_, std::abs(el));
-
-  initialized_ = true;
+  initialize(parameters.compute_all_transfers(),parameters.get_four_point_frequency_transfer());
 }
 
 template <class Writer>

--- a/include/dca/phys/parameters/four_point_parameters.hpp
+++ b/include/dca/phys/parameters/four_point_parameters.hpp
@@ -39,7 +39,8 @@ public:
   FourPointParameters()
       : four_point_type_(NONE),
         four_point_momentum_transfer_input_(lattice_dimension, 0.),
-        four_point_frequency_transfer_(0) {}
+        four_point_frequency_transfer_(0),
+        compute_all_transfers_(false) {}
 
   template <typename Concurrency>
   int getBufferSize(const Concurrency& concurrency) const;
@@ -62,9 +63,13 @@ public:
   const std::vector<double>& get_four_point_momentum_transfer_input() const {
     return four_point_momentum_transfer_input_;
   }
+
+  // Returns the index of the bosonic exchange frequency if compute_all_transfers() == false, or the
+  // index of the maximum transfer if compute_all_transfers() == true.
   int get_four_point_frequency_transfer() const {
     return four_point_frequency_transfer_;
   }
+
   // Returns the 'exact' momentum transfer (q-vector), i.e. the DCA momentum space cluster vector
   // whose distance (L2 norm) to the input momentum transfer is minimal.
   // It assumes that the input q-vectors' distance to the next DCA momentum space cluster vector is
@@ -84,12 +89,19 @@ public:
     return q_ind;
   }
 
+  // Returns true if all possible momentum and frequency exchanges are computed, ignoring the values
+  // of 'get_four_point_momentum_transfer' and 'get_four_point_momentum_transfer_index'.
+  bool compute_all_transfers() const {
+    return compute_all_transfers_;
+  }
+
 private:
   // There is no utility to communicate enumerations over mpi, so four_point_type_ is stored
   // as an int rather than a FourPointType.
   int four_point_type_;
   std::vector<double> four_point_momentum_transfer_input_;
   int four_point_frequency_transfer_;
+  bool compute_all_transfers_;
 };
 
 template <int lattice_dimension>
@@ -100,6 +112,7 @@ int FourPointParameters<lattice_dimension>::getBufferSize(const Concurrency& con
   buffer_size += concurrency.get_buffer_size(four_point_type_);
   buffer_size += concurrency.get_buffer_size(four_point_momentum_transfer_input_);
   buffer_size += concurrency.get_buffer_size(four_point_frequency_transfer_);
+  buffer_size += concurrency.get_buffer_size(compute_all_transfers_);
 
   return buffer_size;
 }
@@ -111,6 +124,7 @@ void FourPointParameters<lattice_dimension>::pack(const Concurrency& concurrency
   concurrency.pack(buffer, buffer_size, position, four_point_type_);
   concurrency.pack(buffer, buffer_size, position, four_point_momentum_transfer_input_);
   concurrency.pack(buffer, buffer_size, position, four_point_frequency_transfer_);
+  concurrency.pack(buffer, buffer_size, position, compute_all_transfers_);
 }
 
 template <int lattice_dimension>
@@ -120,6 +134,7 @@ void FourPointParameters<lattice_dimension>::unpack(const Concurrency& concurren
   concurrency.unpack(buffer, buffer_size, position, four_point_type_);
   concurrency.unpack(buffer, buffer_size, position, four_point_momentum_transfer_input_);
   concurrency.unpack(buffer, buffer_size, position, four_point_frequency_transfer_);
+  concurrency.unpack(buffer, buffer_size, position, compute_all_transfers_);
 }
 
 template <int lattice_dimension>
@@ -145,11 +160,20 @@ void FourPointParameters<lattice_dimension>::readWrite(ReaderOrWriter& reader_or
     }
     catch (const std::exception& r_e) {
     }
+    try {
+      reader_or_writer.execute("compute-all-transfers", compute_all_transfers_);
+    }
+    catch (const std::exception& r_e) {
+    }
 
     reader_or_writer.close_group();
   }
   catch (const std::exception& r_e) {
   }
+
+  if (compute_all_transfers_ && four_point_frequency_transfer_ < 0)
+    throw(std::logic_error(
+        "When compute-all-transfers is set, a greater than 0 frequency-transfer must be chosen."));
 }
 
 }  // params

--- a/include/dca/phys/parameters/four_point_parameters.hpp
+++ b/include/dca/phys/parameters/four_point_parameters.hpp
@@ -64,8 +64,9 @@ public:
     return four_point_momentum_transfer_input_;
   }
 
-  // Returns the index of the bosonic exchange frequency if compute_all_transfers() == false, or the
-  // index of the maximum transfer if compute_all_transfers() == true.
+  // Returns the index of the bosonic exchange frequency. If compute_all_transfers() is true, all
+  // non-negative frequency transfers up to and included this index are computed. Otherwise only the
+  // transfer relative to this index is computed.
   int get_four_point_frequency_transfer() const {
     return four_point_frequency_transfer_;
   }

--- a/src/phys/domains/cluster/CMakeLists.txt
+++ b/src/phys/domains/cluster/CMakeLists.txt
@@ -2,4 +2,5 @@
 
 add_library(cluster_domains STATIC
   cluster_definitions.cpp
+  momentum_exchange_domain.cpp
   symmetries/symmetry_operations/group_action.cpp)

--- a/src/phys/domains/cluster/momentum_exchange_domain.cpp
+++ b/src/phys/domains/cluster/momentum_exchange_domain.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.txt for citation guidelines if you use this code for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file implements the methods of momentum_exchange_domain.hpp.
+
+#include "dca/phys/domains/cluster/momentum_exchange_domain.hpp"
+
+namespace dca {
+namespace phys {
+namespace domains {
+// dca::phys::domains::
+
+// Static members initialization.
+std::vector<int> MomentumExchangeDomain::elements_;
+bool MomentumExchangeDomain::initialized_ = false;
+
+void MomentumExchangeDomain::initialize(const bool compute_all_transfers, const int transfer_index,
+                                        const int cluster_size) {
+  if (compute_all_transfers) {
+    ;
+    elements_.resize(cluster_size);
+    int idx_value = 0;
+    for (int& elem : elements_)
+      elem = idx_value++;
+  }
+
+  else {
+    elements_ = std::vector<int>{transfer_index};
+  }
+
+  initialized_ = true;
+}
+
+}  // domains
+}  // phys
+}  // dca

--- a/src/phys/domains/time_and_frequency/CMakeLists.txt
+++ b/src/phys/domains/time_and_frequency/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 add_library(time_and_frequency_domains STATIC
   frequency_domain.cpp
+  frequency_exchange_domain.cpp
   time_domain.cpp
   time_domain_left_oriented.cpp
   vertex_frequency_name.cpp

--- a/src/phys/domains/time_and_frequency/frequency_exchange_domain.cpp
+++ b/src/phys/domains/time_and_frequency/frequency_exchange_domain.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.txt for citation guidelines if you use this code for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This files implements the methods of frequency_exchange_domain.hpp.
+
+#include <stdexcept>
+
+#include "dca/phys/domains/time_and_frequency/frequency_exchange_domain.hpp"
+
+namespace dca {
+namespace phys {
+namespace domains {
+// dca::phys::domains::
+
+// Static members initialization.
+std::vector<int> FrequencyExchangeDomain::elements_;
+bool FrequencyExchangeDomain::initialized_ = false;
+int FrequencyExchangeDomain::extension_size_ = -1;
+
+void FrequencyExchangeDomain::initialize(const bool compute_all_transfers,
+                                         const int frequency_transfer) {
+  if (compute_all_transfers) {
+    if (frequency_transfer < 0)
+      throw(
+          std::logic_error("The frequency transfer for multiple transfers must be non-negative."));
+    elements_.resize(frequency_transfer + 1);
+    int idx_value = 0;
+    for (int& elem : elements_)
+      elem = idx_value++;
+  }
+
+  else {
+    elements_ = std::vector<int>{frequency_transfer};
+  }
+
+  // Compute the extension size.
+  extension_size_ = 0;
+  for (auto el : elements_)
+    extension_size_ = std::max(extension_size_, std::abs(el));
+
+  initialized_ = true;
+}
+
+}  // domains
+}  // phys
+}  // dca

--- a/test/unit/phys/domains/cluster/CMakeLists.txt
+++ b/test/unit/phys/domains/cluster/CMakeLists.txt
@@ -4,5 +4,8 @@ dca_add_gtest(cluster_operations_test
   GTEST_MAIN
   LIBS ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
 
+dca_add_gtest(momentum_exchage_domain_test
+  GTEST_MAIN)
+
 # deprecated (requires NFFT)
 # add_subdirectory(interpolation/wannier_interpolation)

--- a/test/unit/phys/domains/cluster/CMakeLists.txt
+++ b/test/unit/phys/domains/cluster/CMakeLists.txt
@@ -5,7 +5,8 @@ dca_add_gtest(cluster_operations_test
   LIBS ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
 
 dca_add_gtest(momentum_exchage_domain_test
-  GTEST_MAIN)
+  GTEST_MAIN
+  LIBS cluster_domains)
 
 # deprecated (requires NFFT)
 # add_subdirectory(interpolation/wannier_interpolation)

--- a/test/unit/phys/domains/cluster/momentum_exchage_domain_test.cpp
+++ b/test/unit/phys/domains/cluster/momentum_exchage_domain_test.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file tests momentum_exchange_domain.hpp.
+
+#include "dca/phys/domains/cluster/momentum_exchange_domain.hpp"
+
+#include <numeric>
+#include <gtest/gtest.h>
+
+#include "dca/math/util/vector_operations.hpp"
+
+constexpr int cluster_size = 6;
+
+struct MockParameters {
+  struct KClusterDmn {
+    static int dmn_size() {
+      return cluster_size;
+    }
+  };
+
+  bool compute_all_transfers() const {
+    return compute_all_transfers_;
+  }
+  int get_four_point_momentum_transfer_index() const {
+    return transfer_index_;
+  }
+
+  bool compute_all_transfers_ = false;
+  int transfer_index_ = -1;
+};
+
+using dca::phys::domains::MomentumExchangeDomain;
+using dca::math::util::isSameVector;
+
+TEST(MomentumExchangeDomainTest, SingleExchange) {
+  const int exchange_id = -2;
+  MockParameters parameters{false, exchange_id};
+
+  MomentumExchangeDomain::initialize(parameters);
+  EXPECT_TRUE(MomentumExchangeDomain::isInitialized());
+
+  EXPECT_EQ(1, MomentumExchangeDomain::get_size());
+  EXPECT_TRUE(isSameVector(std::vector<int>{-2}, MomentumExchangeDomain::get_elements()));
+}
+
+TEST(MomentumExchangeDomainTest, MultipleExchanges) {
+  MockParameters parameters{true};
+
+  MomentumExchangeDomain::initialize(parameters);
+  EXPECT_TRUE(MomentumExchangeDomain::isInitialized());
+
+  EXPECT_EQ(cluster_size, MomentumExchangeDomain::get_size());
+
+  std::vector<int> expected_elements(cluster_size);
+  std::iota(expected_elements.begin(), expected_elements.end(), 0);
+  EXPECT_TRUE(isSameVector(expected_elements, MomentumExchangeDomain::get_elements()));
+}

--- a/test/unit/phys/domains/time_and_frequency/CMakeLists.txt
+++ b/test/unit/phys/domains/time_and_frequency/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Time and frequency domain unit tests
 
 dca_add_gtest(frequency_exchage_domain_test
-  GTEST_MAIN)
+  time_and_frequency_domains
+  GTEST_MAIN
+  LIBS time_and_frequency_domains)
 
 dca_add_gtest(frequency_domain_test
   GTEST_MAIN

--- a/test/unit/phys/domains/time_and_frequency/CMakeLists.txt
+++ b/test/unit/phys/domains/time_and_frequency/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Time and frequency domain unit tests
 
+dca_add_gtest(frequency_exchage_domain_test
+  GTEST_MAIN)
+
 dca_add_gtest(frequency_domain_test
   GTEST_MAIN
   LIBS time_and_frequency_domains)

--- a/test/unit/phys/domains/time_and_frequency/frequency_exchage_domain_test.cpp
+++ b/test/unit/phys/domains/time_and_frequency/frequency_exchage_domain_test.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file tests frequency_exchange_domain.hpp and momentum_exchange_domain.hpp.
+
+#include "dca/phys/domains/time_and_frequency/frequency_exchange_domain.hpp"
+
+#include <gtest/gtest.h>
+
+#include "dca/math/util/vector_operations.hpp"
+
+struct MockParameters {
+  bool compute_all_transfers() const {
+    return compute_all_transfers_;
+  }
+  int get_four_point_frequency_transfer() const {
+    return fp_freq_exchange_;
+  }
+
+  bool compute_all_transfers_;
+  int fp_freq_exchange_;
+};
+
+using dca::phys::domains::FrequencyExchangeDomain;
+using dca::math::util::isSameVector;
+
+TEST(FrequencyExchangeDomainTest, SingleExchange) {
+  const int exchange_id = -2;
+  MockParameters parameters{false, exchange_id};
+
+  FrequencyExchangeDomain::initialize(parameters);
+  EXPECT_TRUE(FrequencyExchangeDomain::isInitialized());
+
+  EXPECT_EQ(1, FrequencyExchangeDomain::get_size());
+  EXPECT_TRUE(isSameVector(std::vector<int>{-2}, FrequencyExchangeDomain::get_elements()));
+  EXPECT_EQ(2, FrequencyExchangeDomain::get_extension_size());
+}
+
+TEST(FrequencyExchangeDomainTest, MultipleExchanges) {
+  const int max_exchange_id = 3;
+  MockParameters parameters{true, max_exchange_id};
+
+  FrequencyExchangeDomain::initialize(parameters);
+  EXPECT_TRUE(FrequencyExchangeDomain::isInitialized());
+
+  EXPECT_EQ(max_exchange_id + 1, FrequencyExchangeDomain::get_size());
+  EXPECT_TRUE(isSameVector(std::vector<int>{0, 1, 2, 3}, FrequencyExchangeDomain::get_elements()));
+  EXPECT_EQ(3, FrequencyExchangeDomain::get_extension_size());
+
+  // The maximum exchange frequency must be non-negative.
+  parameters.fp_freq_exchange_ = -1;
+  EXPECT_THROW(FrequencyExchangeDomain::initialize(parameters), std::logic_error);
+}

--- a/test/unit/phys/parameters/four_point_parameters/four_point_parameters_test.cpp
+++ b/test/unit/phys/parameters/four_point_parameters/four_point_parameters_test.cpp
@@ -24,6 +24,7 @@ TEST(FourPointParametersTest, DefaultValues) {
   EXPECT_EQ(dca::phys::NONE, pars.get_four_point_type());
   EXPECT_EQ(momentum_transfer_input_check, pars.get_four_point_momentum_transfer_input());
   EXPECT_EQ(0, pars.get_four_point_frequency_transfer());
+  EXPECT_EQ(false, pars.compute_all_transfers());
 }
 
 TEST(FourPointParametersTest, ReadAll) {
@@ -40,7 +41,8 @@ TEST(FourPointParametersTest, ReadAll) {
   EXPECT_EQ(dca::phys::PARTICLE_PARTICLE_UP_DOWN, pars.get_four_point_type());
   EXPECT_EQ(momentum_transfer_input_check, pars.get_four_point_momentum_transfer_input());
   EXPECT_EQ(1, pars.get_four_point_frequency_transfer());
-  
+  EXPECT_EQ(1, pars.compute_all_transfers());
+
   pars.set_four_point_type(dca::phys::PARTICLE_HOLE_MAGNETIC);
   EXPECT_EQ(dca::phys::PARTICLE_HOLE_MAGNETIC, pars.get_four_point_type());
 }

--- a/test/unit/phys/parameters/four_point_parameters/four_point_parameters_test.cpp
+++ b/test/unit/phys/parameters/four_point_parameters/four_point_parameters_test.cpp
@@ -41,7 +41,7 @@ TEST(FourPointParametersTest, ReadAll) {
   EXPECT_EQ(dca::phys::PARTICLE_PARTICLE_UP_DOWN, pars.get_four_point_type());
   EXPECT_EQ(momentum_transfer_input_check, pars.get_four_point_momentum_transfer_input());
   EXPECT_EQ(1, pars.get_four_point_frequency_transfer());
-  EXPECT_EQ(1, pars.compute_all_transfers());
+  EXPECT_EQ(true, pars.compute_all_transfers());
 
   pars.set_four_point_type(dca::phys::PARTICLE_HOLE_MAGNETIC);
   EXPECT_EQ(dca::phys::PARTICLE_HOLE_MAGNETIC, pars.get_four_point_type());

--- a/test/unit/phys/parameters/four_point_parameters/input_read_all.json
+++ b/test/unit/phys/parameters/four_point_parameters/input_read_all.json
@@ -2,5 +2,7 @@
     "four-point": {
         "type": "PARTICLE_PARTICLE_UP_DOWN",
         "momentum-transfer": [3.14, -1.57],
-        "frequency-transfer": 1
+        "frequency-transfer": 1,
+        "compute-all-transfers": true
+    }
 }

--- a/tools/complete_input.json
+++ b/tools/complete_input.json
@@ -127,7 +127,8 @@
     "four-point": {
         "type": "NONE",
         "momentum-transfer": [0., 0.],
-        "frequency-transfer": 0
+        "frequency-transfer": 0,
+        "compute-all-transfers" : false
     },
 
     "analysis": {


### PR DESCRIPTION
Defines the domains used for the computation of multiple frequencies and momenta exchange.
-  ~While a unit test is missing,~ the code itself can be reviewed.
- Issue #19 can be taken care of after the `gpu_trunk` merge.