### PR TITLE
Fix hdf5 cpp link error, honour <packagename>_ROOT policy for find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ project(DCA++ C CXX)
 
 ################################################################################
 # Set any policies that might be needed
+
+# Adds <packagname>_ROOT variables to search path used by find_<packagename>
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@ cmake_minimum_required(VERSION 3.3)
 project(DCA++ C CXX)
 
 ################################################################################
+# Set any policies that might be needed
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
+################################################################################
 # Disable in-source builds.
 if (${PROJECT_BINARY_DIR} STREQUAL ${PROJECT_SOURCE_DIR})
   message(FATAL_ERROR "In-source builds are not permitted. Make a separate folder for building:\n

--- a/cmake/dca_external_libs.cmake
+++ b/cmake/dca_external_libs.cmake
@@ -21,14 +21,13 @@ list(APPEND DCA_EXTERNAL_LIBS ${LAPACK_LIBRARIES})
 ################################################################################
 # HDF5
 # Find HDF5 by looking for a CMake configuration file (hdf5-1.10.x).
-find_package(HDF5 COMPONENTS C CXX NO_MODULE QUIET)
+find_package(HDF5 COMPONENTS C CXX shared NO_MODULE QUIET )
 if (NOT HDF5_FOUND)
   # Fall back to a search for a FindHDF5.cmake file and execute it.
   find_package(HDF5 REQUIRED COMPONENTS C CXX)
 endif()
-
-list(APPEND DCA_EXTERNAL_LIBS ${HDF5_LIBRARIES})
-list(APPEND DCA_EXTERNAL_INCLUDE_DIRS ${HDF5_INCLUDE_DIRS})
+list(APPEND DCA_EXTERNAL_LIBS ${HDF5_LIBRARIES} ${HDF5_C_SHARED_LIBRARY} ${HDF5_CXX_SHARED_LIBRARY})
+list(APPEND DCA_EXTERNAL_INCLUDE_DIRS ${HDF5_INCLUDE_DIRS} ${HDF5_INCLUDE_DIR})
 
 ################################################################################
 # FFTW

--- a/src/io/hdf5/CMakeLists.txt
+++ b/src/io/hdf5/CMakeLists.txt
@@ -1,4 +1,5 @@
 # HDF5
 
 add_library(dca_hdf5 STATIC hdf5_reader.cpp hdf5_writer.cpp)
+target_link_libraries(dca_hdf5 PRIVATE ${DCA_EXTERNAL_LIBS})
 target_include_directories(dca_hdf5 PUBLIC ${HDF5_INCLUDE_DIRS})


### PR DESCRIPTION
For reasons unclear to me, my build started failing due to unlinked symbols in hdf5_cpp since we use the hdf5 c++ interface.

Recent hdf5/cmake find_package combinations seem to do a very poor job of setting up symbols and HDF5_LIBRARIES is empty on my system, but HDF5_C_SHARED_LIBRARY and HDF5_CXX_SHARED_LIBRARY vars do hold the correct vars (if you ask for shared libs). Also HDF5_INCLUDE_DIRS is empty, but HDF5_INCLUDE_DIR hold the correct path. I've added these to the cmake to fix my local build. Hopefully this makes no difference on systems like daint where the module is used to setup paths and the cray wrappers link stuff anyway. 