### PR TITLE
Call target_compile_options only if test is built.

### DIFF
--- a/test/unit/function/CMakeLists.txt
+++ b/test/unit/function/CMakeLists.txt
@@ -7,7 +7,9 @@ dca_add_gtest(function_library_test
   GTEST_MAIN
   LIBS function)
 
-# We want to test self-assignment and self-move.
-target_compile_options(function_library_test PRIVATE -Wno-self-assign-overloaded -Wno-self-move)
+if (function_library_test)
+  # We want to test self-assignment and self-move.
+  target_compile_options(function_library_test PRIVATE -Wno-self-assign-overloaded -Wno-self-move)
+endif()
 
 dca_add_gtest(set_to_zero_test GTEST_MAIN)


### PR DESCRIPTION
Fixes #69.