### PR TITLE
FFTW include dir fixes

### DIFF
--- a/include/dca/phys/models/analytic_hamiltonians/twoband_chain.hpp
+++ b/include/dca/phys/models/analytic_hamiltonians/twoband_chain.hpp
@@ -14,6 +14,7 @@
 #ifndef DCA_PHYS_MODELS_ANALYTIC_HAMILTONIANS_TWOBAND_CHAIN_HPP
 #define DCA_PHYS_MODELS_ANALYTIC_HAMILTONIANS_TWOBAND_CHAIN_HPP
 
+#include <array>
 #include <cmath>
 #include <stdexcept>
 #include <utility>

--- a/test/integration/exact_diagonalization_advanced/CMakeLists.txt
+++ b/test/integration/exact_diagonalization_advanced/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 dca_add_gtest(hamiltonian_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS function json time_and_frequency_domains cluster_domains enumerations quantum_domains ${LAPACK_LIBRARIES}
        ${DCA_CUDA_LIBS})
 

--- a/test/unit/phys/dca_algorithms/CMakeLists.txt
+++ b/test/unit/phys/dca_algorithms/CMakeLists.txt
@@ -2,13 +2,16 @@
 
 dca_add_gtest(compute_band_structure_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS dca_algorithms json function cluster_domains enumerations time_and_frequency_domains quantum_domains
   ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
 
 dca_add_gtest(compute_free_greens_function_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
 
 dca_add_gtest(compute_greens_function_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})

--- a/test/unit/phys/dca_step/lattice_mapping/deconvolution/CMakeLists.txt
+++ b/test/unit/phys/dca_step/lattice_mapping/deconvolution/CMakeLists.txt
@@ -2,6 +2,6 @@
 
 dca_add_gtest(deconvolution_routines_test
   GTEST_MAIN
-  INCLUDE_DIRS ${SIMPLEX_GM_RULE_INCLUDE_DIR}
+  INCLUDE_DIRS ${SIMPLEX_GM_RULE_INCLUDE_DIR} ${FFTW_INCLUDE_DIR}
   LIBS json function cluster_domains time_and_frequency_domains quantum_domains gaussian_quadrature
        tetrahedron_mesh coarsegraining enumerations ${LAPACK_LIBRARIES})

--- a/test/unit/phys/models/CMakeLists.txt
+++ b/test/unit/phys/models/CMakeLists.txt
@@ -3,4 +3,5 @@ add_subdirectory(material_hamiltonians)
 
 dca_add_gtest(general_interaction_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})

--- a/test/unit/phys/models/analytic_hamiltonians/CMakeLists.txt
+++ b/test/unit/phys/models/analytic_hamiltonians/CMakeLists.txt
@@ -2,12 +2,15 @@
 
 dca_add_gtest(bilayer_lattice_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
 
 dca_add_gtest(square_lattice_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
 
 dca_add_gtest(triangular_lattice_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})

--- a/test/unit/phys/models/material_hamiltonians/CMakeLists.txt
+++ b/test/unit/phys/models/material_hamiltonians/CMakeLists.txt
@@ -2,4 +2,5 @@
 
 dca_add_gtest(material_lattice_NiO_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})

--- a/test/unit/phys/parameters/model_parameters/CMakeLists.txt
+++ b/test/unit/phys/parameters/model_parameters/CMakeLists.txt
@@ -10,12 +10,15 @@
 
 dca_add_gtest(model_parameters_bilayer_hubbard_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS json)
 
 dca_add_gtest(model_parameters_material_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS json)
 
 dca_add_gtest(model_parameters_single_band_hubbard_test
   GTEST_MAIN
+  INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
   LIBS json)


### PR DESCRIPTION
FFTW include dir was missing in several dca_add_gtest calls.