### PR TITLE
Abort the MPI network upon unhandled exception.

### DIFF
--- a/applications/cluster_solver_check/cluster_solver_check.cpp
+++ b/applications/cluster_solver_check/cluster_solver_check.cpp
@@ -39,131 +39,137 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  std::string input_file(argv[1]);
-
   Concurrency concurrency(argc, argv);
 
-  const bool perform_statistical_test = concurrency.number_of_processors() >= 8;
+  try {
+    std::string input_file(argv[1]);
 
-  Profiler::start();
+    const bool perform_statistical_test = concurrency.number_of_processors() >= 8;
 
-  // Print some info.
-  if (concurrency.id() == concurrency.first()) {
-    dca::util::GitVersion::print();
-    dca::util::Modules::print();
-    dca::config::CMakeOptions::print();
+    Profiler::start();
 
-#ifdef DCA_WITH_CUDA
-    dca::linalg::util::printInfoDevices();
-#endif  // DCA_WITH_CUDA
-
-    std::cout
-        << "\n"
-        << "********************************************************************************\n"
-        << "**********                    Cluster Solver Check                    **********\n"
-        << "********************************************************************************\n"
-        << "\n"
-        << "Start time : " << dca::util::print_time() << "\n"
-        << "\n"
-        << "MPI-world set up: " << concurrency.number_of_processors() << " processes."
-        << "\n"
-        << std::endl;
-  }
+    // Print some info.
+    if (concurrency.id() == concurrency.first()) {
+      dca::util::GitVersion::print();
+      dca::util::Modules::print();
+      dca::config::CMakeOptions::print();
 
 #ifdef DCA_WITH_CUDA
-  dca::linalg::util::initializeMagma();
+      dca::linalg::util::printInfoDevices();
 #endif  // DCA_WITH_CUDA
 
-  // Create the parameters object from the input file.
-  ParametersType parameters(dca::util::GitVersion::string(), concurrency);
-  parameters.read_input_and_broadcast<dca::io::JSONReader>(input_file);
-  parameters.set_dca_iterations(2);
-  parameters.update_model();
-  parameters.update_domains();
+      std::cout
+          << "\n"
+          << "********************************************************************************\n"
+          << "**********                    Cluster Solver Check                    **********\n"
+          << "********************************************************************************\n"
+          << "\n"
+          << "Start time : " << dca::util::print_time() << "\n"
+          << "\n"
+          << "MPI-world set up: " << concurrency.number_of_processors() << " processes."
+          << "\n"
+          << std::endl;
+    }
 
-  dca::phys::DcaLoopData<ParametersType> dca_loop_data;
+#ifdef DCA_WITH_CUDA
+    dca::linalg::util::initializeMagma();
+#endif  // DCA_WITH_CUDA
 
-  // Create and initialize the DCA_data objects.
-  DcaDataType dca_data_imag(parameters);
-  dca_data_imag.initialize();
-  dca::phys::DcaDataRealFreq<ParametersType> dca_data_real(parameters);
+    // Create the parameters object from the input file.
+    ParametersType parameters(dca::util::GitVersion::string(), concurrency);
+    parameters.read_input_and_broadcast<dca::io::JSONReader>(input_file);
+    parameters.set_dca_iterations(2);
+    parameters.update_model();
+    parameters.update_domains();
 
-  std::string data_file_ed = parameters.get_directory() + parameters.get_filename_ed();
-  std::string data_file_qmc = parameters.get_directory() + parameters.get_filename_qmc();
+    dca::phys::DcaLoopData<ParametersType> dca_loop_data;
 
-  // ED solver
-  EdSolver ed_solver(parameters, dca_data_imag, dca_data_real);
-  ed_solver.initialize(0);
-  ed_solver.execute();
-  ed_solver.finalize(dca_loop_data);
+    // Create and initialize the DCA_data objects.
+    DcaDataType dca_data_imag(parameters);
+    dca_data_imag.initialize();
+    dca::phys::DcaDataRealFreq<ParametersType> dca_data_real(parameters);
 
-  const auto Sigma_ed(dca_data_imag.Sigma);
-  const int tested_frequencies = 10;
-  const auto G_ed(dca::math::util::cutFrequency(dca_data_imag.G_k_w, tested_frequencies));
+    std::string data_file_ed = parameters.get_directory() + parameters.get_filename_ed();
+    std::string data_file_qmc = parameters.get_directory() + parameters.get_filename_qmc();
 
-  if (concurrency.id() == concurrency.first()) {
-    ed_solver.write(data_file_ed);
-  }
+    // ED solver
+    EdSolver ed_solver(parameters, dca_data_imag, dca_data_real);
+    ed_solver.initialize(0);
+    ed_solver.execute();
+    ed_solver.finalize(dca_loop_data);
 
-  // QMC solver
-  // The QMC solver uses the free Greens function G0 computed by the ED solver.
-  // It is passed via the dca_data_imag object.
-  ClusterSolver qmc_solver(parameters, dca_data_imag);
-  qmc_solver.initialize(1);  // 1 = dummy iteration number
-  qmc_solver.integrate();
-
-  // If enabled, perform statistical test.
-  double p_val = -1.;
-  if (perform_statistical_test) {
-    auto G_qmc(dca::math::util::cutFrequency(qmc_solver.local_G_k_w(), tested_frequencies));
-
-    using KDmn = dca::func::dmn_0<dca::phys::domains::cluster_domain<
-        double, Lattice::DIMENSION, dca::phys::domains::CLUSTER, dca::phys::domains::MOMENTUM_SPACE,
-        dca::phys::domains::BRILLOUIN_ZONE>>;
-
-    dca::func::function<double, dca::math::util::CovarianceDomain<KDmn>> covariance;
-    concurrency.computeCovarianceAndAvg(G_qmc, covariance);
+    const auto Sigma_ed(dca_data_imag.Sigma);
+    const int tested_frequencies = 10;
+    const auto G_ed(dca::math::util::cutFrequency(dca_data_imag.G_k_w, tested_frequencies));
 
     if (concurrency.id() == concurrency.first()) {
-      dca::math::StatisticalTesting test(G_qmc, G_ed, covariance, false);
+      ed_solver.write(data_file_ed);
+    }
 
-      try {
-        p_val = test.computePValue(false, concurrency.number_of_processors());
-        test.printInfo("statistical_test_info.txt", true);
-      }
-      catch (std::logic_error& err) {
-        std::cerr << "Warning: " << err.what() << std::endl;
-        if (test.get_dof() >= concurrency.number_of_processors())
-          std::cerr << "Not enough ranks." << std::endl;
-        std::cerr << "Aborting statistical test." << std::endl;
+    // QMC solver
+    // The QMC solver uses the free Greens function G0 computed by the ED solver.
+    // It is passed via the dca_data_imag object.
+    ClusterSolver qmc_solver(parameters, dca_data_imag);
+    qmc_solver.initialize(1);  // 1 = dummy iteration number
+    qmc_solver.integrate();
+
+    // If enabled, perform statistical test.
+    double p_val = -1.;
+    if (perform_statistical_test) {
+      auto G_qmc(dca::math::util::cutFrequency(qmc_solver.local_G_k_w(), tested_frequencies));
+
+      using KDmn = dca::func::dmn_0<dca::phys::domains::cluster_domain<
+          double, Lattice::DIMENSION, dca::phys::domains::CLUSTER,
+          dca::phys::domains::MOMENTUM_SPACE, dca::phys::domains::BRILLOUIN_ZONE>>;
+
+      dca::func::function<double, dca::math::util::CovarianceDomain<KDmn>> covariance;
+      concurrency.computeCovarianceAndAvg(G_qmc, covariance);
+
+      if (concurrency.id() == concurrency.first()) {
+        dca::math::StatisticalTesting test(G_qmc, G_ed, covariance, false);
+
+        try {
+          p_val = test.computePValue(false, concurrency.number_of_processors());
+          test.printInfo("statistical_test_info.txt", true);
+        }
+        catch (std::logic_error& err) {
+          std::cerr << "Warning: " << err.what() << std::endl;
+          if (test.get_dof() >= concurrency.number_of_processors())
+            std::cerr << "Not enough ranks." << std::endl;
+          std::cerr << "Aborting statistical test." << std::endl;
+        }
       }
     }
+
+    qmc_solver.finalize(dca_loop_data);
+
+    if (concurrency.id() == concurrency.first()) {
+      dca_data_imag.write(data_file_qmc);
+    }
+
+    // Print errors.
+    if (concurrency.id() == concurrency.first()) {
+      const auto& Sigma_qmc(dca_data_imag.Sigma);
+      auto errors = dca::func::util::difference(Sigma_ed, Sigma_qmc);
+
+      std::cout << "\n|(Sigma_ED - Sigma_QMC)|_1 = " << errors.l1
+                << "\n|(Sigma_ED - Sigma_QMC)|_2 = " << errors.l2
+                << "\n|(Sigma_ED - Sigma_QMC)|_inf = " << errors.l_inf << std::endl;
+
+      if (p_val != -1.)
+        std::cout << "\n***\nThe p-value is " << p_val << ".\n***" << std::endl;
+      else if (perform_statistical_test)
+        std::cout << "\n***\nStatistical test aborted.\n***" << std::endl;
+    }
+
+    Profiler::stop(concurrency, parameters.get_filename_profiling());
+    if (concurrency.id() == concurrency.first()) {
+      std::cout << "\nFinish time: " << dca::util::print_time() << "\n" << std::endl;
+    }
   }
-
-  qmc_solver.finalize(dca_loop_data);
-
-  if (concurrency.id() == concurrency.first()) {
-    dca_data_imag.write(data_file_qmc);
-  }
-
-  // Print errors.
-  if (concurrency.id() == concurrency.first()) {
-    const auto& Sigma_qmc(dca_data_imag.Sigma);
-    auto errors = dca::func::util::difference(Sigma_ed, Sigma_qmc);
-
-    std::cout << "\n|(Sigma_ED - Sigma_QMC)|_1 = " << errors.l1
-              << "\n|(Sigma_ED - Sigma_QMC)|_2 = " << errors.l2
-              << "\n|(Sigma_ED - Sigma_QMC)|_inf = " << errors.l_inf << std::endl;
-
-    if (p_val != -1.)
-      std::cout << "\n***\nThe p-value is " << p_val << ".\n***" << std::endl;
-    else if (perform_statistical_test)
-      std::cout << "\n***\nStatistical test aborted.\n***" << std::endl;
-  }
-
-  Profiler::stop(concurrency, parameters.get_filename_profiling());
-  if (concurrency.id() == concurrency.first()) {
-    std::cout << "\nFinish time: " << dca::util::print_time() << "\n" << std::endl;
+  catch (const std::exception& err) {
+    std::cout << "Unhandled exception in main function:\n\t" << err.what();
+    concurrency.abort();
   }
 
   return 0;

--- a/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
@@ -33,7 +33,7 @@ namespace dca {
 namespace parallel {
 // dca::parallel::
 
-class MPIConcurrency final : private virtual MPIInitializer,
+class MPIConcurrency final : public virtual MPIInitializer,
                              private virtual MPIProcessorGrouping,
                              public MPIPacking,
                              public MPICollectiveMax,

--- a/include/dca/parallel/mpi_concurrency/mpi_initializer.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_initializer.hpp
@@ -23,12 +23,8 @@ protected:
   ~MPIInitializer();
 
 public:
-  void continueOnException() {
-    exceptions_are_fatal_ = false;
-  }
-
-private:
-  bool exceptions_are_fatal_ = true;
+  // Aborts all processes. Error code 3 stands for internal error.
+  void abort(int code = 3) const;
 };
 
 }  // parallel

--- a/include/dca/parallel/mpi_concurrency/mpi_initializer.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_initializer.hpp
@@ -18,9 +18,17 @@ namespace parallel {
 
 class MPIInitializer {
 protected:
-    MPIInitializer(int argc, char **argv);
+  MPIInitializer(int argc, char** argv);
 
-    ~MPIInitializer();
+  ~MPIInitializer();
+
+public:
+  void continueOnException() {
+    exceptions_are_fatal_ = false;
+  }
+
+private:
+  bool exceptions_are_fatal_ = true;
 };
 
 }  // parallel

--- a/include/dca/parallel/mpi_concurrency/mpi_initializer.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_initializer.hpp
@@ -23,8 +23,8 @@ protected:
   ~MPIInitializer();
 
 public:
-  // Aborts all processes. Error code 3 stands for internal error.
-  void abort(int code = 3) const;
+  // Aborts all processes.
+  void abort() const;
 };
 
 }  // parallel

--- a/include/dca/parallel/no_concurrency/no_concurrency.hpp
+++ b/include/dca/parallel/no_concurrency/no_concurrency.hpp
@@ -24,6 +24,8 @@ class NoConcurrency : public SerialCollectiveSum {
 public:
   NoConcurrency(int /*argc*/, char** /*argv*/){};
 
+  void abort(int /*code*/ = 0) const;
+
   int id() const {
     return 0;
   }

--- a/include/dca/parallel/no_concurrency/no_concurrency.hpp
+++ b/include/dca/parallel/no_concurrency/no_concurrency.hpp
@@ -24,7 +24,7 @@ class NoConcurrency : public SerialCollectiveSum {
 public:
   NoConcurrency(int /*argc*/, char** /*argv*/){};
 
-  void abort(int /*code*/ = 0) const;
+  void abort() const;
 
   int id() const {
     return 0;

--- a/src/parallel/mpi_concurrency/mpi_concurrency.cpp
+++ b/src/parallel/mpi_concurrency/mpi_concurrency.cpp
@@ -26,6 +26,7 @@ MPIConcurrency::MPIConcurrency(int argc, char** argv) : MPIInitializer(argc, arg
       error_string = "Process " + std::to_string(MPIProcessorGrouping::get_world_id()) +
                      "could not execute a CUDA kernel.";
 
+    MPIInitializer::continueOnException();
     throw(std::logic_error(error_string));
   }
 }

--- a/src/parallel/mpi_concurrency/mpi_concurrency.cpp
+++ b/src/parallel/mpi_concurrency/mpi_concurrency.cpp
@@ -26,7 +26,6 @@ MPIConcurrency::MPIConcurrency(int argc, char** argv) : MPIInitializer(argc, arg
       error_string = "Process " + std::to_string(MPIProcessorGrouping::get_world_id()) +
                      "could not execute a CUDA kernel.";
 
-    MPIInitializer::continueOnException();
     throw(std::logic_error(error_string));
   }
 }

--- a/src/parallel/mpi_concurrency/mpi_initializer.cpp
+++ b/src/parallel/mpi_concurrency/mpi_initializer.cpp
@@ -30,9 +30,9 @@ MPIInitializer::~MPIInitializer() {
   MPI_Finalize();
 }
 
-void MPIInitializer::abort(int code) const {
+void MPIInitializer::abort() const {
   std::cout << "\nAborting all processes.\n";
-  MPI_Abort(MPI_COMM_WORLD, code);
+  MPI_Abort(MPI_COMM_WORLD, 134); // Same error code as std::terminate().
 }
 
 }  // parallel

--- a/src/parallel/mpi_concurrency/mpi_initializer.cpp
+++ b/src/parallel/mpi_concurrency/mpi_initializer.cpp
@@ -27,12 +27,12 @@ MPIInitializer::MPIInitializer(int argc, char** argv) {
 }
 
 MPIInitializer::~MPIInitializer() {
-  if (exceptions_are_fatal_ && std::uncaught_exception()) {
-    std::cout << "\nUnhandled exception reached the MPI initializer. Aborting execution.\n";
-    MPI_Abort(MPI_COMM_WORLD, 3);  // Internal error.
-  }
-
   MPI_Finalize();
+}
+
+void MPIInitializer::abort(int code) const {
+  std::cout << "\nAborting all processes.\n";
+  MPI_Abort(MPI_COMM_WORLD, code);
 }
 
 }  // parallel

--- a/src/parallel/mpi_concurrency/mpi_initializer.cpp
+++ b/src/parallel/mpi_concurrency/mpi_initializer.cpp
@@ -11,6 +11,7 @@
 
 #include "dca/parallel/mpi_concurrency/mpi_initializer.hpp"
 
+#include <iostream>
 #include <stdexcept>
 #include <mpi.h>
 
@@ -26,6 +27,11 @@ MPIInitializer::MPIInitializer(int argc, char** argv) {
 }
 
 MPIInitializer::~MPIInitializer() {
+  if (exceptions_are_fatal_ && std::uncaught_exception()) {
+    std::cout << "\nUnhandled exception reached the MPI initializer. Aborting execution.\n";
+    MPI_Abort(MPI_COMM_WORLD, 3);  // Internal error.
+  }
+
   MPI_Finalize();
 }
 

--- a/src/parallel/no_concurrency/no_concurrency.cpp
+++ b/src/parallel/no_concurrency/no_concurrency.cpp
@@ -17,7 +17,7 @@
 namespace dca {
 namespace parallel {
 
-void NoConcurrency::abort(int /*err*/) const {
+void NoConcurrency::abort() const {
   std::cout << "\nAborting process.\n";
   std::terminate();
 }

--- a/src/parallel/no_concurrency/no_concurrency.cpp
+++ b/src/parallel/no_concurrency/no_concurrency.cpp
@@ -6,13 +6,21 @@
 // See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Peter Doak (doakpw@ornl.gov)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This file implements no_concurrency.hpp.
 
 #include "dca/parallel/no_concurrency/no_concurrency.hpp"
 
+#include <iostream>
+
 namespace dca {
 namespace parallel {
+
+void NoConcurrency::abort(int /*err*/) const {
+  std::cout << "\nAborting process.\n";
+  std::terminate();
+}
 
 constexpr char NoConcurrency::parallel_type_str_[];
 


### PR DESCRIPTION
I realized that both with the old master and the current version, if a single processor throws an unhandled exception (i.e. by reading an input file or by running out of memory), and the stack unwinds until MPI_Finalize is called, only that process terminates, while the rest hangs on the first MPI communication. 
This PR shuts down all the processes unless a different behaviour is specified (used for selectively killing processors upon driver failure).
If you have a better implementation in mind, please say so.