### PR TITLE
Remove busy walker wait.

### DIFF
--- a/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_cluster_solver.hpp
@@ -104,6 +104,7 @@ private:
   std::mutex mutex_queue;
   std::mutex mutex_acc_finished;
   std::mutex mutex_numerical_error;
+  std::condition_variable queue_insertion_;
 };
 
 template <class qmci_integrator_type>
@@ -254,14 +255,14 @@ void StdThreadQmciClusterSolver<qmci_integrator_type>::start_walker(int id) {
 
     {
       profiler_type profiler("stdthread-MC-walker waiting", "stdthread-MC-walker", __LINE__, id);
-      acc_ptr = NULL;
+      acc_ptr = nullptr;
 
-      while (acc_ptr == NULL) {  // checking for available accumulators
+      // Wait for available accumulators.
+      {
         std::unique_lock<std::mutex> lock(mutex_queue);
-        if (!accumulators_queue.empty()) {
-          acc_ptr = accumulators_queue.front();
-          accumulators_queue.pop();
-        }
+        queue_insertion_.wait(lock, [&]() { return !accumulators_queue.empty(); });
+        acc_ptr = accumulators_queue.front();
+        accumulators_queue.pop();
       }
 
       acc_ptr->update_from(walker);
@@ -316,6 +317,7 @@ void StdThreadQmciClusterSolver<qmci_integrator_type>::start_accumulator(int id)
       std::lock_guard<std::mutex> lock(mutex_queue);
       accumulators_queue.push(&accumulator_obj);
     }
+    queue_insertion_.notify_one();
 
     {
       profiler_type profiler("stdthread-accumulator waiting", "stdthread-MC-accumulator", __LINE__,


### PR DESCRIPTION
This is not originally part of 'gpu_trunk', but it fixes an easy performance bug.
The walker kept on polling the queue, locking its mutex, until it found an element in it. This could actually prevent for some time the accumulator thread to obtain a lock on the mutex.  This way the thread sleeps until an accumulator writes to the queue.