### PR TITLE
Fix compiler warnings

### DIFF
--- a/cmake/dca_compiler_options.cmake
+++ b/cmake/dca_compiler_options.cmake
@@ -18,7 +18,7 @@
 # unset(CMAKE_REQUIRED_FLAGS)
 
 # Warnings
-set(DCA_WARNINGS -Wall -Wextra -Wpedantic -Wno-sign-compare)
+set(DCA_WARNINGS -Wall -Wextra -Wpedantic -Wno-sign-compare -Wno-dangling-else)
 
 # Languange standard
 set(DCA_STD_FLAG -std=c++14)

--- a/include/dca/linalg/util/memory.hpp
+++ b/include/dca/linalg/util/memory.hpp
@@ -80,7 +80,7 @@ struct Memory<CPU> {
   template <typename ScalarType>
   static std::enable_if_t<std::is_arithmetic<ScalarType>::value == true, void> setToZero(
       std::complex<ScalarType>* ptr, size_t size) {
-    std::memset(ptr, 0, size * sizeof(std::complex<ScalarType>));
+    std::memset(static_cast<void*>(ptr), 0, size * sizeof(std::complex<ScalarType>));
   }
 };
 

--- a/include/dca/math/geometry/tetrahedron_mesh/tetrahedron_mesh_initializer.hpp
+++ b/include/dca/math/geometry/tetrahedron_mesh/tetrahedron_mesh_initializer.hpp
@@ -160,7 +160,7 @@ void tetrahedron_mesh_initializer<2, k_cluster_type>::make_convex_hull() {
       try {
         linalg::lapack::solve(2, A, 2, B);  // overwrites A with its LU factorization.
       }
-      catch (linalg::lapack::util::LapackException e) {
+      catch (linalg::lapack::util::LapackException& e) {
         if (e.info() < 0)
           // Argument error: re-throw.
           throw;

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -489,8 +489,8 @@ void CtauxClusterSolver<device_t, parameters_type, Data>::compute_G_k_w_from_M_r
 
   for (int k_ind = 0; k_ind < KClusterDmn::dmn_size(); k_ind++) {
     for (int w_ind = 0; w_ind < w::dmn_size(); w_ind++) {
-      memset(G_matrix, 0, sizeof(std::complex<double>) * matrix_size);
-      memset(G0_times_M_matrix, 0, sizeof(std::complex<double>) * matrix_size);
+      memset(static_cast<void*>(G_matrix), 0, sizeof(std::complex<double>) * matrix_size);
+      memset(static_cast<void*>(G0_times_M_matrix), 0, sizeof(std::complex<double>) * matrix_size);
 
       memcpy(G0_cluster_excluded_matrix, &data_.G0_k_w_cluster_excluded(0, 0, 0, 0, k_ind, w_ind),
              sizeof(std::complex<double>) * matrix_size);

--- a/include/dca/phys/dca_step/cluster_solver/exact_diagonalization_advanced/greens_functions/tp_greens_function.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/exact_diagonalization_advanced/greens_functions/tp_greens_function.hpp
@@ -759,7 +759,6 @@ typename TpGreensFunction<parameters_type, ed_options>::complex_type TpGreensFun
   bool do_regular = true;
   bool do_special = true;
 
-  complex_type ONE(1, 0);
   complex_type I(0, 1);
 
   scalar_type beta = parameters.get_beta();

--- a/test/integration/phys/lattice_mapping/lattice_mapping_sp_test.cpp
+++ b/test/integration/phys/lattice_mapping/lattice_mapping_sp_test.cpp
@@ -143,5 +143,6 @@ TEST_P(LatticeMappingSpTest, Execute) {
   }
 }
 
+// The last comma in the outer parentheses suppresses the gnu-zero-variadic-macro-arguments warning.
 INSTANTIATE_TEST_CASE_P(InputType, LatticeMappingSpTest,
-                        ::testing::Values("dcaplus-converging", "dca-not-terminating"));
+                        ::testing::Values("dcaplus-converging", "dca-not-terminating"), );

--- a/test/unit/function/CMakeLists.txt
+++ b/test/unit/function/CMakeLists.txt
@@ -7,4 +7,7 @@ dca_add_gtest(function_library_test
   GTEST_MAIN
   LIBS function)
 
+# We want to test self-assignment and self-move.
+target_compile_options(function_library_test PRIVATE -Wno-self-assign-overloaded -Wno-self-move)
+
 dca_add_gtest(set_to_zero_test GTEST_MAIN)

--- a/test/unit/linalg/matrixop_complex_cpu_test.cpp
+++ b/test/unit/linalg/matrixop_complex_cpu_test.cpp
@@ -46,7 +46,6 @@ TYPED_TEST(MatrixopComplexCPUTest, Gemv) {
 
   int m = 2;
   int n = 3;
-  std::pair<int, int> size_c(2, 3);
 
   char trans_opts[] = {'N', 'T', 'C'};
 

--- a/test/unit/linalg/matrixop_real_cpu_test.cpp
+++ b/test/unit/linalg/matrixop_real_cpu_test.cpp
@@ -41,7 +41,6 @@ TYPED_TEST(MatrixopRealCPUTest, Gemv) {
 
   int m = 2;
   int n = 3;
-  std::pair<int, int> size_c(2, 3);
 
   char trans_opts[] = {'N', 'T', 'C'};
 


### PR DESCRIPTION
Fixes parts of #56, i.e.

-Wunused-variable
-Wgnu-zero-variadic-macro-arguments
-Wself-assign-overloaded
-Wself-move