### PR TITLE
Minor tweaks of Titan test script

### DIFF
--- a/test/titan_run_tests.pbs
+++ b/test/titan_run_tests.pbs
@@ -1,9 +1,11 @@
 #!/bin/bash
 #
 # Batch script to run DCA++'s test suite on ORNL's Titan supercomputer.
-# The script has to be submitted from the top-level source directory.
-# 
-# Usage: qsub test/titan_run_tests.pbs
+# The script has to be submitted from the directory where the script is located (test) or the
+# top-level source directory (DCA).
+#
+# Usage: qsub titan_run_tests.lsf      [from test dir]
+#        qsub test/titan_run_tests.lsf [from DCA dir]
 
 #PBS -q debug
 #PBS -A cph102
@@ -17,16 +19,23 @@
 # Required since some GPU tests run multiple MPI tasks per node.
 export CRAY_CUDA_MPS=1
 
-# Change to the directory from which the batch job was submitted, i.e the top-level source
-# directory.
-cd $PBS_O_WORKDIR
+# Check where the script has been submitted from and change to the top-level source dir (DCA).
+if [ "${PBS_O_WORKDIR: -4}" = "test" ]; then
+    cd $PBS_O_WORKDIR/..
+elif [ "${PBS_O_WORKDIR: -3}" == "DCA" ]; then
+    cd $PBS_O_WORKDIR
+else
+    1>&2 printf "Usage: qsub titan_run_tests.lsf      [from test dir]\n       qsub test/titan_run_tests.lsf [from DCA dir]\n"
+    exit
+fi
 
 # Load all required modules.
 source $MODULESHOME/init/bash
 source build-aux/titan_load_modules.sh
 
 # Create a clean build directory and change to it.
-rm -rf build && mkdir build && cd build
+BUILD_DIR="build_$PBS_JOBID"
+mkdir $BUILD_DIR && cd $BUILD_DIR
 
 # Run CMake to configure the build.
 cmake -C ../build-aux/titan.cmake -DDCA_WITH_TESTS_FAST=ON -DDCA_WITH_TESTS_EXTENSIVE=ON ../

--- a/test/titan_run_tests.pbs
+++ b/test/titan_run_tests.pbs
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
 # Batch script to run DCA++'s test suite on ORNL's Titan supercomputer.
-# The script has to be submitted from the directory where the script is located (test) or the
+# The script has to be submitted from the directory where the script is located (DCA/test) or the
 # top-level source directory (DCA).
 #
-# Usage: qsub titan_run_tests.lsf      [from test dir]
+# Usage: qsub titan_run_tests.lsf      [from DCA/test dir]
 #        qsub test/titan_run_tests.lsf [from DCA dir]
 
 #PBS -q debug


### PR DESCRIPTION
- The script can also be submitted from its location, i.e. DCA/test.
- Append the JOB ID to the build dir.