### PR TITLE
Lowered default amount of ranks for the validation test.

### DIFF
--- a/cmake/dca_mpi.cmake
+++ b/cmake/dca_mpi.cmake
@@ -21,6 +21,8 @@ check_cxx_source_compiles(
 if (CXX_SUPPORTS_MPI)
   set(DCA_HAVE_MPI TRUE CACHE INTERNAL "")
   dca_add_haves_define(DCA_HAVE_MPI)
+  # even if the compiler supports MPI, call find_package to init vars we want
+  find_package(MPI QUIET)
 else()
   # if MPICC is not the default compiler, try finding MPI
   # using the usual CMake find_package mechanism

--- a/test/integration/statistical_tests/square_lattice/CMakeLists.txt
+++ b/test/integration/statistical_tests/square_lattice/CMakeLists.txt
@@ -15,8 +15,8 @@ dca_add_gtest(ctaux_square_lattice_verification_stattest
 
 dca_add_gtest(ctaux_square_lattice_validation_stattest
     STOCHASTIC
-    # Run with more ranks for better error detection.
-    MPI MPI_NUMPROC 32
+    # Run with more than 32 ranks for reliable error detection. The more the better.
+    MPI MPI_NUMPROC 8
     INCLUDE_DIRS ${TEST_INCLUDES}
     LIBS     ${TEST_LIBS}
     )

--- a/test/integration/statistical_tests/square_lattice/CMakeLists.txt
+++ b/test/integration/statistical_tests/square_lattice/CMakeLists.txt
@@ -13,10 +13,12 @@ dca_add_gtest(ctaux_square_lattice_verification_stattest
     LIBS     ${TEST_LIBS}
     )
 
+message("MPIEXEC_MAX_NUMPROCS is ${MPIEXEC_MAX_NUMPROCS}")
+
 dca_add_gtest(ctaux_square_lattice_validation_stattest
     STOCHASTIC
     # Run with more than 32 ranks for reliable error detection. The more the better.
-    MPI MPI_NUMPROC 8
+    MPI MPI_NUMPROC ${MPIEXEC_MAX_NUMPROCS}
     INCLUDE_DIRS ${TEST_INCLUDES}
     LIBS     ${TEST_LIBS}
     )


### PR DESCRIPTION
Allows the pycycle build with STOCHASTIC tests to not break. The test is still somewhat useful as errors of magnitude 10^-2 are still detected.