### PR TITLE
Fixed error computation of G4.

### DIFF
--- a/include/dca/phys/dca_data/dca_data.hpp
+++ b/include/dca/phys/dca_data/dca_data.hpp
@@ -457,15 +457,8 @@ void DcaData<Parameters>::write(Writer& writer) {
     writer.execute(G0_r_t_cluster_excluded);
   }
 
-  if (parameters_.get_four_point_type() != NONE) {
-    if (!(parameters_.dump_cluster_Greens_functions())) {
-      writer.execute(G_k_w);
-      writer.execute(G_k_w_err_);
-    }
-
-    writer.execute(G4_);
-    writer.execute(G4_err_);
-  }
+  writer.execute(G4_);
+  writer.execute(G4_err_);
 
   writer.close_group();
 }

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -283,7 +283,7 @@ double CtauxClusterSolver<device_t, Parameters, Data>::finalize(dca_info_struct_
     data_.get_G4() /= parameters_.get_beta() * parameters_.get_beta();
 
   if (compute_jack_knife_)
-    concurrency_.jackknifeError(data_.get_G4(), true);
+    data_.get_G4_error() = concurrency_.jackknifeError(data_.get_G4(), true);
 
   double total = 1.e-6, integral = 0;
 


### PR DESCRIPTION
I did not store correctly the result of the G4 error computation. If we were using c++17, the jackknifeError function should have a [[nodiscard]] attribute.
 

