### PR TITLE
Jack knife.

### DIFF
--- a/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
@@ -341,7 +341,7 @@ func::function<std::complex<Scalar>, Domain> MPICollectiveSum::jackknifeError(
 
   const int n = MPIProcessorGrouping::get_size();
 
-  if (n == 1)  // No Jack Knife procedure possible.
+  if (n == 1)  // No jackknife procedure possible.
     return err;
 
   func::function<std::complex<Scalar>, Domain> f_avg("f_avg");

--- a/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
+++ b/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
@@ -57,10 +57,10 @@ public:
   template <typename T>
   void sum_and_average(T& /*obj*/) const {}
 
-  template <typename Scalar>
-  void leaveOneOutAvg(Scalar&) const {}
-  template <typename Scalar, class Domain>
-  void leaveOneOutAvg(func::function<Scalar, Domain>&) const {}
+  template <typename T>
+  void leaveOneOutAvg(T&) const {}
+  template <typename T>
+  void leaveOneOutSum(T&) const {}
 
   template <typename Scalar, class Domain>
   func::function<Scalar, Domain> jackknifeError(func::function<Scalar, Domain>&,

--- a/include/dca/phys/dca_data/dca_data.hpp
+++ b/include/dca/phys/dca_data/dca_data.hpp
@@ -90,6 +90,8 @@ public:
 
   using SpGreensFunction =
       func::function<std::complex<double>, func::dmn_variadic<NuDmn, NuDmn, KClusterDmn, WDmn>>;
+    using SpRGreensFunction =
+    func::function<std::complex<double>, func::dmn_variadic<NuDmn, NuDmn, RClusterDmn, WDmn>>;
   using TpGreensFunction =
       func::function<std::complex<TpAccumulatorScalar>,
                      func::dmn_variadic<BDmn, BDmn, BDmn, BDmn, KClusterDmn, KClusterDmn,
@@ -178,6 +180,11 @@ public:  // Optional members getters.
       G_k_w_err_.reset(new SpGreensFunction("G_k_w-error"));
     return *G_k_w_err_;
   }
+  auto& get_G_r_w_error() {
+    if (not G_r_w_err_)
+      G_r_w_err_ = std::make_unique<SpRGreensFunction>("G_r_w-error");
+    return *G_r_w_err_;
+  }
   auto& get_G_k_w_stdv() {
     if (not G_k_w_err_)
       G_k_w_err_.reset(new SpGreensFunction("cluster_greens_function_G_k_w-stddev"));
@@ -221,6 +228,7 @@ public:  // Optional members getters.
 
 private:  // Optional members.
   std::unique_ptr<SpGreensFunction> G_k_w_err_;
+  std::unique_ptr<SpRGreensFunction> G_r_w_err_;
   std::unique_ptr<SpGreensFunction> Sigma_err_;
   std::unique_ptr<TpGreensFunction> G4_;
   std::unique_ptr<TpGreensFunction> G4_err_;
@@ -434,6 +442,7 @@ void DcaData<Parameters>::write(Writer& writer) {
     writer.execute(G_k_w);
     writer.execute(G_k_w_err_);
     writer.execute(G_r_w);
+    writer.execute(G_r_w_err_);
     writer.execute(G_k_t);
     writer.execute(G_r_t);
 

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -146,8 +146,8 @@ private:
   func::function<std::complex<double>, NuNuRClusterWDmn> M_r_w_;
   func::function<std::complex<double>, NuNuRClusterWDmn> M_r_w_squared_;
 
-private:
   bool averaged_;
+  bool compute_jack_knife_;
 };
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
@@ -201,6 +201,9 @@ void CtauxClusterSolver<device_t, Parameters, Data>::initialize(int dca_iteratio
   accumulator_.initialize(dca_iteration_);
 
   averaged_ = false;
+  compute_jack_knife_ =
+      (dca_iteration == parameters_.get_dca_iterations() - 1) &&
+      (parameters_.get_error_computation_type() == ErrorComputationType::JACK_KNIFE);
 
   if (concurrency_.id() == concurrency_.first())
     std::cout << "\n\n\t CT-AUX Integrator has initialized (DCA-iteration : " << dca_iteration
@@ -278,6 +281,9 @@ double CtauxClusterSolver<device_t, Parameters, Data>::finalize(dca_info_struct_
   if (dca_iteration_ == parameters_.get_dca_iterations() - 1 &&
       parameters_.get_four_point_type() != NONE)
     data_.get_G4() /= parameters_.get_beta() * parameters_.get_beta();
+
+  if (compute_jack_knife_)
+    concurrency_.jackknifeError(data_.get_G4(), true);
 
   double total = 1.e-6, integral = 0;
 
@@ -400,12 +406,19 @@ void CtauxClusterSolver<device_t, Parameters, Data>::computeErrorBars() {
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
 void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
+  auto collect = [&](auto& f) {
+    if (compute_jack_knife_)
+      concurrency_.leaveOneOutSum(f);
+    else
+      concurrency_.sum(f);
+  };
+
   {
     Profiler profiler("Scalars", "QMC-collectives", __LINE__);
     concurrency_.sum(total_time_);
     concurrency_.sum(accumulator_.get_Gflop());
     accumulated_sign_ = accumulator_.get_accumulated_sign();
-    concurrency_.sum(accumulated_sign_);
+    collect(accumulated_sign_);
   }
 
   if (concurrency_.id() == concurrency_.first())
@@ -419,7 +432,7 @@ void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
   M_r_w_ = accumulator_.get_sign_times_M_r_w();
   {
     Profiler profiler("QMC-self-energy", "QMC-collectives", __LINE__);
-    concurrency_.sum(M_r_w_);
+    collect(M_r_w_);
   }
   M_r_w_ /= accumulated_sign_;
 
@@ -457,7 +470,7 @@ void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
     Profiler profiler("QMC-two-particle-Greens-function", "QMC-collectives", __LINE__);
     auto& G4 = data_.get_G4();
     G4 = accumulator_.get_sign_times_G4();
-    concurrency_.sum(G4);
+    collect(G4);
     G4 /= accumulated_sign_;
   }
 
@@ -565,6 +578,12 @@ double CtauxClusterSolver<device_t, Parameters, Data>::compute_S_k_w_from_G_k_w(
       dca::linalg::matrixop::copyMatrixToArray(sigma_matrix, &data_.Sigma(0, 0, 0, 0, k_ind, w_ind),
                                                matrix_dim);
     }
+  }
+
+  // Compute error on G and Self Energy.
+  if (compute_jack_knife_) {
+    data_.get_G_k_w_error() = concurrency_.jackknifeError(data_.G_k_w, true);
+    data_.get_Sigma_error() = concurrency_.jackknifeError(data_.Sigma, true);
   }
 
   // set_non_interacting_bands_to_zero();

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -583,6 +583,7 @@ double CtauxClusterSolver<device_t, Parameters, Data>::compute_S_k_w_from_G_k_w(
   // Compute error on G and Self Energy.
   if (compute_jack_knife_) {
     data_.get_G_k_w_error() = concurrency_.jackknifeError(data_.G_k_w, true);
+    data_.get_G_r_w_error() = concurrency_.jackknifeError(data_.G_r_w, true);
     data_.get_Sigma_error() = concurrency_.jackknifeError(data_.Sigma, true);
   }
 

--- a/test/unit/parallel/mpi_concurrency/mpi_collective_sum_test.cpp
+++ b/test/unit/parallel/mpi_concurrency/mpi_collective_sum_test.cpp
@@ -67,7 +67,7 @@ TEST_F(MPICollectiveSumTest, SumFunction) {
     EXPECT_EQ(function_expected(i), function_test(i));
 }
 
-TEST_F(MPICollectiveSumTest, LeaveOneOutAvg) {
+TEST_F(MPICollectiveSumTest, LeaveOneOutAvgAndSum) {
   std::vector<double> values(size_);
   double sum = 0.;
   for (int i = 0; i < size_; ++i) {
@@ -80,8 +80,11 @@ TEST_F(MPICollectiveSumTest, LeaveOneOutAvg) {
 
   // Check scalar version.
   double scalar = values[rank_];
+  double sum_one_out = scalar;
   sum_interface_.leaveOneOutAvg(scalar);
+  sum_interface_.leaveOneOutSum(sum_one_out);
   EXPECT_DOUBLE_EQ(expected, scalar);
+  EXPECT_DOUBLE_EQ(expected * (size_ - 1), sum_one_out);
 
   // Check dca::func::function version.
   using TestDomain = dca::func::dmn_0<dca::func::dmn<2, int>>;
@@ -89,10 +92,15 @@ TEST_F(MPICollectiveSumTest, LeaveOneOutAvg) {
   f(0) = values[rank_];
   f(1) = 0.;
 
+  dca::func::function<double, TestDomain> f_sum(f);
   sum_interface_.leaveOneOutAvg(f);
+  sum_interface_.leaveOneOutSum(f_sum);
 
   EXPECT_DOUBLE_EQ(expected, f(0));
+  EXPECT_DOUBLE_EQ(expected * (size_ - 1), f_sum(0));
+
   EXPECT_DOUBLE_EQ(0., f(1));
+  EXPECT_DOUBLE_EQ(0., f_sum(1));
 }
 
 TEST_F(MPICollectiveSumTest, JackknifeErrorReal) {


### PR DESCRIPTION
Compute the jackknife error on the G(r,t) and G(k,t) provided by the CT-AUX walker (Useful for validating the phase factors changes).