### PR TITLE
Vertex frequency domain

### DIFF
--- a/include/dca/phys/domains/time_and_frequency/vertex_frequency_domain.hpp
+++ b/include/dca/phys/domains/time_and_frequency/vertex_frequency_domain.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "dca/phys/domains/time_and_frequency/frequency_domain.hpp"
+#include "dca/phys/domains/time_and_frequency/frequency_exchange_domain.hpp"
 #include "dca/phys/domains/time_and_frequency/vertex_frequency_name.hpp"
 
 namespace dca {
@@ -146,8 +147,11 @@ void vertex_frequency_domain<EXTENDED>::initialize(parameters_t& parameters) {
   get_basis()[0] = (2. * M_PI) / parameters.get_beta();
   get_inverse_basis()[0] = parameters.get_beta() / (2. * M_PI);
 
+  if (!FrequencyExchangeDomain::isInitialized())
+    FrequencyExchangeDomain::initialize(parameters);
+
   get_size() = 2 * (parameters.get_four_point_fermionic_frequencies() +
-                    abs(parameters.get_four_point_frequency_transfer()));
+                    FrequencyExchangeDomain::get_extension_size());
 
   get_elements().resize(get_size());
 
@@ -177,8 +181,11 @@ void vertex_frequency_domain<EXTENDED_POSITIVE>::initialize(parameters_t& parame
   get_basis()[0] = (2. * M_PI) / parameters.get_beta();
   get_inverse_basis()[0] = parameters.get_beta() / (2. * M_PI);
 
+  if (!FrequencyExchangeDomain::isInitialized())
+    FrequencyExchangeDomain::initialize(parameters);
+
   get_size() = parameters.get_four_point_fermionic_frequencies() +
-               abs(parameters.get_four_point_frequency_transfer());
+               FrequencyExchangeDomain::get_extension_size();
 
   get_elements().resize(get_size());
 


### PR DESCRIPTION
Should have been part of #20.
The domain containing the tp frequencies where G needs to be computed, uses the exchange domain to determine its size.