### PR TITLE
added  clang-format option.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,6 +54,7 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+FixNamespaceComments: false
 PenaltyBreakBeforeFirstCallParameter: 10
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 400


### PR DESCRIPTION
Prevents clang from adding `namespace` in a namespace closing comment.