### PR TITLE
Split number of measurements among walkers.

### DIFF
--- a/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_accumulator.hpp
@@ -54,6 +54,10 @@ public:
   // Signals that this object will not need to perform any more accumulation.
   void notifyDone();
 
+  bool done() const {
+    return done_;
+  }
+
 protected:
   using QmciAccumulator::get_Gflop;
   using QmciAccumulator::get_number_of_measurements;

--- a/include/dca/phys/parameters/mci_parameters.hpp
+++ b/include/dca/phys/parameters/mci_parameters.hpp
@@ -36,7 +36,8 @@ public:
         walkers_(1),
         accumulators_(1),
         shared_walk_and_accumulation_thread_(false),
-        fix_meas_per_walker_(true),
+        // TODO: consider setting default do true.
+        fix_meas_per_walker_(false),
         adjust_self_energy_for_double_counting_(false),
         error_computation_type_(ErrorComputationType::NONE) {}
 
@@ -75,6 +76,9 @@ public:
   bool shared_walk_and_accumulation_thread() const {
     return shared_walk_and_accumulation_thread_;
   }
+
+  // If true, the number of sweeps performed by each walker is fixed a priory. This avoids possible
+  // bias toward faster walkers, at the expanse of load balance.
   bool fix_meas_per_walker() const {
     return fix_meas_per_walker_;
   }

--- a/include/dca/phys/parameters/mci_parameters.hpp
+++ b/include/dca/phys/parameters/mci_parameters.hpp
@@ -36,6 +36,7 @@ public:
         walkers_(1),
         accumulators_(1),
         shared_walk_and_accumulation_thread_(false),
+        fix_meas_per_walker_(true),
         adjust_self_energy_for_double_counting_(false),
         error_computation_type_(ErrorComputationType::NONE) {}
 
@@ -74,6 +75,9 @@ public:
   bool shared_walk_and_accumulation_thread() const {
     return shared_walk_and_accumulation_thread_;
   }
+  bool fix_meas_per_walker() const {
+    return fix_meas_per_walker_;
+  }
   bool adjust_self_energy_for_double_counting() const {
     return adjust_self_energy_for_double_counting_;
   }
@@ -97,6 +101,7 @@ private:
   int walkers_;
   int accumulators_;
   bool shared_walk_and_accumulation_thread_;
+  bool fix_meas_per_walker_;
   bool adjust_self_energy_for_double_counting_;
   ErrorComputationType error_computation_type_;
 };
@@ -112,6 +117,7 @@ int MciParameters::getBufferSize(const Concurrency& concurrency) const {
   buffer_size += concurrency.get_buffer_size(walkers_);
   buffer_size += concurrency.get_buffer_size(accumulators_);
   buffer_size += concurrency.get_buffer_size(shared_walk_and_accumulation_thread_);
+  buffer_size += concurrency.get_buffer_size(fix_meas_per_walker_);
   buffer_size += concurrency.get_buffer_size(adjust_self_energy_for_double_counting_);
   buffer_size += concurrency.get_buffer_size(error_computation_type_);
 
@@ -128,6 +134,7 @@ void MciParameters::pack(const Concurrency& concurrency, char* buffer, int buffe
   concurrency.pack(buffer, buffer_size, position, walkers_);
   concurrency.pack(buffer, buffer_size, position, accumulators_);
   concurrency.pack(buffer, buffer_size, position, shared_walk_and_accumulation_thread_);
+  concurrency.pack(buffer, buffer_size, position, fix_meas_per_walker_);
   concurrency.pack(buffer, buffer_size, position, adjust_self_energy_for_double_counting_);
   concurrency.pack(buffer, buffer_size, position, error_computation_type_);
 }
@@ -142,6 +149,7 @@ void MciParameters::unpack(const Concurrency& concurrency, char* buffer, int buf
   concurrency.unpack(buffer, buffer_size, position, walkers_);
   concurrency.unpack(buffer, buffer_size, position, accumulators_);
   concurrency.unpack(buffer, buffer_size, position, shared_walk_and_accumulation_thread_);
+  concurrency.unpack(buffer, buffer_size, position, fix_meas_per_walker_);
   concurrency.unpack(buffer, buffer_size, position, adjust_self_energy_for_double_counting_);
   concurrency.unpack(buffer, buffer_size, position, error_computation_type_);
 }
@@ -227,6 +235,11 @@ void MciParameters::readWrite(ReaderOrWriter& reader_or_writer) {
       try {
         reader_or_writer.execute("shared-walk-and-accumulation-thread",
                                  shared_walk_and_accumulation_thread_);
+      }
+      catch (const std::exception& r_e) {
+      }
+      try {
+        reader_or_writer.execute("fix-meas-per-walker", fix_meas_per_walker_);
       }
       catch (const std::exception& r_e) {
       }

--- a/test/integration/cluster_solver/stdthread_qmci/stdthread_ctaux_tp_test_shared_input.json
+++ b/test/integration/cluster_solver/stdthread_qmci/stdthread_ctaux_tp_test_shared_input.json
@@ -60,7 +60,8 @@
     "threaded-solver" : {
       "walkers": 4,
       "accumulators": 4,
-      "shared-walk-and-accumulation-thread": true
+      "shared-walk-and-accumulation-thread": true,
+      "fix-meas-per-walker" : true
     },
 
     "seed" : 0

--- a/test/integration/statistical_tests/square_lattice/square_lattice_input.json
+++ b/test/integration/statistical_tests/square_lattice/square_lattice_input.json
@@ -45,7 +45,8 @@
     "threaded-solver": {
       "walkers": 2,
       "accumulators": 2,
-      "shared-walk-and-accumulation-thread" : false
+      "shared-walk-and-accumulation-thread" : false,
+      "fix-meas-per-walker" : true
     }
   }
 }

--- a/tools/complete_input.json
+++ b/tools/complete_input.json
@@ -102,13 +102,13 @@
         "warm-up-sweeps": 20,
         "sweeps-per-measurement": 1.,
         "measurements": 100,
-        "fix-meas-per-walker" : false,
         "error-computation-type" : "NONE",
 
         "threaded-solver": {
             "walkers": 1,
             "accumulators": 1,
-            "shared-walk-and-accumulation-thread" : false
+            "shared-walk-and-accumulation-thread" : false,
+            "fix-meas-per-walker" : false
         }
     },
 

--- a/tools/complete_input.json
+++ b/tools/complete_input.json
@@ -102,6 +102,7 @@
         "warm-up-sweeps": 20,
         "sweeps-per-measurement": 1.,
         "measurements": 100,
+        "fix-meas-per-walker" : false,
         "error-computation-type" : "NONE",
 
         "threaded-solver": {


### PR DESCRIPTION
Changes the work distribution in the PR solver and gives the option (on by default) to solve https://github.com/CompFUSE/DCA-develop/issues/185. 
Previously the measurements per process were split evenly at the beginning among accumulators.
Now it depends on the parameter `fix_meas_per_walker()`:
- if false the total number of measurements per process is reached independently on the contribution of each walker. Should provide better load balance.
- if true each walker contributes a fixed amount of measurements. It is more statistically safe. 