### PR TITLE
Changed matrix for inverse and pseudoInverse test

### DIFF
--- a/test/unit/linalg/matrixop_complex_cpu_test.cpp
+++ b/test/unit/linalg/matrixop_complex_cpu_test.cpp
@@ -407,7 +407,9 @@ TYPED_TEST(MatrixopComplexCPUTest, InsertRowCol) {
 TYPED_TEST(MatrixopComplexCPUTest, Inverse) {
   using ScalarType = TypeParam;
   int size = 6;
-  auto val = [](int i, int j) { return ScalarType(10 * i + j * j / (i + 1), 1 + i + j); };
+  auto val = [size](int i, int j) {
+    return std::polar<typename ScalarType::value_type>(2. / ((4 + size + i - j) % size + 1), i + j);
+  };
   dca::linalg::Matrix<ScalarType, dca::linalg::CPU> mat(size);
   testing::setMatrixElements(mat, val);
 
@@ -420,16 +422,18 @@ TYPED_TEST(MatrixopComplexCPUTest, Inverse) {
   for (int j = 0; j < mat.nrCols(); ++j) {
     for (int i = 0; i < mat.nrRows(); ++i) {
       if (i == j)
-        EXPECT_GE(2000 * this->epsilon, std::abs(ScalarType(1) - res(i, j)));
+        EXPECT_GE(500 * this->epsilon, std::abs(ScalarType(1) - res(i, j)));
       else
-        EXPECT_GE(2000 * this->epsilon, std::abs(res(i, j)));
+        EXPECT_GE(500 * this->epsilon, std::abs(res(i, j)));
     }
   }
 }
 
 TYPED_TEST(MatrixopComplexCPUTest, PseudoInverse) {
   using ScalarType = TypeParam;
-  auto val = [](int i, int j) { return ScalarType(10 * i + j * j / (i + 1), 1 + i + j); };
+  auto val = [](int i, int j) {
+    return std::polar<typename ScalarType::value_type>(2. / ((5 + i - j) % 3 + 1), i + j);
+  };
   auto val0 = [](int, int) { return 0; };
   {
     std::pair<int, int> size(2, 3);
@@ -447,9 +451,9 @@ TYPED_TEST(MatrixopComplexCPUTest, PseudoInverse) {
     for (int j = 0; j < res.nrCols(); ++j) {
       for (int i = 0; i < res.nrRows(); ++i) {
         if (i == j)
-          EXPECT_GE(2000 * this->epsilon, std::abs(ScalarType(1) - res(i, j)));
+          EXPECT_GE(500 * this->epsilon, std::abs(ScalarType(1) - res(i, j)));
         else
-          EXPECT_GE(2000 * this->epsilon, std::abs(res(i, j)));
+          EXPECT_GE(500 * this->epsilon, std::abs(res(i, j)));
       }
     }
 

--- a/test/unit/linalg/matrixop_complex_gpu_test.cpp
+++ b/test/unit/linalg/matrixop_complex_gpu_test.cpp
@@ -316,7 +316,9 @@ TYPED_TEST(MatrixopComplexGPUTest, Inverse) {
 
   using ScalarType = TypeParam;
   int size = 6;
-  auto val = [](int i, int j) { return ScalarType(10 * i + j * j / (i + 1), 1 + i + j); };
+  auto val = [size](int i, int j) {
+    return std::polar<typename ScalarType::value_type>(2. / ((4 + size + i - j) % size + 1), i + j);
+  };
   dca::linalg::Matrix<ScalarType, dca::linalg::CPU> mat(size);
   testing::setMatrixElements(mat, val);
 
@@ -330,9 +332,9 @@ TYPED_TEST(MatrixopComplexGPUTest, Inverse) {
   for (int j = 0; j < mat.nrCols(); ++j) {
     for (int i = 0; i < mat.nrRows(); ++i) {
       if (i == j)
-        EXPECT_GE(2000 * this->epsilon, std::abs(ScalarType(1) - res(i, j)));
+        EXPECT_GE(500 * this->epsilon, std::abs(ScalarType(1) - res(i, j)));
       else
-        EXPECT_GE(2000 * this->epsilon, std::abs(res(i, j)));
+        EXPECT_GE(500 * this->epsilon, std::abs(res(i, j)));
     }
   }
 }

--- a/test/unit/linalg/matrixop_real_cpu_test.cpp
+++ b/test/unit/linalg/matrixop_real_cpu_test.cpp
@@ -416,7 +416,7 @@ TYPED_TEST(MatrixopRealCPUTest, InsertRowCol) {
 TYPED_TEST(MatrixopRealCPUTest, Inverse) {
   using ScalarType = TypeParam;
   int size = 6;
-  auto val = [](int i, int j) { return 10 * i + j * j / (i + 1); };
+  auto val = [size](int i, int j) { return ScalarType(2. / ((4 + size + i - j) % size + 1)); };
   dca::linalg::Matrix<ScalarType, dca::linalg::CPU> mat(size);
   testing::setMatrixElements(mat, val);
 
@@ -429,16 +429,16 @@ TYPED_TEST(MatrixopRealCPUTest, Inverse) {
   for (int j = 0; j < mat.nrCols(); ++j) {
     for (int i = 0; i < mat.nrRows(); ++i) {
       if (i == j)
-        EXPECT_NEAR(1, res(i, j), 2000 * this->epsilon);
+        EXPECT_NEAR(1, res(i, j), 500 * this->epsilon);
       else
-        EXPECT_NEAR(0, res(i, j), 2000 * this->epsilon);
+        EXPECT_NEAR(0, res(i, j), 500 * this->epsilon);
     }
   }
 }
 
 TYPED_TEST(MatrixopRealCPUTest, PseudoInverse) {
   using ScalarType = TypeParam;
-  auto val = [](int i, int j) { return 10 * i + j * j / (i + 1); };
+  auto val = [](int i, int j) { return ScalarType(2. / ((5 + i - j) % 3 + 1)); };
   auto val0 = [](int, int) { return 0; };
   {
     std::pair<int, int> size(2, 3);
@@ -456,9 +456,9 @@ TYPED_TEST(MatrixopRealCPUTest, PseudoInverse) {
     for (int j = 0; j < res.nrCols(); ++j) {
       for (int i = 0; i < res.nrRows(); ++i) {
         if (i == j)
-          EXPECT_NEAR(1, res(i, j), 1000 * this->epsilon);
+          EXPECT_NEAR(1, res(i, j), 500 * this->epsilon);
         else
-          EXPECT_NEAR(0, res(i, j), 1000 * this->epsilon);
+          EXPECT_NEAR(0, res(i, j), 500 * this->epsilon);
       }
     }
 

--- a/test/unit/linalg/matrixop_real_gpu_test.cpp
+++ b/test/unit/linalg/matrixop_real_gpu_test.cpp
@@ -315,7 +315,7 @@ TYPED_TEST(MatrixopRealGPUTest, Inverse) {
 
   using ScalarType = TypeParam;
   int size = 6;
-  auto val = [](int i, int j) { return 10 * i + j * j / (i + 1); };
+  auto val = [size](int i, int j) { return ScalarType(2. / ((4 + size + i - j) % size + 1)); };
   dca::linalg::Matrix<ScalarType, dca::linalg::CPU> mat(size);
   testing::setMatrixElements(mat, val);
 
@@ -329,9 +329,9 @@ TYPED_TEST(MatrixopRealGPUTest, Inverse) {
   for (int j = 0; j < mat.nrCols(); ++j) {
     for (int i = 0; i < mat.nrRows(); ++i) {
       if (i == j)
-        EXPECT_NEAR(1, res(i, j), 2000 * this->epsilon);
+        EXPECT_NEAR(1, res(i, j), 500 * this->epsilon);
       else
-        EXPECT_NEAR(0, res(i, j), 2000 * this->epsilon);
+        EXPECT_NEAR(0, res(i, j), 500 * this->epsilon);
     }
   }
 }


### PR DESCRIPTION
Fixes #50.

The matrix used previously for the inverse tests were almost singular (therefore the result of the inverse is very susceptible to round-off errors).