### PR TITLE
MPITypeMap for enumerations.

### DIFF
--- a/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
@@ -7,6 +7,7 @@
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
 //         Urs R. Haehner (haehneru@itp.phys.ethz.ch)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This class maps C++ types to MPI types.
 //
@@ -17,16 +18,25 @@
 
 #include <complex>
 #include <cstdlib>
+#include <type_traits>
 #include <mpi.h>
 
 namespace dca {
 namespace parallel {
 // dca::parallel::
 
-// Empty class template that causes a compile error when a type without template specialization is
-// used.
-template <typename scalar_type>
-class MPITypeMap {};
+template <typename T>
+class MPITypeMap {
+public:
+  static constexpr std::size_t factor() {
+    return 1;
+  }
+
+  template <typename = std::enable_if_t<std::is_enum<T>::value>>
+  static MPI_Datatype value() {
+    return MPITypeMap<std::underlying_type_t<T>>::value();
+  }
+};
 
 template <>
 class MPITypeMap<bool> {

--- a/include/dca/phys/parameters/four_point_parameters.hpp
+++ b/include/dca/phys/parameters/four_point_parameters.hpp
@@ -53,7 +53,7 @@ public:
   void readWrite(ReaderOrWriter& reader_or_writer);
 
   FourPointType get_four_point_type() const {
-    return static_cast<FourPointType>(four_point_type_);
+    return four_point_type_;
   }
 
   void set_four_point_type(FourPointType type) {
@@ -99,7 +99,7 @@ public:
 private:
   // There is no utility to communicate enumerations over mpi, so four_point_type_ is stored
   // as an int rather than a FourPointType.
-  int four_point_type_;
+  FourPointType four_point_type_;
   std::vector<double> four_point_momentum_transfer_input_;
   int four_point_frequency_transfer_;
   bool compute_all_transfers_;
@@ -144,7 +144,7 @@ void FourPointParameters<lattice_dimension>::readWrite(ReaderOrWriter& reader_or
   try {
     reader_or_writer.open_group("four-point");
 
-    std::string four_point_name = toString(static_cast<FourPointType>(four_point_type_));
+    std::string four_point_name = toString(four_point_type_);
     try {
       reader_or_writer.execute("type", four_point_name);
       four_point_type_ = stringToFourPointType(four_point_name);

--- a/include/dca/phys/parameters/mci_parameters.hpp
+++ b/include/dca/phys/parameters/mci_parameters.hpp
@@ -37,7 +37,7 @@ public:
         accumulators_(1),
         shared_walk_and_accumulation_thread_(false),
         adjust_self_energy_for_double_counting_(false),
-        error_computation_type_(0) {}
+        error_computation_type_(ErrorComputationType::NONE) {}
 
   template <typename Concurrency>
   int getBufferSize(const Concurrency& concurrency) const;
@@ -78,7 +78,7 @@ public:
     return adjust_self_energy_for_double_counting_;
   }
   ErrorComputationType get_error_computation_type() const {
-    return ErrorComputationType(error_computation_type_);
+    return error_computation_type_;
   }
 
 private:
@@ -98,7 +98,7 @@ private:
   int accumulators_;
   bool shared_walk_and_accumulation_thread_;
   bool adjust_self_energy_for_double_counting_;
-  int error_computation_type_;
+  ErrorComputationType error_computation_type_;
 };
 
 template <typename Concurrency>
@@ -203,10 +203,10 @@ void MciParameters::readWrite(ReaderOrWriter& reader_or_writer) {
     }
 
     // Read error computation type.
-    std::string error_type = toString(static_cast<ErrorComputationType>(error_computation_type_));
+    std::string error_type = toString(error_computation_type_);
     try {
       reader_or_writer.execute("error-computation-type", error_type);
-      error_computation_type_ = static_cast<int>(stringToErrorComputationType(error_type));
+      error_computation_type_ = stringToErrorComputationType(error_type);
     }
     catch (const std::exception& r_e) {
     }

--- a/test/unit/parallel/mpi_concurrency/mpi_type_map_test.cpp
+++ b/test/unit/parallel/mpi_concurrency/mpi_type_map_test.cpp
@@ -6,6 +6,7 @@
 // See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Urs R. Haehner (haehneru@itp.phys.ethz.ch)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This file tests mpi_type_map.hpp.
 // It is run with 1 MPI process.
@@ -39,4 +40,17 @@ TEST(MPITypeMapTest, All) {
 
   EXPECT_EQ(2, MPITypeMap<std::complex<double>>::factor());
   EXPECT_EQ(MPI_DOUBLE, MPITypeMap<std::complex<double>>::value());
+}
+
+TEST(MPITypeMapTest, Enums) {
+  {
+    enum TestEnum : int {};
+    EXPECT_EQ(1, MPITypeMap<TestEnum>::factor());
+    EXPECT_EQ(MPI_INT, MPITypeMap<TestEnum>::value());
+  }
+  {
+    enum TestEnum : long unsigned int {};
+    EXPECT_EQ(1, MPITypeMap<TestEnum>::factor());
+    EXPECT_EQ(MPI_UNSIGNED_LONG, MPITypeMap<TestEnum>::value());
+  }
 }


### PR DESCRIPTION
Improvement of #27.
I found a way to pass a general enumeration to our MPI broadcast wrapper, so we can store them directly as parameter members.