### PR TITLE
Fix 107

### DIFF
--- a/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
@@ -3,8 +3,7 @@
 // All rights reserved.
 //
 // See LICENSE for terms of usage.
-// See CITATION.md for citation guidelines, if DCA++ is used for scientific
-// publications.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
 //         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
@@ -915,9 +914,9 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::sumTo(
   other.GFLOP += GFLOP;
 }
 
-}  // ctaux
-}  // solver
-}  // phys
-}  // dca
+}  // namespace ctaux
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_ACCUMULATOR_TP_TP_EQUAL_TIME_ACCUMULATOR_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
@@ -3,7 +3,8 @@
 // All rights reserved.
 //
 // See LICENSE for terms of usage.
-// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific
+// publications.
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
 //
@@ -25,12 +26,12 @@
 #include "dca/math/interpolation/akima_interpolation.hpp"
 #include "dca/phys/dca_step/cluster_solver/ctaux/structs/vertex_singleton.hpp"
 #include "dca/phys/domains/cluster/cluster_domain.hpp"
+#include "dca/phys/domains/cluster/cluster_domain_aliases.hpp"
 #include "dca/phys/domains/quantum/electron_band_domain.hpp"
 #include "dca/phys/domains/quantum/electron_spin_domain.hpp"
 #include "dca/phys/domains/time_and_frequency/time_domain.hpp"
 #include "dca/phys/domains/time_and_frequency/time_domain_left_oriented.hpp"
 #include "dca/phys/domains/time_and_frequency/vertex_time_domain.hpp"
-#include "dca/phys/domains/cluster/cluster_domain_aliases.hpp"
 #include "dca/util/plot.hpp"
 
 namespace dca {
@@ -39,8 +40,7 @@ namespace solver {
 namespace ctaux {
 // dca::phys::solver::ctaux::
 
-template <class parameters_type, class MOMS_type>
-class TpEqualTimeAccumulator {
+template <class parameters_type, class MOMS_type> class TpEqualTimeAccumulator {
 public:
   typedef double scalar_type;
   typedef vertex_singleton vertex_singleton_type;
@@ -49,11 +49,12 @@ public:
   typedef typename parameters_type::concurrency_type concurrency_type;
 
   using t = func::dmn_0<domains::time_domain>;
-  using t_VERTEX = func::dmn_0<domains::vertex_time_domain<domains::TP_TIME_DOMAIN_POSITIVE>>;
+  using t_VERTEX = func::dmn_0<
+      domains::vertex_time_domain<domains::TP_TIME_DOMAIN_POSITIVE>>;
 
   using b = func::dmn_0<domains::electron_band_domain>;
   using s = func::dmn_0<domains::electron_spin_domain>;
-  using nu = func::dmn_variadic<b, s>;  // orbital-spin index
+  using nu = func::dmn_variadic<b, s>; // orbital-spin index
 
   using CDA = ClusterDomainAliases<parameters_type::lattice_type::DIMENSION>;
   using RClusterDmn = typename CDA::RClusterDmn;
@@ -64,40 +65,50 @@ public:
   typedef func::dmn_variadic<b, r_dmn_t, t_VERTEX> b_r_t_VERTEX_dmn_t;
 
   typedef func::dmn_0<domains::time_domain_left_oriented> shifted_t;
-  typedef func::dmn_variadic<nu, nu, r_dmn_t, shifted_t> nu_nu_r_dmn_t_shifted_t;
+  typedef func::dmn_variadic<nu, nu, r_dmn_t, shifted_t>
+      nu_nu_r_dmn_t_shifted_t;
 
   typedef func::dmn_0<func::dmn<4, int>> akima_dmn_t;
-  typedef func::dmn_variadic<akima_dmn_t, nu, nu, r_dmn_t, shifted_t> akima_nu_nu_r_dmn_t_shifted_t;
+  typedef func::dmn_variadic<akima_dmn_t, nu, nu, r_dmn_t, shifted_t>
+      akima_nu_nu_r_dmn_t_shifted_t;
 
 public:
-  TpEqualTimeAccumulator(parameters_type& parameters_ref, MOMS_type& MOMS_ref, int id);
+  TpEqualTimeAccumulator(parameters_type &parameters_ref, MOMS_type &MOMS_ref,
+                         int id);
 
   void initialize();
 
   void finalize();
 
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& get_G_r_t() {
+  void sumTo(TpEqualTimeAccumulator<parameters_type, MOMS_type> &other) const;
+
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &get_G_r_t() {
     return G_r_t;
   }
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& get_G_r_t_stddev() {
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &
+  get_G_r_t_stddev() {
     return G_r_t_stddev;
   }
 
-  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_charge_cluster_moment() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
+  get_charge_cluster_moment() {
     return charge_cluster_moment;
   }
-  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_magnetic_cluster_moment() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
+  get_magnetic_cluster_moment() {
     return magnetic_cluster_moment;
   }
-  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_dwave_pp_correlator() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
+  get_dwave_pp_correlator() {
     return dwave_pp_correlator;
   }
 
   template <class configuration_type, typename RealInp>
-  void compute_G_r_t(const configuration_type& configuration_e_up,
-                     const dca::linalg::Matrix<RealInp, dca::linalg::CPU>& M_up,
-                     const configuration_type& configuration_e_dn,
-                     const dca::linalg::Matrix<RealInp, dca::linalg::CPU>& M_dn);
+  void
+  compute_G_r_t(const configuration_type &configuration_e_up,
+                const dca::linalg::Matrix<RealInp, dca::linalg::CPU> &M_up,
+                const configuration_type &configuration_e_dn,
+                const dca::linalg::Matrix<RealInp, dca::linalg::CPU> &M_dn);
 
   void accumulate_G_r_t(double sign);
 
@@ -115,24 +126,32 @@ private:
   void initialize_G0_original();
   void test_G0_original();
 
-  void interpolate(func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& G_r_t,
-                   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& G_r_t_stddev);
+  void interpolate(
+      func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &G_r_t,
+      func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>
+          &G_r_t_stddev);
 
-  int find_first_non_interacting_spin(const std::vector<vertex_singleton_type>& configuration_e_spin);
-
-  template <class configuration_type>
-  void compute_G0_matrix(e_spin_states e_spin, const configuration_type& configuration,
-                         dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix);
-
-  template <class configuration_type>
-  void compute_G0_matrix_left(e_spin_states e_spin, const configuration_type& configuration,
-                              dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix);
+  int find_first_non_interacting_spin(
+      const std::vector<vertex_singleton_type> &configuration_e_spin);
 
   template <class configuration_type>
-  void compute_G0_matrix_right(e_spin_states e_spin, const configuration_type& configuration,
-                               dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix);
+  void
+  compute_G0_matrix(e_spin_states e_spin,
+                    const configuration_type &configuration,
+                    dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix);
 
-  double interpolate_akima(int b_i, int s_i, int b_j, int s_j, int delta_r, double tau);
+  template <class configuration_type>
+  void compute_G0_matrix_left(
+      e_spin_states e_spin, const configuration_type &configuration,
+      dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix);
+
+  template <class configuration_type>
+  void compute_G0_matrix_right(
+      e_spin_states e_spin, const configuration_type &configuration,
+      dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix);
+
+  double interpolate_akima(int b_i, int s_i, int b_j, int s_j, int delta_r,
+                           double tau);
 
 private:
   struct singleton_operator {
@@ -144,9 +163,9 @@ private:
   };
 
 private:
-  parameters_type& parameters;
-  concurrency_type& concurrency;
-  MOMS_type& MOMS;
+  parameters_type &parameters;
+  concurrency_type &concurrency;
+  MOMS_type &MOMS;
 
   int thread_id;
   double GFLOP;
@@ -159,25 +178,31 @@ private:
   std::vector<singleton_operator> fixed_configuration;
   std::vector<singleton_operator> ctaux_configuration;
 
-  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float,
+                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_sign_up;
-  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float,
+                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_sign_dn;
 
-  func::function<int, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                         func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<int,
+                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_indices_up;
-  func::function<int, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                         func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<int,
+                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_indices_dn;
 
-  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float,
+                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_integration_factor_up;
-  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float,
+                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_integration_factor_dn;
 
   dca::linalg::Matrix<float, dca::linalg::CPU> G0_original_up;
@@ -201,21 +226,26 @@ private:
   dca::linalg::Matrix<float, dca::linalg::CPU> G0_M_G0_matrix_up;
   dca::linalg::Matrix<float, dca::linalg::CPU> G0_M_G0_matrix_dn;
 
-  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float,
+                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G_r_t_dn;
-  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float,
+                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G_r_t_up;
 
   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> G_r_t;
   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> G_r_t_stddev;
 
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX>> G_r_t_accumulated;
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX>> G_r_t_accumulated_squared;
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX>>
+      G_r_t_accumulated;
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX>>
+      G_r_t_accumulated_squared;
 
   func::function<double, func::dmn_variadic<b, r_dmn_t>> charge_cluster_moment;
-  func::function<double, func::dmn_variadic<b, r_dmn_t>> magnetic_cluster_moment;
+  func::function<double, func::dmn_variadic<b, r_dmn_t>>
+      magnetic_cluster_moment;
 
   func::function<double, k_dmn_t> dwave_k_factor;
   func::function<double, r_dmn_t> dwave_r_factor;
@@ -225,9 +255,8 @@ private:
 
 template <class parameters_type, class MOMS_type>
 TpEqualTimeAccumulator<parameters_type, MOMS_type>::TpEqualTimeAccumulator(
-    parameters_type& parameters_ref, MOMS_type& MOMS_ref, int id)
-    : parameters(parameters_ref),
-      concurrency(parameters.get_concurrency()),
+    parameters_type &parameters_ref, MOMS_type &MOMS_ref, int id)
+    : parameters(parameters_ref), concurrency(parameters.get_concurrency()),
 
       MOMS(MOMS_ref),
 
@@ -267,10 +296,11 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize() {
 
   {
     for (int k_ind = 0; k_ind < k_dmn_t::dmn_size(); k_ind++)
-      dwave_k_factor(k_ind) =
-          cos(k_dmn_t::get_elements()[k_ind][0]) - cos(k_dmn_t::get_elements()[k_ind][1]);
+      dwave_k_factor(k_ind) = cos(k_dmn_t::get_elements()[k_ind][0]) -
+                              cos(k_dmn_t::get_elements()[k_ind][1]);
 
-    math::transform::FunctionTransform<k_dmn_t, r_dmn_t>::execute(dwave_k_factor, dwave_r_factor);
+    math::transform::FunctionTransform<k_dmn_t, r_dmn_t>::execute(
+        dwave_k_factor, dwave_r_factor);
 
     /*
     if(thread_id==0)
@@ -297,8 +327,10 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize() {
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_my_configuration() {
-  fixed_configuration.resize(b::dmn_size() * r_dmn_t::dmn_size() * t_VERTEX::dmn_size());
+void TpEqualTimeAccumulator<parameters_type,
+                            MOMS_type>::initialize_my_configuration() {
+  fixed_configuration.resize(b::dmn_size() * r_dmn_t::dmn_size() *
+                             t_VERTEX::dmn_size());
 
   int index = 0;
   for (int b_ind = 0; b_ind < b::dmn_size(); b_ind++) {
@@ -320,13 +352,14 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_my_configura
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_akima_coefficients() {
+void TpEqualTimeAccumulator<parameters_type,
+                            MOMS_type>::initialize_akima_coefficients() {
   int size = t::dmn_size() / 2;
 
   math::interpolation::akima_interpolation<double> ai_obj(size);
 
-  double* x = new double[size];
-  double* y = new double[size];
+  double *x = new double[size];
+  double *y = new double[size];
 
   for (int t_ind = 0; t_ind < t::dmn_size() / 2; t_ind++)
     x[t_ind] = t_ind;
@@ -336,13 +369,15 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_akima_coeffi
       for (int nu1_ind = 0; nu1_ind < nu::dmn_size(); nu1_ind++) {
         for (int nu0_ind = 0; nu0_ind < nu::dmn_size(); nu0_ind++) {
           for (int t_ind = 0; t_ind < t::dmn_size() / 2; t_ind++)
-            y[t_ind] = MOMS.G0_r_t_cluster_excluded(nu0_ind, nu1_ind, r_ind, t_ind);
+            y[t_ind] =
+                MOMS.G0_r_t_cluster_excluded(nu0_ind, nu1_ind, r_ind, t_ind);
 
           ai_obj.initialize(x, y);
 
           for (int t_ind = 0; t_ind < t::dmn_size() / 2 - 1; t_ind++)
             for (int l = 0; l < 4; l++)
-              akima_coefficients(l, nu0_ind, nu1_ind, r_ind, t_ind) = ai_obj.get_alpha(l, t_ind);
+              akima_coefficients(l, nu0_ind, nu1_ind, r_ind, t_ind) =
+                  ai_obj.get_alpha(l, t_ind);
         }
       }
     }
@@ -358,7 +393,8 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_akima_coeffi
 
           ai_obj.initialize(x, y);
 
-          for (int t_ind = t::dmn_size() / 2; t_ind < t::dmn_size() - 1; t_ind++)
+          for (int t_ind = t::dmn_size() / 2; t_ind < t::dmn_size() - 1;
+               t_ind++)
             for (int l = 0; l < 4; l++)
               akima_coefficients(l, nu0_ind, nu1_ind, r_ind, t_ind - 1) =
                   ai_obj.get_alpha(l, t_ind - t::dmn_size() / 2);
@@ -372,20 +408,23 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_akima_coeffi
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_G0_indices() {
+void TpEqualTimeAccumulator<parameters_type,
+                            MOMS_type>::initialize_G0_indices() {
   std::vector<double> multiplicities(t_VERTEX::dmn_size(), 0);
   {
     for (int i = 0; i < t_VERTEX::dmn_size(); i++) {
       for (int j = 0; j < t_VERTEX::dmn_size(); j++) {
         int t_ind = i - j;
 
-        if (std::abs(t_VERTEX::get_elements().back() - parameters.get_beta()) < 1.e-6)
+        if (std::abs(t_VERTEX::get_elements().back() - parameters.get_beta()) <
+            1.e-6)
           t_ind = t_ind < 0 ? t_ind + t_VERTEX::dmn_size() - 1 : t_ind;
         else
           t_ind = t_ind < 0 ? t_ind + t_VERTEX::dmn_size() - 0 : t_ind;
 
         for (int l = 0; l < t_VERTEX::dmn_size(); l++)
-          if (std::abs(t_VERTEX::get_elements()[l] - t_VERTEX::get_elements()[t_ind]) < 1.e-6)
+          if (std::abs(t_VERTEX::get_elements()[l] -
+                       t_VERTEX::get_elements()[t_ind]) < 1.e-6)
             multiplicities[l] += 1;
       }
     }
@@ -395,10 +434,10 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_G0_indices()
   int r_i, r_j, delta_r;
   int t_i, t_j, delta_tau;
 
-  G0_original_up.resizeNoCopy(
-      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
-  G0_original_dn.resizeNoCopy(
-      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_original_up.resizeNoCopy(std::pair<int, int>(
+      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_original_dn.resizeNoCopy(std::pair<int, int>(
+      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
 
   func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX> G_r_t_dmn;
   for (int j = 0; j < b_r_t_VERTEX_dmn_t::dmn_size(); j++) {
@@ -418,15 +457,20 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_G0_indices()
       G0_sign_dn(i, j) = delta_tau < 0 ? -1 : 1;
       G0_sign_up(i, j) = delta_tau < 0 ? -1 : 1;
 
-      if (std::abs(t_VERTEX::get_elements().back() - parameters.get_beta()) < 1.e-6)
-        delta_tau = delta_tau < 0 ? delta_tau + t_VERTEX::dmn_size() - 1 : delta_tau;
+      if (std::abs(t_VERTEX::get_elements().back() - parameters.get_beta()) <
+          1.e-6)
+        delta_tau =
+            delta_tau < 0 ? delta_tau + t_VERTEX::dmn_size() - 1 : delta_tau;
       else
-        delta_tau = delta_tau < 0 ? delta_tau + t_VERTEX::dmn_size() - 0 : delta_tau;
+        delta_tau =
+            delta_tau < 0 ? delta_tau + t_VERTEX::dmn_size() - 0 : delta_tau;
 
       assert(multiplicities[delta_tau] > 0);
 
-      G0_integration_factor_dn(i, j) = 1. / (r_dmn_t::dmn_size() * multiplicities[delta_tau]);
-      G0_integration_factor_up(i, j) = 1. / (r_dmn_t::dmn_size() * multiplicities[delta_tau]);
+      G0_integration_factor_dn(i, j) =
+          1. / (r_dmn_t::dmn_size() * multiplicities[delta_tau]);
+      G0_integration_factor_up(i, j) =
+          1. / (r_dmn_t::dmn_size() * multiplicities[delta_tau]);
 
       G0_indices_dn(i, j) = G_r_t_dmn(b_i, 0, b_j, 0, delta_r, delta_tau);
       G0_indices_up(i, j) = G_r_t_dmn(b_i, 1, b_j, 1, delta_r, delta_tau);
@@ -435,19 +479,20 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_G0_indices()
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_G0_original() {
+void TpEqualTimeAccumulator<parameters_type,
+                            MOMS_type>::initialize_G0_original() {
   int r_ind, b_i, b_j, r_i, r_j;
-  scalar_type t_i, t_j, delta_tau;  //, scaled_tau, f_tau;
+  scalar_type t_i, t_j, delta_tau; //, scaled_tau, f_tau;
 
-  G0_original_dn.resizeNoCopy(
-      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
-  G0_original_up.resizeNoCopy(
-      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_original_dn.resizeNoCopy(std::pair<int, int>(
+      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_original_up.resizeNoCopy(std::pair<int, int>(
+      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
 
-  G0_M_G0_matrix_dn.resizeNoCopy(
-      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
-  G0_M_G0_matrix_up.resizeNoCopy(
-      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_M_G0_matrix_dn.resizeNoCopy(std::pair<int, int>(
+      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_M_G0_matrix_up.resizeNoCopy(std::pair<int, int>(
+      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
 
   for (int j = 0; j < b_r_t_VERTEX_dmn_t::dmn_size(); j++) {
     b_j = fixed_configuration[j].b_ind;
@@ -463,8 +508,10 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_G0_original(
 
       delta_tau = t_i - t_j;
 
-      G0_original_dn(i, j) = interpolate_akima(b_i, 0, b_j, 0, r_ind, delta_tau);
-      G0_original_up(i, j) = interpolate_akima(b_i, 1, b_j, 1, r_ind, delta_tau);
+      G0_original_dn(i, j) =
+          interpolate_akima(b_i, 0, b_j, 0, r_ind, delta_tau);
+      G0_original_up(i, j) =
+          interpolate_akima(b_i, 1, b_j, 1, r_ind, delta_tau);
     }
   }
 
@@ -488,16 +535,19 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::test_G0_original() {
 
   for (int j = 0; j < G0_original_dn.size().first; j++)
     for (int i = 0; i < G0_original_dn.size().first; i++)
-      G_r_t_accumulated(G0_indices_dn(i, j)) +=
-          G0_sign_dn(i, j) * G0_integration_factor_dn(i, j) * G0_original_dn(i, j);
+      G_r_t_accumulated(G0_indices_dn(i, j)) += G0_sign_dn(i, j) *
+                                                G0_integration_factor_dn(i, j) *
+                                                G0_original_dn(i, j);
 
   for (int j = 0; j < G0_original_up.size().first; j++)
     for (int i = 0; i < G0_original_up.size().first; i++)
-      G_r_t_accumulated(G0_indices_up(i, j)) +=
-          G0_sign_up(i, j) * G0_integration_factor_up(i, j) * G0_original_up(i, j);
+      G_r_t_accumulated(G0_indices_up(i, j)) += G0_sign_up(i, j) *
+                                                G0_integration_factor_up(i, j) *
+                                                G0_original_up(i, j);
 
   for (int i = 0; i < t_VERTEX::dmn_size(); i++)
-    std::cout << "\t" << t_VERTEX::get_elements()[i] << "\t" << G_r_t_accumulated(0, 0, 0, i) << "\n";
+    std::cout << "\t" << t_VERTEX::get_elements()[i] << "\t"
+              << G_r_t_accumulated(0, 0, 0, i) << "\n";
   std::cout << std::endl;
 
   util::Plot::plotLinesPoints(MOMS.G0_r_t_cluster_excluded);
@@ -518,8 +568,8 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::finalize() {
   // util::Plot::plotLinesPoints(G_r_t_accumulated);
 
   for (int l = 0; l < G_r_t_accumulated_squared.size(); l++)
-    G_r_t_accumulated_squared(l) =
-        std::sqrt(std::abs(G_r_t_accumulated_squared(l) - std::pow(G_r_t_accumulated(l), 2)));
+    G_r_t_accumulated_squared(l) = std::sqrt(std::abs(
+        G_r_t_accumulated_squared(l) - std::pow(G_r_t_accumulated(l), 2)));
 
   interpolate(G_r_t, G_r_t_stddev);
 
@@ -528,14 +578,15 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::finalize() {
 
 template <class parameters_type, class MOMS_type>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate(
-    func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& G_r_t,
-    func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& G_r_t_stddev) {
+    func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &G_r_t,
+    func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>
+        &G_r_t_stddev) {
   int size = t_VERTEX::dmn_size();
 
   math::interpolation::akima_interpolation<double> ai_obj(size);
 
-  double* x = new double[size];
-  double* y = new double[size];
+  double *x = new double[size];
+  double *y = new double[size];
 
   for (int t_ind = 0; t_ind < t_VERTEX::dmn_size(); t_ind++)
     x[t_ind] = t_VERTEX::get_elements()[t_ind];
@@ -551,12 +602,14 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate(
             ai_obj.initialize(x, y);
 
             for (int t_ind = t::dmn_size() / 2; t_ind < t::dmn_size(); t_ind++)
-              G_r_t(nu0_ind, nu1_ind, r_ind, t_ind) = ai_obj.evaluate(t::get_elements()[t_ind]);
+              G_r_t(nu0_ind, nu1_ind, r_ind, t_ind) =
+                  ai_obj.evaluate(t::get_elements()[t_ind]);
           }
 
           {
             for (int t_ind = 0; t_ind < t_VERTEX::dmn_size(); t_ind++)
-              y[t_ind] = G_r_t_accumulated_squared(nu0_ind, nu1_ind, r_ind, t_ind);
+              y[t_ind] =
+                  G_r_t_accumulated_squared(nu0_ind, nu1_ind, r_ind, t_ind);
 
             ai_obj.initialize(x, y);
 
@@ -579,8 +632,8 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate(
       for (int nu1_ind = 0; nu1_ind < nu::dmn_size(); nu1_ind++)
         for (int nu0_ind = 0; nu0_ind < nu::dmn_size(); nu0_ind++)
           for (int t_ind = 0; t_ind < t::dmn_size() / 2; t_ind++)
-            G_r_t_stddev(nu0_ind, nu1_ind, r_ind, t_ind) =
-                G_r_t_stddev(nu0_ind, nu1_ind, r_ind, t_ind + t::dmn_size() / 2);
+            G_r_t_stddev(nu0_ind, nu1_ind, r_ind, t_ind) = G_r_t_stddev(
+                nu0_ind, nu1_ind, r_ind, t_ind + t::dmn_size() / 2);
   }
 
   delete[] x;
@@ -590,50 +643,58 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate(
 template <class parameters_type, class MOMS_type>
 template <class configuration_type, typename RealInp>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G_r_t(
-    const configuration_type& configuration_e_up,
-    const dca::linalg::Matrix<RealInp, linalg::CPU>& M_up,
-    const configuration_type& configuration_e_dn,
-    const dca::linalg::Matrix<RealInp, linalg::CPU>& M_dn) {
+    const configuration_type &configuration_e_up,
+    const dca::linalg::Matrix<RealInp, linalg::CPU> &M_up,
+    const configuration_type &configuration_e_dn,
+    const dca::linalg::Matrix<RealInp, linalg::CPU> &M_dn) {
   {
-    int configuration_size = find_first_non_interacting_spin(configuration_e_dn);
+    int configuration_size =
+        find_first_non_interacting_spin(configuration_e_dn);
 
-    M_matrix_dn.resizeNoCopy(std::pair<int, int>(configuration_size, configuration_size));
+    M_matrix_dn.resizeNoCopy(
+        std::pair<int, int>(configuration_size, configuration_size));
 
-    G0_matrix_dn_left.resizeNoCopy(
-        std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), configuration_size));
-    G0_matrix_dn_right.resizeNoCopy(
-        std::pair<int, int>(configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
+    G0_matrix_dn_left.resizeNoCopy(std::pair<int, int>(
+        b_r_t_VERTEX_dmn_t::dmn_size(), configuration_size));
+    G0_matrix_dn_right.resizeNoCopy(std::pair<int, int>(
+        configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
 
-    M_G0_matrix_dn.resizeNoCopy(
-        std::pair<int, int>(configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
+    M_G0_matrix_dn.resizeNoCopy(std::pair<int, int>(
+        configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
 
     for (int j = 0; j < configuration_size; j++)
       for (int i = 0; i < configuration_size; i++)
         M_matrix_dn(i, j) = M_dn(i, j);
 
-    GFLOP += 2 * (1.e-9) * b_r_t_VERTEX_dmn_t::dmn_size() * std::pow(configuration_size, 2.);
-    GFLOP += 2 * (1.e-9) * configuration_size * std::pow(b_r_t_VERTEX_dmn_t::dmn_size(), 2.);
+    GFLOP += 2 * (1.e-9) * b_r_t_VERTEX_dmn_t::dmn_size() *
+             std::pow(configuration_size, 2.);
+    GFLOP += 2 * (1.e-9) * configuration_size *
+             std::pow(b_r_t_VERTEX_dmn_t::dmn_size(), 2.);
   }
 
   {
-    int configuration_size = find_first_non_interacting_spin(configuration_e_up);
+    int configuration_size =
+        find_first_non_interacting_spin(configuration_e_up);
 
-    M_matrix_up.resizeNoCopy(std::pair<int, int>(configuration_size, configuration_size));
+    M_matrix_up.resizeNoCopy(
+        std::pair<int, int>(configuration_size, configuration_size));
 
-    G0_matrix_up_left.resizeNoCopy(
-        std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), configuration_size));
-    G0_matrix_up_right.resizeNoCopy(
-        std::pair<int, int>(configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
+    G0_matrix_up_left.resizeNoCopy(std::pair<int, int>(
+        b_r_t_VERTEX_dmn_t::dmn_size(), configuration_size));
+    G0_matrix_up_right.resizeNoCopy(std::pair<int, int>(
+        configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
 
-    M_G0_matrix_up.resizeNoCopy(
-        std::pair<int, int>(configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
+    M_G0_matrix_up.resizeNoCopy(std::pair<int, int>(
+        configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
 
     for (int j = 0; j < configuration_size; j++)
       for (int i = 0; i < configuration_size; i++)
         M_matrix_up(i, j) = M_up(i, j);
 
-    GFLOP += 2. * (1.e-9) * b_r_t_VERTEX_dmn_t::dmn_size() * std::pow(configuration_size, 2.);
-    GFLOP += 2. * (1.e-9) * configuration_size * std::pow(b_r_t_VERTEX_dmn_t::dmn_size(), 2.);
+    GFLOP += 2. * (1.e-9) * b_r_t_VERTEX_dmn_t::dmn_size() *
+             std::pow(configuration_size, 2.);
+    GFLOP += 2. * (1.e-9) * configuration_size *
+             std::pow(b_r_t_VERTEX_dmn_t::dmn_size(), 2.);
   }
 
   {
@@ -645,38 +706,47 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G_r_t(
   }
 
   {
-    dca::linalg::matrixop::gemm(M_matrix_dn, G0_matrix_dn_right, M_G0_matrix_dn);
-    dca::linalg::matrixop::gemm(M_matrix_up, G0_matrix_up_right, M_G0_matrix_up);
+    dca::linalg::matrixop::gemm(M_matrix_dn, G0_matrix_dn_right,
+                                M_G0_matrix_dn);
+    dca::linalg::matrixop::gemm(M_matrix_up, G0_matrix_up_right,
+                                M_G0_matrix_up);
 
-    dca::linalg::matrixop::gemm(G0_matrix_dn_left, M_G0_matrix_dn, G0_M_G0_matrix_dn);
-    dca::linalg::matrixop::gemm(G0_matrix_up_left, M_G0_matrix_up, G0_M_G0_matrix_up);
+    dca::linalg::matrixop::gemm(G0_matrix_dn_left, M_G0_matrix_dn,
+                                G0_M_G0_matrix_dn);
+    dca::linalg::matrixop::gemm(G0_matrix_up_left, M_G0_matrix_up,
+                                G0_M_G0_matrix_up);
   }
 
   {
     for (int j = 0; j < G0_M_G0_matrix_dn.size().second; j++)
       for (int i = 0; i < G0_M_G0_matrix_dn.size().first; i++)
-        G_r_t_dn(i, j) = G0_sign_dn(i, j) * (G0_original_dn(i, j) - G0_M_G0_matrix_dn(i, j));
+        G_r_t_dn(i, j) =
+            G0_sign_dn(i, j) * (G0_original_dn(i, j) - G0_M_G0_matrix_dn(i, j));
 
     for (int j = 0; j < G0_M_G0_matrix_up.size().second; j++)
       for (int i = 0; i < G0_M_G0_matrix_up.size().first; i++)
-        G_r_t_up(i, j) = G0_sign_up(i, j) * (G0_original_up(i, j) - G0_M_G0_matrix_up(i, j));
+        G_r_t_up(i, j) =
+            G0_sign_up(i, j) * (G0_original_up(i, j) - G0_M_G0_matrix_up(i, j));
   }
 }
 
 template <class parameters_type, class MOMS_type>
 //     template<class configuration_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_G_r_t(double sign) {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_G_r_t(
+    double sign) {
   for (int j = 0; j < b_r_t_VERTEX_dmn_t::dmn_size(); j++) {
     for (int i = 0; i < b_r_t_VERTEX_dmn_t::dmn_size(); i++) {
       G_r_t_accumulated(G0_indices_dn(i, j)) +=
           sign * G0_integration_factor_dn(i, j) * G_r_t_dn(i, j);
       G_r_t_accumulated_squared(G0_indices_dn(i, j)) +=
-          sign * G0_integration_factor_dn(i, j) * G_r_t_dn(i, j) * G_r_t_dn(i, j);
+          sign * G0_integration_factor_dn(i, j) * G_r_t_dn(i, j) *
+          G_r_t_dn(i, j);
 
       G_r_t_accumulated(G0_indices_up(i, j)) +=
           sign * G0_integration_factor_up(i, j) * G_r_t_up(i, j);
       G_r_t_accumulated_squared(G0_indices_up(i, j)) +=
-          sign * G0_integration_factor_up(i, j) * G_r_t_up(i, j) * G_r_t_up(i, j);
+          sign * G0_integration_factor_up(i, j) * G_r_t_up(i, j) *
+          G_r_t_up(i, j);
     }
   }
 }
@@ -685,20 +755,25 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_G_r_t(double
  *   <S_z> = (n_up-1/2)*(n_dn-1/2)
  */
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_moments(double sign) {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_moments(
+    double sign) {
   for (int b_ind = 0; b_ind < b::dmn_size(); b_ind++) {
     for (int r_i = 0; r_i < r_dmn_t::dmn_size(); r_i++) {
       for (int t_ind = 0; t_ind < t_VERTEX::dmn_size(); t_ind++) {
         int i = b_r_t_dmn(b_ind, r_i, t_ind);
         int j = i;
 
-        double charge_val = G_r_t_up(i, j) * G_r_t_dn(i, j);  // double occupancy = <n_d*n_u>
+        double charge_val =
+            G_r_t_up(i, j) * G_r_t_dn(i, j); // double occupancy = <n_d*n_u>
         double magnetic_val =
             1. -
-            2. * G_r_t_up(i, j) * G_r_t_dn(i, j);  // <m^2> = 1-2*<n_d*n_u> (T. Paiva, PRB 2001)
+            2. * G_r_t_up(i, j) *
+                G_r_t_dn(i, j); // <m^2> = 1-2*<n_d*n_u> (T. Paiva, PRB 2001)
 
-        charge_cluster_moment(b_ind, r_i) += sign * charge_val / t_VERTEX::dmn_size();
-        magnetic_cluster_moment(b_ind, r_i) += sign * magnetic_val / t_VERTEX::dmn_size();
+        charge_cluster_moment(b_ind, r_i) +=
+            sign * charge_val / t_VERTEX::dmn_size();
+        magnetic_cluster_moment(b_ind, r_i) +=
+            sign * magnetic_val / t_VERTEX::dmn_size();
       }
     }
   }
@@ -708,7 +783,8 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_moments(doub
  * P_d
  */
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_dwave_pp_correlator(double sign) {
+void TpEqualTimeAccumulator<
+    parameters_type, MOMS_type>::accumulate_dwave_pp_correlator(double sign) {
   double renorm = 1. / (t_VERTEX::dmn_size() * pow(r_dmn_t::dmn_size(), 2.));
   double factor = sign * renorm;
 
@@ -718,7 +794,8 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_dwave_pp_cor
         int l_minus_i = r_dmn_t::parameter_type::subtract(r_i, r_l);
         int l_minus_j = r_dmn_t::parameter_type::subtract(r_j, r_l);
 
-        double struct_factor = dwave_r_factor(l_minus_i) * dwave_r_factor(l_minus_j);
+        double struct_factor =
+            dwave_r_factor(l_minus_i) * dwave_r_factor(l_minus_j);
 
         if (std::abs(struct_factor) > 1.e-6) {
           for (int b_i = 0; b_i < b::dmn_size(); b_i++) {
@@ -734,7 +811,7 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_dwave_pp_cor
                   double d_ij = i == j ? 1 : 0;
                   double d_il = i == l ? 1 : 0;
                   double d_lj = l == j ? 1 : 0;
-                  double d_ll = 1;  // l==l? 1 : 0;
+                  double d_ll = 1; // l==l? 1 : 0;
 
                   value += (d_ij - G_r_t_up(j, i)) * (d_ll - G_r_t_dn(l, l));
                   value += (d_ij - G_r_t_dn(j, i)) * (d_ll - G_r_t_up(l, l));
@@ -754,8 +831,9 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_dwave_pp_cor
 }
 
 template <class parameters_type, class MOMS_type>
-int TpEqualTimeAccumulator<parameters_type, MOMS_type>::find_first_non_interacting_spin(
-    const std::vector<vertex_singleton_type>& configuration_e_spin) {
+int TpEqualTimeAccumulator<parameters_type, MOMS_type>::
+    find_first_non_interacting_spin(
+        const std::vector<vertex_singleton_type> &configuration_e_spin) {
   int configuration_size = configuration_e_spin.size();
 
   int vertex_index = 0;
@@ -772,16 +850,16 @@ int TpEqualTimeAccumulator<parameters_type, MOMS_type>::find_first_non_interacti
 template <class parameters_type, class MOMS_type>
 template <class configuration_type>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix(
-    e_spin_states e_spin, const configuration_type& configuration,
-    dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix) {
+    e_spin_states e_spin, const configuration_type &configuration,
+    dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix) {
   int spin_index = domains::electron_spin_domain::to_coordinate(e_spin);
 
-  int r_ind, b_i, b_j, r_i, r_j;    //, s_i, s_j;
-  scalar_type t_i, t_j, delta_tau;  //, scaled_tau, f_tau;
+  int r_ind, b_i, b_j, r_i, r_j;   //, s_i, s_j;
+  scalar_type t_i, t_j, delta_tau; //, scaled_tau, f_tau;
 
   int configuration_size = find_first_non_interacting_spin(configuration);
   for (int j = 0; j < configuration_size; j++) {
-    const vertex_singleton_type& configuration_e_spin_j = configuration[j];
+    const vertex_singleton_type &configuration_e_spin_j = configuration[j];
 
     b_j = configuration_e_spin_j.get_band();
     r_j = configuration_e_spin_j.get_r_site();
@@ -796,7 +874,8 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix(
 
       delta_tau = t_i - t_j;
 
-      G0_matrix(i, j) = interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
+      G0_matrix(i, j) =
+          interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
     }
   }
 }
@@ -804,16 +883,16 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix(
 template <class parameters_type, class MOMS_type>
 template <class configuration_type>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix_left(
-    e_spin_states e_spin, const configuration_type& configuration,
-    dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix) {
+    e_spin_states e_spin, const configuration_type &configuration,
+    dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix) {
   int spin_index = domains::electron_spin_domain::to_coordinate(e_spin);
 
-  int r_ind, b_i, b_j, r_i, r_j;    //, s_i, s_j;
-  scalar_type t_i, t_j, delta_tau;  //, scaled_tau, f_tau;
+  int r_ind, b_i, b_j, r_i, r_j;   //, s_i, s_j;
+  scalar_type t_i, t_j, delta_tau; //, scaled_tau, f_tau;
 
   int configuration_size = find_first_non_interacting_spin(configuration);
   for (int j = 0; j < configuration_size; j++) {
-    const vertex_singleton_type& configuration_e_spin_j = configuration[j];
+    const vertex_singleton_type &configuration_e_spin_j = configuration[j];
 
     b_j = configuration_e_spin_j.get_band();
     r_j = configuration_e_spin_j.get_r_site();
@@ -828,20 +907,22 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix_left(
 
       delta_tau = t_i - t_j;
 
-      G0_matrix(i, j) = interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
+      G0_matrix(i, j) =
+          interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
     }
   }
 }
 
 template <class parameters_type, class MOMS_type>
 template <class configuration_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix_right(
-    e_spin_states e_spin, const configuration_type& configuration,
-    dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix) {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::
+    compute_G0_matrix_right(
+        e_spin_states e_spin, const configuration_type &configuration,
+        dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix) {
   int spin_index = domains::electron_spin_domain::to_coordinate(e_spin);
 
-  int r_ind, b_i, b_j, r_i, r_j;    //, s_i, s_j;
-  scalar_type t_i, t_j, delta_tau;  //, scaled_tau, f_tau;
+  int r_ind, b_i, b_j, r_i, r_j;   //, s_i, s_j;
+  scalar_type t_i, t_j, delta_tau; //, scaled_tau, f_tau;
 
   int configuration_size = find_first_non_interacting_spin(configuration);
 
@@ -851,7 +932,7 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix_right
     t_j = fixed_configuration[j].t_val;
 
     for (int i = 0; i < configuration_size; i++) {
-      const vertex_singleton_type& configuration_e_spin_i = configuration[i];
+      const vertex_singleton_type &configuration_e_spin_i = configuration[i];
 
       b_i = configuration_e_spin_i.get_band();
       r_i = configuration_e_spin_i.get_r_site();
@@ -861,13 +942,15 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix_right
 
       delta_tau = t_i - t_j;
 
-      G0_matrix(i, j) = interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
+      G0_matrix(i, j) =
+          interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
     }
   }
 }
 
 template <class parameters_type, class MOMS_type>
-inline double TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate_akima(
+inline double
+TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate_akima(
     int b_i, int s_i, int b_j, int s_j, int delta_r, double tau) {
   const static double beta = parameters.get_beta();
   const static double N_div_beta = parameters.get_sp_time_intervals() / beta;
@@ -884,18 +967,32 @@ inline double TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate_ak
   double delta_tau = scaled_tau - t_ind;
   assert(delta_tau > -1.e-16 && delta_tau <= 1 + 1.e-16);
 
-  int linind = 4 * nu_nu_r_dmn_t_t_shifted_dmn(b_i, s_i, b_j, s_j, delta_r, t_ind);
+  int linind =
+      4 * nu_nu_r_dmn_t_t_shifted_dmn(b_i, s_i, b_j, s_j, delta_r, t_ind);
 
-  double* a_ptr = &akima_coefficients(linind);
+  double *a_ptr = &akima_coefficients(linind);
 
-  double result = (a_ptr[0] + delta_tau * (a_ptr[1] + delta_tau * (a_ptr[2] + delta_tau * a_ptr[3])));
+  double result =
+      (a_ptr[0] +
+       delta_tau * (a_ptr[1] + delta_tau * (a_ptr[2] + delta_tau * a_ptr[3])));
 
   return result;
 }
 
-}  // ctaux
-}  // solver
-}  // phys
-}  // dca
+template <class parameters_type, class MOMS_type>
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::sumTo(
+    dca::phys::solver::ctaux::TpEqualTimeAccumulator<parameters_type, MOMS_type>
+        &other) const {
+  other.G_r_t_accumulated += G_r_t_accumulated;
+  other.G_r_t_accumulated_squared += G_r_t_accumulated_squared;
+  other.charge_cluster_moment += charge_cluster_moment;
+  other.dwave_pp_correlator += dwave_pp_correlator;
+  other.GFLOP += GFLOP;
+}
 
-#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_ACCUMULATOR_TP_TP_EQUAL_TIME_ACCUMULATOR_HPP
+} // ctaux
+} // solver
+} // phys
+} // dca
+
+#endif // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_ACCUMULATOR_TP_TP_EQUAL_TIME_ACCUMULATOR_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
@@ -986,6 +986,7 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::sumTo(
   other.G_r_t_accumulated += G_r_t_accumulated;
   other.G_r_t_accumulated_squared += G_r_t_accumulated_squared;
   other.charge_cluster_moment += charge_cluster_moment;
+  other.magnetic_cluster_moment += magnetic_cluster_moment;
   other.dwave_pp_correlator += dwave_pp_correlator;
   other.GFLOP += GFLOP;
 }

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
@@ -7,6 +7,7 @@
 // publications.
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This class measures the equal time operator functions.
 
@@ -40,7 +41,8 @@ namespace solver {
 namespace ctaux {
 // dca::phys::solver::ctaux::
 
-template <class parameters_type, class MOMS_type> class TpEqualTimeAccumulator {
+template <class parameters_type, class MOMS_type>
+class TpEqualTimeAccumulator {
 public:
   typedef double scalar_type;
   typedef vertex_singleton vertex_singleton_type;
@@ -49,12 +51,11 @@ public:
   typedef typename parameters_type::concurrency_type concurrency_type;
 
   using t = func::dmn_0<domains::time_domain>;
-  using t_VERTEX = func::dmn_0<
-      domains::vertex_time_domain<domains::TP_TIME_DOMAIN_POSITIVE>>;
+  using t_VERTEX = func::dmn_0<domains::vertex_time_domain<domains::TP_TIME_DOMAIN_POSITIVE>>;
 
   using b = func::dmn_0<domains::electron_band_domain>;
   using s = func::dmn_0<domains::electron_spin_domain>;
-  using nu = func::dmn_variadic<b, s>; // orbital-spin index
+  using nu = func::dmn_variadic<b, s>;  // orbital-spin index
 
   using CDA = ClusterDomainAliases<parameters_type::lattice_type::DIMENSION>;
   using RClusterDmn = typename CDA::RClusterDmn;
@@ -65,56 +66,56 @@ public:
   typedef func::dmn_variadic<b, r_dmn_t, t_VERTEX> b_r_t_VERTEX_dmn_t;
 
   typedef func::dmn_0<domains::time_domain_left_oriented> shifted_t;
-  typedef func::dmn_variadic<nu, nu, r_dmn_t, shifted_t>
-      nu_nu_r_dmn_t_shifted_t;
+  typedef func::dmn_variadic<nu, nu, r_dmn_t, shifted_t> nu_nu_r_dmn_t_shifted_t;
 
   typedef func::dmn_0<func::dmn<4, int>> akima_dmn_t;
-  typedef func::dmn_variadic<akima_dmn_t, nu, nu, r_dmn_t, shifted_t>
-      akima_nu_nu_r_dmn_t_shifted_t;
+  typedef func::dmn_variadic<akima_dmn_t, nu, nu, r_dmn_t, shifted_t> akima_nu_nu_r_dmn_t_shifted_t;
 
 public:
-  TpEqualTimeAccumulator(parameters_type &parameters_ref, MOMS_type &MOMS_ref,
-                         int id);
+  TpEqualTimeAccumulator(parameters_type& parameters_ref, MOMS_type& MOMS_ref, int id);
 
-  void initialize();
+  void resetAccumulation();
 
   void finalize();
 
-  void sumTo(TpEqualTimeAccumulator<parameters_type, MOMS_type> &other) const;
+  void sumTo(TpEqualTimeAccumulator<parameters_type, MOMS_type>& other) const;
 
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &get_G_r_t() {
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& get_G_r_t() {
     return G_r_t;
   }
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &
-  get_G_r_t_stddev() {
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& get_G_r_t_stddev() {
     return G_r_t_stddev;
   }
 
-  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
-  get_charge_cluster_moment() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_charge_cluster_moment() {
     return charge_cluster_moment;
   }
-  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
-  get_magnetic_cluster_moment() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_magnetic_cluster_moment() {
     return magnetic_cluster_moment;
   }
-  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
-  get_dwave_pp_correlator() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_dwave_pp_correlator() {
     return dwave_pp_correlator;
   }
 
   template <class configuration_type, typename RealInp>
-  void
-  compute_G_r_t(const configuration_type &configuration_e_up,
-                const dca::linalg::Matrix<RealInp, dca::linalg::CPU> &M_up,
-                const configuration_type &configuration_e_dn,
-                const dca::linalg::Matrix<RealInp, dca::linalg::CPU> &M_dn);
+  void compute_G_r_t(const configuration_type& configuration_e_up,
+                     const dca::linalg::Matrix<RealInp, dca::linalg::CPU>& M_up,
+                     const configuration_type& configuration_e_dn,
+                     const dca::linalg::Matrix<RealInp, dca::linalg::CPU>& M_dn);
 
   void accumulate_G_r_t(double sign);
 
   void accumulate_moments(double sign);
 
   void accumulate_dwave_pp_correlator(double sign);
+
+  // Accumulate all relevant quantities. This is equivalent to calling compute_G_r_t followed by all
+  // the accumulation methods.
+  template <class configuration_type, typename RealInp>
+  void accumulateAll(const configuration_type& configuration_e_up,
+                     const dca::linalg::Matrix<RealInp, dca::linalg::CPU>& M_up,
+                     const configuration_type& configuration_e_dn,
+                     const dca::linalg::Matrix<RealInp, dca::linalg::CPU>& M_dn, int sign);
 
   double get_GFLOP();
 
@@ -126,32 +127,24 @@ private:
   void initialize_G0_original();
   void test_G0_original();
 
-  void interpolate(
-      func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &G_r_t,
-      func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>
-          &G_r_t_stddev);
+  void interpolate(func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& G_r_t,
+                   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& G_r_t_stddev);
 
-  int find_first_non_interacting_spin(
-      const std::vector<vertex_singleton_type> &configuration_e_spin);
+  int find_first_non_interacting_spin(const std::vector<vertex_singleton_type>& configuration_e_spin);
 
   template <class configuration_type>
-  void
-  compute_G0_matrix(e_spin_states e_spin,
-                    const configuration_type &configuration,
-                    dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix);
+  void compute_G0_matrix(e_spin_states e_spin, const configuration_type& configuration,
+                         dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix);
 
   template <class configuration_type>
-  void compute_G0_matrix_left(
-      e_spin_states e_spin, const configuration_type &configuration,
-      dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix);
+  void compute_G0_matrix_left(e_spin_states e_spin, const configuration_type& configuration,
+                              dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix);
 
   template <class configuration_type>
-  void compute_G0_matrix_right(
-      e_spin_states e_spin, const configuration_type &configuration,
-      dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix);
+  void compute_G0_matrix_right(e_spin_states e_spin, const configuration_type& configuration,
+                               dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix);
 
-  double interpolate_akima(int b_i, int s_i, int b_j, int s_j, int delta_r,
-                           double tau);
+  double interpolate_akima(int b_i, int s_i, int b_j, int s_j, int delta_r, double tau);
 
 private:
   struct singleton_operator {
@@ -163,9 +156,9 @@ private:
   };
 
 private:
-  parameters_type &parameters;
-  concurrency_type &concurrency;
-  MOMS_type &MOMS;
+  parameters_type& parameters;
+  concurrency_type& concurrency;
+  MOMS_type& MOMS;
 
   int thread_id;
   double GFLOP;
@@ -178,31 +171,25 @@ private:
   std::vector<singleton_operator> fixed_configuration;
   std::vector<singleton_operator> ctaux_configuration;
 
-  func::function<float,
-                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_sign_up;
-  func::function<float,
-                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_sign_dn;
 
-  func::function<int,
-                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<int, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                         func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_indices_up;
-  func::function<int,
-                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<int, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                         func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_indices_dn;
 
-  func::function<float,
-                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_integration_factor_up;
-  func::function<float,
-                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G0_integration_factor_dn;
 
   dca::linalg::Matrix<float, dca::linalg::CPU> G0_original_up;
@@ -226,26 +213,21 @@ private:
   dca::linalg::Matrix<float, dca::linalg::CPU> G0_M_G0_matrix_up;
   dca::linalg::Matrix<float, dca::linalg::CPU> G0_M_G0_matrix_dn;
 
-  func::function<float,
-                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G_r_t_dn;
-  func::function<float,
-                 func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
-                                    func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
+  func::function<float, func::dmn_variadic<func::dmn_variadic<b, r_dmn_t, t_VERTEX>,
+                                           func::dmn_variadic<b, r_dmn_t, t_VERTEX>>>
       G_r_t_up;
 
   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> G_r_t;
   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> G_r_t_stddev;
 
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX>>
-      G_r_t_accumulated;
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX>>
-      G_r_t_accumulated_squared;
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX>> G_r_t_accumulated;
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX>> G_r_t_accumulated_squared;
 
   func::function<double, func::dmn_variadic<b, r_dmn_t>> charge_cluster_moment;
-  func::function<double, func::dmn_variadic<b, r_dmn_t>>
-      magnetic_cluster_moment;
+  func::function<double, func::dmn_variadic<b, r_dmn_t>> magnetic_cluster_moment;
 
   func::function<double, k_dmn_t> dwave_k_factor;
   func::function<double, r_dmn_t> dwave_r_factor;
@@ -255,8 +237,9 @@ private:
 
 template <class parameters_type, class MOMS_type>
 TpEqualTimeAccumulator<parameters_type, MOMS_type>::TpEqualTimeAccumulator(
-    parameters_type &parameters_ref, MOMS_type &MOMS_ref, int id)
-    : parameters(parameters_ref), concurrency(parameters.get_concurrency()),
+    parameters_type& parameters_ref, MOMS_type& MOMS_ref, int id)
+    : parameters(parameters_ref),
+      concurrency(parameters.get_concurrency()),
 
       MOMS(MOMS_ref),
 
@@ -270,7 +253,21 @@ TpEqualTimeAccumulator<parameters_type, MOMS_type>::TpEqualTimeAccumulator(
       charge_cluster_moment("charge-cluster-moment"),
       magnetic_cluster_moment("magnetic-cluster-moment"),
 
-      dwave_pp_correlator("dwave-pp-correlator") {}
+      dwave_pp_correlator("dwave-pp-correlator") {
+  for (int k_ind = 0; k_ind < k_dmn_t::dmn_size(); k_ind++)
+    dwave_k_factor(k_ind) =
+        cos(k_dmn_t::get_elements()[k_ind][0]) - cos(k_dmn_t::get_elements()[k_ind][1]);
+
+  math::transform::FunctionTransform<k_dmn_t, r_dmn_t>::execute(dwave_k_factor, dwave_r_factor);
+
+  initialize_my_configuration();
+
+  initialize_akima_coefficients();
+
+  initialize_G0_indices();
+
+  initialize_G0_original();
+}
 
 template <class parameters_type, class MOMS_type>
 double TpEqualTimeAccumulator<parameters_type, MOMS_type>::get_GFLOP() {
@@ -280,7 +277,7 @@ double TpEqualTimeAccumulator<parameters_type, MOMS_type>::get_GFLOP() {
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize() {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::resetAccumulation() {
   GFLOP = 0;
 
   G_r_t = 0;
@@ -293,44 +290,11 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize() {
   magnetic_cluster_moment = 0;
 
   dwave_pp_correlator = 0;
-
-  {
-    for (int k_ind = 0; k_ind < k_dmn_t::dmn_size(); k_ind++)
-      dwave_k_factor(k_ind) = cos(k_dmn_t::get_elements()[k_ind][0]) -
-                              cos(k_dmn_t::get_elements()[k_ind][1]);
-
-    math::transform::FunctionTransform<k_dmn_t, r_dmn_t>::execute(
-        dwave_k_factor, dwave_r_factor);
-
-    /*
-    if(thread_id==0)
-      {
-        std::cout << "\n\n";
-        for(int r_ind=0; r_ind<r_dmn_t::dmn_size(); r_ind++)
-          std::cout << "\t" << r_ind
-               << "\t" << r_dmn_t::get_elements()[r_ind][0]
-               << "\t" << r_dmn_t::get_elements()[r_ind][1]
-               << "\t" << dwave_r_factor(r_ind) << "\n";
-
-        std::cout << "\n\n";
-      }
-    */
-  }
-
-  initialize_my_configuration();
-
-  initialize_akima_coefficients();
-
-  initialize_G0_indices();
-
-  initialize_G0_original();
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type,
-                            MOMS_type>::initialize_my_configuration() {
-  fixed_configuration.resize(b::dmn_size() * r_dmn_t::dmn_size() *
-                             t_VERTEX::dmn_size());
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_my_configuration() {
+  fixed_configuration.resize(b::dmn_size() * r_dmn_t::dmn_size() * t_VERTEX::dmn_size());
 
   int index = 0;
   for (int b_ind = 0; b_ind < b::dmn_size(); b_ind++) {
@@ -352,14 +316,13 @@ void TpEqualTimeAccumulator<parameters_type,
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type,
-                            MOMS_type>::initialize_akima_coefficients() {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_akima_coefficients() {
   int size = t::dmn_size() / 2;
 
   math::interpolation::akima_interpolation<double> ai_obj(size);
 
-  double *x = new double[size];
-  double *y = new double[size];
+  double* x = new double[size];
+  double* y = new double[size];
 
   for (int t_ind = 0; t_ind < t::dmn_size() / 2; t_ind++)
     x[t_ind] = t_ind;
@@ -369,15 +332,13 @@ void TpEqualTimeAccumulator<parameters_type,
       for (int nu1_ind = 0; nu1_ind < nu::dmn_size(); nu1_ind++) {
         for (int nu0_ind = 0; nu0_ind < nu::dmn_size(); nu0_ind++) {
           for (int t_ind = 0; t_ind < t::dmn_size() / 2; t_ind++)
-            y[t_ind] =
-                MOMS.G0_r_t_cluster_excluded(nu0_ind, nu1_ind, r_ind, t_ind);
+            y[t_ind] = MOMS.G0_r_t_cluster_excluded(nu0_ind, nu1_ind, r_ind, t_ind);
 
           ai_obj.initialize(x, y);
 
           for (int t_ind = 0; t_ind < t::dmn_size() / 2 - 1; t_ind++)
             for (int l = 0; l < 4; l++)
-              akima_coefficients(l, nu0_ind, nu1_ind, r_ind, t_ind) =
-                  ai_obj.get_alpha(l, t_ind);
+              akima_coefficients(l, nu0_ind, nu1_ind, r_ind, t_ind) = ai_obj.get_alpha(l, t_ind);
         }
       }
     }
@@ -393,8 +354,7 @@ void TpEqualTimeAccumulator<parameters_type,
 
           ai_obj.initialize(x, y);
 
-          for (int t_ind = t::dmn_size() / 2; t_ind < t::dmn_size() - 1;
-               t_ind++)
+          for (int t_ind = t::dmn_size() / 2; t_ind < t::dmn_size() - 1; t_ind++)
             for (int l = 0; l < 4; l++)
               akima_coefficients(l, nu0_ind, nu1_ind, r_ind, t_ind - 1) =
                   ai_obj.get_alpha(l, t_ind - t::dmn_size() / 2);
@@ -408,23 +368,20 @@ void TpEqualTimeAccumulator<parameters_type,
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type,
-                            MOMS_type>::initialize_G0_indices() {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_G0_indices() {
   std::vector<double> multiplicities(t_VERTEX::dmn_size(), 0);
   {
     for (int i = 0; i < t_VERTEX::dmn_size(); i++) {
       for (int j = 0; j < t_VERTEX::dmn_size(); j++) {
         int t_ind = i - j;
 
-        if (std::abs(t_VERTEX::get_elements().back() - parameters.get_beta()) <
-            1.e-6)
+        if (std::abs(t_VERTEX::get_elements().back() - parameters.get_beta()) < 1.e-6)
           t_ind = t_ind < 0 ? t_ind + t_VERTEX::dmn_size() - 1 : t_ind;
         else
           t_ind = t_ind < 0 ? t_ind + t_VERTEX::dmn_size() - 0 : t_ind;
 
         for (int l = 0; l < t_VERTEX::dmn_size(); l++)
-          if (std::abs(t_VERTEX::get_elements()[l] -
-                       t_VERTEX::get_elements()[t_ind]) < 1.e-6)
+          if (std::abs(t_VERTEX::get_elements()[l] - t_VERTEX::get_elements()[t_ind]) < 1.e-6)
             multiplicities[l] += 1;
       }
     }
@@ -434,10 +391,10 @@ void TpEqualTimeAccumulator<parameters_type,
   int r_i, r_j, delta_r;
   int t_i, t_j, delta_tau;
 
-  G0_original_up.resizeNoCopy(std::pair<int, int>(
-      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
-  G0_original_dn.resizeNoCopy(std::pair<int, int>(
-      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_original_up.resizeNoCopy(
+      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_original_dn.resizeNoCopy(
+      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
 
   func::dmn_variadic<nu, nu, r_dmn_t, t_VERTEX> G_r_t_dmn;
   for (int j = 0; j < b_r_t_VERTEX_dmn_t::dmn_size(); j++) {
@@ -457,20 +414,15 @@ void TpEqualTimeAccumulator<parameters_type,
       G0_sign_dn(i, j) = delta_tau < 0 ? -1 : 1;
       G0_sign_up(i, j) = delta_tau < 0 ? -1 : 1;
 
-      if (std::abs(t_VERTEX::get_elements().back() - parameters.get_beta()) <
-          1.e-6)
-        delta_tau =
-            delta_tau < 0 ? delta_tau + t_VERTEX::dmn_size() - 1 : delta_tau;
+      if (std::abs(t_VERTEX::get_elements().back() - parameters.get_beta()) < 1.e-6)
+        delta_tau = delta_tau < 0 ? delta_tau + t_VERTEX::dmn_size() - 1 : delta_tau;
       else
-        delta_tau =
-            delta_tau < 0 ? delta_tau + t_VERTEX::dmn_size() - 0 : delta_tau;
+        delta_tau = delta_tau < 0 ? delta_tau + t_VERTEX::dmn_size() - 0 : delta_tau;
 
       assert(multiplicities[delta_tau] > 0);
 
-      G0_integration_factor_dn(i, j) =
-          1. / (r_dmn_t::dmn_size() * multiplicities[delta_tau]);
-      G0_integration_factor_up(i, j) =
-          1. / (r_dmn_t::dmn_size() * multiplicities[delta_tau]);
+      G0_integration_factor_dn(i, j) = 1. / (r_dmn_t::dmn_size() * multiplicities[delta_tau]);
+      G0_integration_factor_up(i, j) = 1. / (r_dmn_t::dmn_size() * multiplicities[delta_tau]);
 
       G0_indices_dn(i, j) = G_r_t_dmn(b_i, 0, b_j, 0, delta_r, delta_tau);
       G0_indices_up(i, j) = G_r_t_dmn(b_i, 1, b_j, 1, delta_r, delta_tau);
@@ -479,20 +431,19 @@ void TpEqualTimeAccumulator<parameters_type,
 }
 
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type,
-                            MOMS_type>::initialize_G0_original() {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::initialize_G0_original() {
   int r_ind, b_i, b_j, r_i, r_j;
-  scalar_type t_i, t_j, delta_tau; //, scaled_tau, f_tau;
+  scalar_type t_i, t_j, delta_tau;  //, scaled_tau, f_tau;
 
-  G0_original_dn.resizeNoCopy(std::pair<int, int>(
-      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
-  G0_original_up.resizeNoCopy(std::pair<int, int>(
-      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_original_dn.resizeNoCopy(
+      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_original_up.resizeNoCopy(
+      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
 
-  G0_M_G0_matrix_dn.resizeNoCopy(std::pair<int, int>(
-      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
-  G0_M_G0_matrix_up.resizeNoCopy(std::pair<int, int>(
-      b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_M_G0_matrix_dn.resizeNoCopy(
+      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
+  G0_M_G0_matrix_up.resizeNoCopy(
+      std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), b_r_t_VERTEX_dmn_t::dmn_size()));
 
   for (int j = 0; j < b_r_t_VERTEX_dmn_t::dmn_size(); j++) {
     b_j = fixed_configuration[j].b_ind;
@@ -508,10 +459,8 @@ void TpEqualTimeAccumulator<parameters_type,
 
       delta_tau = t_i - t_j;
 
-      G0_original_dn(i, j) =
-          interpolate_akima(b_i, 0, b_j, 0, r_ind, delta_tau);
-      G0_original_up(i, j) =
-          interpolate_akima(b_i, 1, b_j, 1, r_ind, delta_tau);
+      G0_original_dn(i, j) = interpolate_akima(b_i, 0, b_j, 0, r_ind, delta_tau);
+      G0_original_up(i, j) = interpolate_akima(b_i, 1, b_j, 1, r_ind, delta_tau);
     }
   }
 
@@ -535,19 +484,16 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::test_G0_original() {
 
   for (int j = 0; j < G0_original_dn.size().first; j++)
     for (int i = 0; i < G0_original_dn.size().first; i++)
-      G_r_t_accumulated(G0_indices_dn(i, j)) += G0_sign_dn(i, j) *
-                                                G0_integration_factor_dn(i, j) *
-                                                G0_original_dn(i, j);
+      G_r_t_accumulated(G0_indices_dn(i, j)) +=
+          G0_sign_dn(i, j) * G0_integration_factor_dn(i, j) * G0_original_dn(i, j);
 
   for (int j = 0; j < G0_original_up.size().first; j++)
     for (int i = 0; i < G0_original_up.size().first; i++)
-      G_r_t_accumulated(G0_indices_up(i, j)) += G0_sign_up(i, j) *
-                                                G0_integration_factor_up(i, j) *
-                                                G0_original_up(i, j);
+      G_r_t_accumulated(G0_indices_up(i, j)) +=
+          G0_sign_up(i, j) * G0_integration_factor_up(i, j) * G0_original_up(i, j);
 
   for (int i = 0; i < t_VERTEX::dmn_size(); i++)
-    std::cout << "\t" << t_VERTEX::get_elements()[i] << "\t"
-              << G_r_t_accumulated(0, 0, 0, i) << "\n";
+    std::cout << "\t" << t_VERTEX::get_elements()[i] << "\t" << G_r_t_accumulated(0, 0, 0, i) << "\n";
   std::cout << std::endl;
 
   util::Plot::plotLinesPoints(MOMS.G0_r_t_cluster_excluded);
@@ -568,8 +514,8 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::finalize() {
   // util::Plot::plotLinesPoints(G_r_t_accumulated);
 
   for (int l = 0; l < G_r_t_accumulated_squared.size(); l++)
-    G_r_t_accumulated_squared(l) = std::sqrt(std::abs(
-        G_r_t_accumulated_squared(l) - std::pow(G_r_t_accumulated(l), 2)));
+    G_r_t_accumulated_squared(l) =
+        std::sqrt(std::abs(G_r_t_accumulated_squared(l) - std::pow(G_r_t_accumulated(l), 2)));
 
   interpolate(G_r_t, G_r_t_stddev);
 
@@ -578,15 +524,14 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::finalize() {
 
 template <class parameters_type, class MOMS_type>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate(
-    func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &G_r_t,
-    func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>
-        &G_r_t_stddev) {
+    func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& G_r_t,
+    func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& G_r_t_stddev) {
   int size = t_VERTEX::dmn_size();
 
   math::interpolation::akima_interpolation<double> ai_obj(size);
 
-  double *x = new double[size];
-  double *y = new double[size];
+  double* x = new double[size];
+  double* y = new double[size];
 
   for (int t_ind = 0; t_ind < t_VERTEX::dmn_size(); t_ind++)
     x[t_ind] = t_VERTEX::get_elements()[t_ind];
@@ -602,14 +547,12 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate(
             ai_obj.initialize(x, y);
 
             for (int t_ind = t::dmn_size() / 2; t_ind < t::dmn_size(); t_ind++)
-              G_r_t(nu0_ind, nu1_ind, r_ind, t_ind) =
-                  ai_obj.evaluate(t::get_elements()[t_ind]);
+              G_r_t(nu0_ind, nu1_ind, r_ind, t_ind) = ai_obj.evaluate(t::get_elements()[t_ind]);
           }
 
           {
             for (int t_ind = 0; t_ind < t_VERTEX::dmn_size(); t_ind++)
-              y[t_ind] =
-                  G_r_t_accumulated_squared(nu0_ind, nu1_ind, r_ind, t_ind);
+              y[t_ind] = G_r_t_accumulated_squared(nu0_ind, nu1_ind, r_ind, t_ind);
 
             ai_obj.initialize(x, y);
 
@@ -632,8 +575,8 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate(
       for (int nu1_ind = 0; nu1_ind < nu::dmn_size(); nu1_ind++)
         for (int nu0_ind = 0; nu0_ind < nu::dmn_size(); nu0_ind++)
           for (int t_ind = 0; t_ind < t::dmn_size() / 2; t_ind++)
-            G_r_t_stddev(nu0_ind, nu1_ind, r_ind, t_ind) = G_r_t_stddev(
-                nu0_ind, nu1_ind, r_ind, t_ind + t::dmn_size() / 2);
+            G_r_t_stddev(nu0_ind, nu1_ind, r_ind, t_ind) =
+                G_r_t_stddev(nu0_ind, nu1_ind, r_ind, t_ind + t::dmn_size() / 2);
   }
 
   delete[] x;
@@ -643,58 +586,50 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate(
 template <class parameters_type, class MOMS_type>
 template <class configuration_type, typename RealInp>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G_r_t(
-    const configuration_type &configuration_e_up,
-    const dca::linalg::Matrix<RealInp, linalg::CPU> &M_up,
-    const configuration_type &configuration_e_dn,
-    const dca::linalg::Matrix<RealInp, linalg::CPU> &M_dn) {
+    const configuration_type& configuration_e_up,
+    const dca::linalg::Matrix<RealInp, linalg::CPU>& M_up,
+    const configuration_type& configuration_e_dn,
+    const dca::linalg::Matrix<RealInp, linalg::CPU>& M_dn) {
   {
-    int configuration_size =
-        find_first_non_interacting_spin(configuration_e_dn);
+    int configuration_size = find_first_non_interacting_spin(configuration_e_dn);
 
-    M_matrix_dn.resizeNoCopy(
-        std::pair<int, int>(configuration_size, configuration_size));
+    M_matrix_dn.resizeNoCopy(std::pair<int, int>(configuration_size, configuration_size));
 
-    G0_matrix_dn_left.resizeNoCopy(std::pair<int, int>(
-        b_r_t_VERTEX_dmn_t::dmn_size(), configuration_size));
-    G0_matrix_dn_right.resizeNoCopy(std::pair<int, int>(
-        configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
+    G0_matrix_dn_left.resizeNoCopy(
+        std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), configuration_size));
+    G0_matrix_dn_right.resizeNoCopy(
+        std::pair<int, int>(configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
 
-    M_G0_matrix_dn.resizeNoCopy(std::pair<int, int>(
-        configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
+    M_G0_matrix_dn.resizeNoCopy(
+        std::pair<int, int>(configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
 
     for (int j = 0; j < configuration_size; j++)
       for (int i = 0; i < configuration_size; i++)
         M_matrix_dn(i, j) = M_dn(i, j);
 
-    GFLOP += 2 * (1.e-9) * b_r_t_VERTEX_dmn_t::dmn_size() *
-             std::pow(configuration_size, 2.);
-    GFLOP += 2 * (1.e-9) * configuration_size *
-             std::pow(b_r_t_VERTEX_dmn_t::dmn_size(), 2.);
+    GFLOP += 2 * (1.e-9) * b_r_t_VERTEX_dmn_t::dmn_size() * std::pow(configuration_size, 2.);
+    GFLOP += 2 * (1.e-9) * configuration_size * std::pow(b_r_t_VERTEX_dmn_t::dmn_size(), 2.);
   }
 
   {
-    int configuration_size =
-        find_first_non_interacting_spin(configuration_e_up);
+    int configuration_size = find_first_non_interacting_spin(configuration_e_up);
 
-    M_matrix_up.resizeNoCopy(
-        std::pair<int, int>(configuration_size, configuration_size));
+    M_matrix_up.resizeNoCopy(std::pair<int, int>(configuration_size, configuration_size));
 
-    G0_matrix_up_left.resizeNoCopy(std::pair<int, int>(
-        b_r_t_VERTEX_dmn_t::dmn_size(), configuration_size));
-    G0_matrix_up_right.resizeNoCopy(std::pair<int, int>(
-        configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
+    G0_matrix_up_left.resizeNoCopy(
+        std::pair<int, int>(b_r_t_VERTEX_dmn_t::dmn_size(), configuration_size));
+    G0_matrix_up_right.resizeNoCopy(
+        std::pair<int, int>(configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
 
-    M_G0_matrix_up.resizeNoCopy(std::pair<int, int>(
-        configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
+    M_G0_matrix_up.resizeNoCopy(
+        std::pair<int, int>(configuration_size, b_r_t_VERTEX_dmn_t::dmn_size()));
 
     for (int j = 0; j < configuration_size; j++)
       for (int i = 0; i < configuration_size; i++)
         M_matrix_up(i, j) = M_up(i, j);
 
-    GFLOP += 2. * (1.e-9) * b_r_t_VERTEX_dmn_t::dmn_size() *
-             std::pow(configuration_size, 2.);
-    GFLOP += 2. * (1.e-9) * configuration_size *
-             std::pow(b_r_t_VERTEX_dmn_t::dmn_size(), 2.);
+    GFLOP += 2. * (1.e-9) * b_r_t_VERTEX_dmn_t::dmn_size() * std::pow(configuration_size, 2.);
+    GFLOP += 2. * (1.e-9) * configuration_size * std::pow(b_r_t_VERTEX_dmn_t::dmn_size(), 2.);
   }
 
   {
@@ -706,47 +641,38 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G_r_t(
   }
 
   {
-    dca::linalg::matrixop::gemm(M_matrix_dn, G0_matrix_dn_right,
-                                M_G0_matrix_dn);
-    dca::linalg::matrixop::gemm(M_matrix_up, G0_matrix_up_right,
-                                M_G0_matrix_up);
+    dca::linalg::matrixop::gemm(M_matrix_dn, G0_matrix_dn_right, M_G0_matrix_dn);
+    dca::linalg::matrixop::gemm(M_matrix_up, G0_matrix_up_right, M_G0_matrix_up);
 
-    dca::linalg::matrixop::gemm(G0_matrix_dn_left, M_G0_matrix_dn,
-                                G0_M_G0_matrix_dn);
-    dca::linalg::matrixop::gemm(G0_matrix_up_left, M_G0_matrix_up,
-                                G0_M_G0_matrix_up);
+    dca::linalg::matrixop::gemm(G0_matrix_dn_left, M_G0_matrix_dn, G0_M_G0_matrix_dn);
+    dca::linalg::matrixop::gemm(G0_matrix_up_left, M_G0_matrix_up, G0_M_G0_matrix_up);
   }
 
   {
     for (int j = 0; j < G0_M_G0_matrix_dn.size().second; j++)
       for (int i = 0; i < G0_M_G0_matrix_dn.size().first; i++)
-        G_r_t_dn(i, j) =
-            G0_sign_dn(i, j) * (G0_original_dn(i, j) - G0_M_G0_matrix_dn(i, j));
+        G_r_t_dn(i, j) = G0_sign_dn(i, j) * (G0_original_dn(i, j) - G0_M_G0_matrix_dn(i, j));
 
     for (int j = 0; j < G0_M_G0_matrix_up.size().second; j++)
       for (int i = 0; i < G0_M_G0_matrix_up.size().first; i++)
-        G_r_t_up(i, j) =
-            G0_sign_up(i, j) * (G0_original_up(i, j) - G0_M_G0_matrix_up(i, j));
+        G_r_t_up(i, j) = G0_sign_up(i, j) * (G0_original_up(i, j) - G0_M_G0_matrix_up(i, j));
   }
 }
 
 template <class parameters_type, class MOMS_type>
 //     template<class configuration_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_G_r_t(
-    double sign) {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_G_r_t(double sign) {
   for (int j = 0; j < b_r_t_VERTEX_dmn_t::dmn_size(); j++) {
     for (int i = 0; i < b_r_t_VERTEX_dmn_t::dmn_size(); i++) {
       G_r_t_accumulated(G0_indices_dn(i, j)) +=
           sign * G0_integration_factor_dn(i, j) * G_r_t_dn(i, j);
       G_r_t_accumulated_squared(G0_indices_dn(i, j)) +=
-          sign * G0_integration_factor_dn(i, j) * G_r_t_dn(i, j) *
-          G_r_t_dn(i, j);
+          sign * G0_integration_factor_dn(i, j) * G_r_t_dn(i, j) * G_r_t_dn(i, j);
 
       G_r_t_accumulated(G0_indices_up(i, j)) +=
           sign * G0_integration_factor_up(i, j) * G_r_t_up(i, j);
       G_r_t_accumulated_squared(G0_indices_up(i, j)) +=
-          sign * G0_integration_factor_up(i, j) * G_r_t_up(i, j) *
-          G_r_t_up(i, j);
+          sign * G0_integration_factor_up(i, j) * G_r_t_up(i, j) * G_r_t_up(i, j);
     }
   }
 }
@@ -755,25 +681,19 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_G_r_t(
  *   <S_z> = (n_up-1/2)*(n_dn-1/2)
  */
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_moments(
-    double sign) {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_moments(double sign) {
   for (int b_ind = 0; b_ind < b::dmn_size(); b_ind++) {
     for (int r_i = 0; r_i < r_dmn_t::dmn_size(); r_i++) {
       for (int t_ind = 0; t_ind < t_VERTEX::dmn_size(); t_ind++) {
         int i = b_r_t_dmn(b_ind, r_i, t_ind);
         int j = i;
 
-        double charge_val =
-            G_r_t_up(i, j) * G_r_t_dn(i, j); // double occupancy = <n_d*n_u>
+        double charge_val = G_r_t_up(i, j) * G_r_t_dn(i, j);  // double occupancy = <n_d*n_u>
         double magnetic_val =
-            1. -
-            2. * G_r_t_up(i, j) *
-                G_r_t_dn(i, j); // <m^2> = 1-2*<n_d*n_u> (T. Paiva, PRB 2001)
+            1. - 2. * G_r_t_up(i, j) * G_r_t_dn(i, j);  // <m^2> = 1-2*<n_d*n_u> (T. Paiva, PRB 2001)
 
-        charge_cluster_moment(b_ind, r_i) +=
-            sign * charge_val / t_VERTEX::dmn_size();
-        magnetic_cluster_moment(b_ind, r_i) +=
-            sign * magnetic_val / t_VERTEX::dmn_size();
+        charge_cluster_moment(b_ind, r_i) += sign * charge_val / t_VERTEX::dmn_size();
+        magnetic_cluster_moment(b_ind, r_i) += sign * magnetic_val / t_VERTEX::dmn_size();
       }
     }
   }
@@ -783,8 +703,7 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_moments(
  * P_d
  */
 template <class parameters_type, class MOMS_type>
-void TpEqualTimeAccumulator<
-    parameters_type, MOMS_type>::accumulate_dwave_pp_correlator(double sign) {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulate_dwave_pp_correlator(double sign) {
   double renorm = 1. / (t_VERTEX::dmn_size() * pow(r_dmn_t::dmn_size(), 2.));
   double factor = sign * renorm;
 
@@ -794,8 +713,7 @@ void TpEqualTimeAccumulator<
         int l_minus_i = r_dmn_t::parameter_type::subtract(r_i, r_l);
         int l_minus_j = r_dmn_t::parameter_type::subtract(r_j, r_l);
 
-        double struct_factor =
-            dwave_r_factor(l_minus_i) * dwave_r_factor(l_minus_j);
+        double struct_factor = dwave_r_factor(l_minus_i) * dwave_r_factor(l_minus_j);
 
         if (std::abs(struct_factor) > 1.e-6) {
           for (int b_i = 0; b_i < b::dmn_size(); b_i++) {
@@ -811,7 +729,7 @@ void TpEqualTimeAccumulator<
                   double d_ij = i == j ? 1 : 0;
                   double d_il = i == l ? 1 : 0;
                   double d_lj = l == j ? 1 : 0;
-                  double d_ll = 1; // l==l? 1 : 0;
+                  double d_ll = 1;  // l==l? 1 : 0;
 
                   value += (d_ij - G_r_t_up(j, i)) * (d_ll - G_r_t_dn(l, l));
                   value += (d_ij - G_r_t_dn(j, i)) * (d_ll - G_r_t_up(l, l));
@@ -831,9 +749,8 @@ void TpEqualTimeAccumulator<
 }
 
 template <class parameters_type, class MOMS_type>
-int TpEqualTimeAccumulator<parameters_type, MOMS_type>::
-    find_first_non_interacting_spin(
-        const std::vector<vertex_singleton_type> &configuration_e_spin) {
+int TpEqualTimeAccumulator<parameters_type, MOMS_type>::find_first_non_interacting_spin(
+    const std::vector<vertex_singleton_type>& configuration_e_spin) {
   int configuration_size = configuration_e_spin.size();
 
   int vertex_index = 0;
@@ -850,16 +767,16 @@ int TpEqualTimeAccumulator<parameters_type, MOMS_type>::
 template <class parameters_type, class MOMS_type>
 template <class configuration_type>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix(
-    e_spin_states e_spin, const configuration_type &configuration,
-    dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix) {
+    e_spin_states e_spin, const configuration_type& configuration,
+    dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix) {
   int spin_index = domains::electron_spin_domain::to_coordinate(e_spin);
 
-  int r_ind, b_i, b_j, r_i, r_j;   //, s_i, s_j;
-  scalar_type t_i, t_j, delta_tau; //, scaled_tau, f_tau;
+  int r_ind, b_i, b_j, r_i, r_j;    //, s_i, s_j;
+  scalar_type t_i, t_j, delta_tau;  //, scaled_tau, f_tau;
 
   int configuration_size = find_first_non_interacting_spin(configuration);
   for (int j = 0; j < configuration_size; j++) {
-    const vertex_singleton_type &configuration_e_spin_j = configuration[j];
+    const vertex_singleton_type& configuration_e_spin_j = configuration[j];
 
     b_j = configuration_e_spin_j.get_band();
     r_j = configuration_e_spin_j.get_r_site();
@@ -874,8 +791,7 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix(
 
       delta_tau = t_i - t_j;
 
-      G0_matrix(i, j) =
-          interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
+      G0_matrix(i, j) = interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
     }
   }
 }
@@ -883,16 +799,16 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix(
 template <class parameters_type, class MOMS_type>
 template <class configuration_type>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix_left(
-    e_spin_states e_spin, const configuration_type &configuration,
-    dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix) {
+    e_spin_states e_spin, const configuration_type& configuration,
+    dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix) {
   int spin_index = domains::electron_spin_domain::to_coordinate(e_spin);
 
-  int r_ind, b_i, b_j, r_i, r_j;   //, s_i, s_j;
-  scalar_type t_i, t_j, delta_tau; //, scaled_tau, f_tau;
+  int r_ind, b_i, b_j, r_i, r_j;    //, s_i, s_j;
+  scalar_type t_i, t_j, delta_tau;  //, scaled_tau, f_tau;
 
   int configuration_size = find_first_non_interacting_spin(configuration);
   for (int j = 0; j < configuration_size; j++) {
-    const vertex_singleton_type &configuration_e_spin_j = configuration[j];
+    const vertex_singleton_type& configuration_e_spin_j = configuration[j];
 
     b_j = configuration_e_spin_j.get_band();
     r_j = configuration_e_spin_j.get_r_site();
@@ -907,22 +823,20 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix_left(
 
       delta_tau = t_i - t_j;
 
-      G0_matrix(i, j) =
-          interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
+      G0_matrix(i, j) = interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
     }
   }
 }
 
 template <class parameters_type, class MOMS_type>
 template <class configuration_type>
-void TpEqualTimeAccumulator<parameters_type, MOMS_type>::
-    compute_G0_matrix_right(
-        e_spin_states e_spin, const configuration_type &configuration,
-        dca::linalg::Matrix<float, dca::linalg::CPU> &G0_matrix) {
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::compute_G0_matrix_right(
+    e_spin_states e_spin, const configuration_type& configuration,
+    dca::linalg::Matrix<float, dca::linalg::CPU>& G0_matrix) {
   int spin_index = domains::electron_spin_domain::to_coordinate(e_spin);
 
-  int r_ind, b_i, b_j, r_i, r_j;   //, s_i, s_j;
-  scalar_type t_i, t_j, delta_tau; //, scaled_tau, f_tau;
+  int r_ind, b_i, b_j, r_i, r_j;    //, s_i, s_j;
+  scalar_type t_i, t_j, delta_tau;  //, scaled_tau, f_tau;
 
   int configuration_size = find_first_non_interacting_spin(configuration);
 
@@ -932,7 +846,7 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::
     t_j = fixed_configuration[j].t_val;
 
     for (int i = 0; i < configuration_size; i++) {
-      const vertex_singleton_type &configuration_e_spin_i = configuration[i];
+      const vertex_singleton_type& configuration_e_spin_i = configuration[i];
 
       b_i = configuration_e_spin_i.get_band();
       r_i = configuration_e_spin_i.get_r_site();
@@ -942,15 +856,13 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::
 
       delta_tau = t_i - t_j;
 
-      G0_matrix(i, j) =
-          interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
+      G0_matrix(i, j) = interpolate_akima(b_i, spin_index, b_j, spin_index, r_ind, delta_tau);
     }
   }
 }
 
 template <class parameters_type, class MOMS_type>
-inline double
-TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate_akima(
+inline double TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate_akima(
     int b_i, int s_i, int b_j, int s_j, int delta_r, double tau) {
   const static double beta = parameters.get_beta();
   const static double N_div_beta = parameters.get_sp_time_intervals() / beta;
@@ -967,22 +879,34 @@ TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate_akima(
   double delta_tau = scaled_tau - t_ind;
   assert(delta_tau > -1.e-16 && delta_tau <= 1 + 1.e-16);
 
-  int linind =
-      4 * nu_nu_r_dmn_t_t_shifted_dmn(b_i, s_i, b_j, s_j, delta_r, t_ind);
+  int linind = 4 * nu_nu_r_dmn_t_t_shifted_dmn(b_i, s_i, b_j, s_j, delta_r, t_ind);
 
-  double *a_ptr = &akima_coefficients(linind);
+  double* a_ptr = &akima_coefficients(linind);
 
-  double result =
-      (a_ptr[0] +
-       delta_tau * (a_ptr[1] + delta_tau * (a_ptr[2] + delta_tau * a_ptr[3])));
+  double result = (a_ptr[0] + delta_tau * (a_ptr[1] + delta_tau * (a_ptr[2] + delta_tau * a_ptr[3])));
 
   return result;
 }
 
 template <class parameters_type, class MOMS_type>
+template <class configuration_type, typename RealInp>
+void TpEqualTimeAccumulator<parameters_type, MOMS_type>::accumulateAll(
+    const configuration_type& configuration_e_up,
+    const dca::linalg::Matrix<RealInp, dca::linalg::CPU>& M_up,
+    const configuration_type& configuration_e_dn,
+    const dca::linalg::Matrix<RealInp, dca::linalg::CPU>& M_dn, int sign) {
+  compute_G_r_t(configuration_e_up, M_up, configuration_e_dn, M_dn);
+
+  accumulate_G_r_t(sign);
+
+  accumulate_moments(sign);
+
+  accumulate_dwave_pp_correlator(sign);
+}
+
+template <class parameters_type, class MOMS_type>
 void TpEqualTimeAccumulator<parameters_type, MOMS_type>::sumTo(
-    dca::phys::solver::ctaux::TpEqualTimeAccumulator<parameters_type, MOMS_type>
-        &other) const {
+    dca::phys::solver::ctaux::TpEqualTimeAccumulator<parameters_type, MOMS_type>& other) const {
   other.G_r_t_accumulated += G_r_t_accumulated;
   other.G_r_t_accumulated_squared += G_r_t_accumulated_squared;
   other.charge_cluster_moment += charge_cluster_moment;
@@ -991,9 +915,9 @@ void TpEqualTimeAccumulator<parameters_type, MOMS_type>::sumTo(
   other.GFLOP += GFLOP;
 }
 
-} // ctaux
-} // solver
-} // phys
-} // dca
+}  // ctaux
+}  // solver
+}  // phys
+}  // dca
 
-#endif // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_ACCUMULATOR_TP_TP_EQUAL_TIME_ACCUMULATOR_HPP
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_ACCUMULATOR_TP_TP_EQUAL_TIME_ACCUMULATOR_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_accumulator.hpp
@@ -491,9 +491,9 @@ void CtauxAccumulator<device_t, Parameters, Data>::sumTo(this_type& other) {
     two_particle_accumulator_.sumTo(other.two_particle_accumulator_);
 }
 
-}  // ctaux
-}  // solver
-}  // phys
-}  // dca
+}  // namespace ctaux
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_CTAUX_ACCUMULATOR_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_accumulator.hpp
@@ -3,7 +3,8 @@
 // All rights reserved.
 //
 // See LICENSE for terms of usage.
-// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific
+// publications.
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
 //         Raffaele Solca' (rasolca@itp.phys.ethz.ch)
@@ -23,14 +24,14 @@
 #include "dca/function/function.hpp"
 #include "dca/linalg/matrix.hpp"
 #include "dca/linalg/util/cuda_event.hpp"
-#include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator.hpp"
-#include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/sp/sp_accumulator.hpp"
 #include "dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp"
 #include "dca/phys/dca_step/cluster_solver/ctaux/domains/feynman_expansion_order_domain.hpp"
 #include "dca/phys/dca_step/cluster_solver/ctaux/structs/ct_aux_hs_configuration.hpp"
 #include "dca/phys/dca_step/cluster_solver/ctaux/structs/vertex_pair.hpp"
 #include "dca/phys/dca_step/cluster_solver/ctaux/structs/vertex_singleton.hpp"
 #include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/mc_accumulator_data.hpp"
+#include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/sp/sp_accumulator.hpp"
+#include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator.hpp"
 #include "dca/phys/domains/cluster/cluster_domain.hpp"
 #include "dca/phys/domains/quantum/electron_band_domain.hpp"
 #include "dca/phys/domains/quantum/electron_spin_domain.hpp"
@@ -42,7 +43,7 @@
 #ifdef DCA_HAVE_CUDA
 #include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/sp/sp_accumulator_gpu.hpp"
 #include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu.hpp"
-#endif  // DCA_HAVE_CUDA
+#endif // DCA_HAVE_CUDA
 
 namespace dca {
 namespace phys {
@@ -63,11 +64,12 @@ public:
 
   using t = func::dmn_0<domains::time_domain>;
   using w = func::dmn_0<domains::frequency_domain>;
-  using w_VERTEX = func::dmn_0<domains::vertex_frequency_domain<domains::COMPACT>>;
+  using w_VERTEX =
+      func::dmn_0<domains::vertex_frequency_domain<domains::COMPACT>>;
 
   using b = func::dmn_0<domains::electron_band_domain>;
   using s = func::dmn_0<domains::electron_spin_domain>;
-  using nu = func::dmn_variadic<b, s>;  // orbital-spin index
+  using nu = func::dmn_variadic<b, s>; // orbital-spin index
 
   using CDA = ClusterDomainAliases<Parameters::lattice_type::DIMENSION>;
   using RClusterDmn = typename CDA::RClusterDmn;
@@ -81,73 +83,77 @@ public:
 
   typedef CT_AUX_HS_configuration<Parameters> configuration_type;
 
-  CtauxAccumulator(Parameters& parameters_ref, Data& data_ref, int id);
+  CtauxAccumulator(Parameters &parameters_ref, Data &data_ref, int id);
 
-  template <typename Writer>
-  void write(Writer& writer);
+  template <typename Writer> void write(Writer &writer);
 
   void initialize(int dca_iteration);
 
-  template <typename walker_type>
-  void updateFrom(walker_type& walker);
+  template <typename walker_type> void updateFrom(walker_type &walker);
 
   void measure();
 
-  // Sums all accumulated objects of this accumulator to the equivalent objects of the 'other'
+  // Sums all accumulated objects of this accumulator to the equivalent objects
+  // of the 'other'
   // accumulator.
-  void sumTo(this_type& other);
+  void sumTo(this_type &other);
 
   void finalize();
 
-  std::vector<vertex_singleton_type>& get_configuration(e_spin_states_type e_spin = e_UP);
+  std::vector<vertex_singleton_type> &
+  get_configuration(e_spin_states_type e_spin = e_UP);
 
-  func::function<double, func::dmn_0<domains::numerical_error_domain>>& get_error_distribution() {
+  func::function<double, func::dmn_0<domains::numerical_error_domain>> &
+  get_error_distribution() {
     return error;
   }
 
-  func::function<double, func::dmn_0<Feynman_expansion_order_domain>>& get_visited_expansion_order_k() {
+  func::function<double, func::dmn_0<Feynman_expansion_order_domain>> &
+  get_visited_expansion_order_k() {
     return visited_expansion_order_k;
   }
 
   // equal time-measurements
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& get_G_r_t() {
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &get_G_r_t() {
     return G_r_t;
   }
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& get_G_r_t_stddev() {
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &
+  get_G_r_t_stddev() {
     return G_r_t_stddev;
   }
 
-  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_charge_cluster_moment() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
+  get_charge_cluster_moment() {
     return charge_cluster_moment;
   }
-  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_magnetic_cluster_moment() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
+  get_magnetic_cluster_moment() {
     return magnetic_cluster_moment;
   }
-  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_dwave_pp_correlator() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
+  get_dwave_pp_correlator() {
     return dwave_pp_correlator;
   }
 
   // sp-measurements
-  const auto& get_sign_times_M_r_w() const {
+  const auto &get_sign_times_M_r_w() const {
     return single_particle_accumulator_obj.get_sign_times_M_r_w();
   }
 
-  const auto& get_sign_times_M_r_w_sqr() const {
+  const auto &get_sign_times_M_r_w_sqr() const {
     return single_particle_accumulator_obj.get_sign_times_M_r_w_sqr();
   }
 
   // tp-measurements
-  const auto& get_sign_times_G4() {
+  const auto &get_sign_times_G4() {
     return two_particle_accumulator_.get_sign_times_G4();
   }
 
-  bool compute_std_deviation() const {
-    return compute_std_deviation_;
-  }
+  bool compute_std_deviation() const { return compute_std_deviation_; }
 
 #ifdef MEASURE_ERROR_BARS
-  void store_standard_deviation(int nr_measurements, std::ofstream& points_file,
-                                std::ofstream& norm_file);
+  void store_standard_deviation(int nr_measurements, std::ofstream &points_file,
+                                std::ofstream &norm_file);
   void update_sum_squares();
 #endif
 
@@ -158,7 +164,8 @@ public:
   }
 
   static std::size_t staticDeviceFingerprint() {
-    return accumulator::TpAccumulator<Parameters, device_t>::staticDeviceFingerprint();
+    return accumulator::TpAccumulator<Parameters,
+                                      device_t>::staticDeviceFingerprint();
   }
 
 private:
@@ -166,15 +173,17 @@ private:
 
   void accumulate_equal_time_quantities();
   using AccumType = typename Parameters::MC_measurement_scalar_type;
-  void accumulate_equal_time_quantities(const std::array<linalg::Matrix<AccumType, linalg::GPU>, 2>& M);
-  void accumulate_equal_time_quantities(const std::array<linalg::Matrix<AccumType, linalg::CPU>, 2>& M);
+  void accumulate_equal_time_quantities(
+      const std::array<linalg::Matrix<AccumType, linalg::GPU>, 2> &M);
+  void accumulate_equal_time_quantities(
+      const std::array<linalg::Matrix<AccumType, linalg::CPU>, 2> &M);
 
   void accumulate_two_particle_quantities();
 
 protected:
-  Parameters& parameters_;
-  Data& data_;
-  concurrency_type& concurrency;
+  Parameters &parameters_;
+  Data &data_;
+  concurrency_type &concurrency;
 
   int thread_id;
 
@@ -194,20 +203,25 @@ protected:
   std::array<dca::linalg::Matrix<AccumType, linalg::CPU>, 2> M_host_;
 
   func::function<double, func::dmn_0<domains::numerical_error_domain>> error;
-  func::function<double, func::dmn_0<Feynman_expansion_order_domain>> visited_expansion_order_k;
+  func::function<double, func::dmn_0<Feynman_expansion_order_domain>>
+      visited_expansion_order_k;
 
   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> G_r_t;
   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> G_r_t_stddev;
 
   func::function<double, func::dmn_variadic<b, r_dmn_t>> charge_cluster_moment;
-  func::function<double, func::dmn_variadic<b, r_dmn_t>> magnetic_cluster_moment;
+  func::function<double, func::dmn_variadic<b, r_dmn_t>>
+      magnetic_cluster_moment;
   func::function<double, func::dmn_variadic<b, r_dmn_t>> dwave_pp_correlator;
 
-  func::function<std::complex<double>, func::dmn_variadic<nu, nu, r_dmn_t, w>> M_r_w_stddev;
+  func::function<std::complex<double>, func::dmn_variadic<nu, nu, r_dmn_t, w>>
+      M_r_w_stddev;
 
-  accumulator::SpAccumulator<Parameters, device_t> single_particle_accumulator_obj;
+  accumulator::SpAccumulator<Parameters, device_t>
+      single_particle_accumulator_obj;
 
-  ctaux::TpEqualTimeAccumulator<Parameters, Data> MC_two_particle_equal_time_accumulator_obj;
+  ctaux::TpEqualTimeAccumulator<Parameters, Data>
+      MC_two_particle_equal_time_accumulator_obj;
 
   accumulator::TpAccumulator<Parameters, device_t> two_particle_accumulator_;
 
@@ -215,12 +229,11 @@ protected:
 };
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-CtauxAccumulator<device_t, Parameters, Data>::CtauxAccumulator(Parameters& parameters_ref,
-                                                               Data& data_ref, int id)
+CtauxAccumulator<device_t, Parameters, Data>::CtauxAccumulator(
+    Parameters &parameters_ref, Data &data_ref, int id)
     : MC_accumulator_data(),
 
-      parameters_(parameters_ref),
-      data_(data_ref),
+      parameters_(parameters_ref), data_(data_ref),
       concurrency(parameters_.get_concurrency()),
 
       thread_id(id),
@@ -231,8 +244,7 @@ CtauxAccumulator<device_t, Parameters, Data>::CtauxAccumulator(Parameters& param
       error("numerical-error-distribution-of-N-matrices"),
       visited_expansion_order_k("<k>"),
 
-      G_r_t("G_r_t_measured"),
-      G_r_t_stddev("G_r_t_stddev"),
+      G_r_t("G_r_t_measured"), G_r_t_stddev("G_r_t_stddev"),
 
       charge_cluster_moment("charge-cluster-moment"),
       magnetic_cluster_moment("magnetic-cluster-moment"),
@@ -247,11 +259,14 @@ CtauxAccumulator<device_t, Parameters, Data>::CtauxAccumulator(Parameters& param
       two_particle_accumulator_(data_.G0_k_w_cluster_excluded, parameters_) {}
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::initialize(int dca_iteration) {
-  // Note: profiling this function breaks the PAPI profiler as both the master thread and the first
+void CtauxAccumulator<device_t, Parameters, Data>::initialize(
+    int dca_iteration) {
+  // Note: profiling this function breaks the PAPI profiler as both the master
+  // thread and the first
   // worker call this with the same thread_id.
   // TODO: fix thread id assignment.
-  //  profiler_type profiler(__FUNCTION__, "CT-AUX accumulator", __LINE__, thread_id);
+  //  profiler_type profiler(__FUNCTION__, "CT-AUX accumulator", __LINE__,
+  //  thread_id);
 
   MC_accumulator_data::initialize(dca_iteration);
 
@@ -287,10 +302,12 @@ void CtauxAccumulator<device_t, Parameters, Data>::finalize() {
   single_particle_accumulator_obj.finalize();
 
   if (compute_std_deviation_) {
-    const auto& M_r_w = single_particle_accumulator_obj.get_sign_times_M_r_w();
-    const auto& M_r_w_squared = single_particle_accumulator_obj.get_sign_times_M_r_w_sqr();
+    const auto &M_r_w = single_particle_accumulator_obj.get_sign_times_M_r_w();
+    const auto &M_r_w_squared =
+        single_particle_accumulator_obj.get_sign_times_M_r_w_sqr();
     for (int l = 0; l < M_r_w_stddev.size(); l++)
-      M_r_w_stddev(l) = std::sqrt(abs(M_r_w_squared(l)) - std::pow(abs(M_r_w(l)), 2));
+      M_r_w_stddev(l) =
+          std::sqrt(abs(M_r_w_squared(l)) - std::pow(abs(M_r_w(l)), 2));
 
     double factor = 1. / std::sqrt(parameters_.get_measurements() - 1);
 
@@ -298,15 +315,18 @@ void CtauxAccumulator<device_t, Parameters, Data>::finalize() {
   }
 
   if (parameters_.additional_time_measurements()) {
-    MC_two_particle_equal_time_accumulator_obj.finalize();  // G_r_t, G_r_t_stddev);
+    MC_two_particle_equal_time_accumulator_obj.finalize();
 
     G_r_t = MC_two_particle_equal_time_accumulator_obj.get_G_r_t();
-    G_r_t_stddev = MC_two_particle_equal_time_accumulator_obj.get_G_r_t_stddev();
+    G_r_t_stddev =
+        MC_two_particle_equal_time_accumulator_obj.get_G_r_t_stddev();
 
-    charge_cluster_moment = MC_two_particle_equal_time_accumulator_obj.get_charge_cluster_moment();
-    magnetic_cluster_moment =
-        MC_two_particle_equal_time_accumulator_obj.get_magnetic_cluster_moment();
-    dwave_pp_correlator = MC_two_particle_equal_time_accumulator_obj.get_dwave_pp_correlator();
+    charge_cluster_moment =
+        MC_two_particle_equal_time_accumulator_obj.get_charge_cluster_moment();
+    magnetic_cluster_moment = MC_two_particle_equal_time_accumulator_obj
+                                  .get_magnetic_cluster_moment();
+    dwave_pp_correlator =
+        MC_two_particle_equal_time_accumulator_obj.get_dwave_pp_correlator();
   }
 
   if (perform_tp_accumulation_)
@@ -314,7 +334,8 @@ void CtauxAccumulator<device_t, Parameters, Data>::finalize() {
 }
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-std::vector<vertex_singleton>& CtauxAccumulator<device_t, Parameters, Data>::get_configuration(
+std::vector<vertex_singleton> &
+CtauxAccumulator<device_t, Parameters, Data>::get_configuration(
     e_spin_states_type e_spin) {
   if (e_spin == e_UP)
     return hs_configuration_[0];
@@ -324,12 +345,12 @@ std::vector<vertex_singleton>& CtauxAccumulator<device_t, Parameters, Data>::get
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
 template <typename Writer>
-void CtauxAccumulator<device_t, Parameters, Data>::write(Writer& writer) {
+void CtauxAccumulator<device_t, Parameters, Data>::write(Writer &writer) {
 //       writer.open_group("CT-AUX-SOLVER-functions");
 
 #ifdef DCA_WITH_QMC_BIT
   writer.execute(error);
-#endif  // DCA_WITH_QMC_BIT
+#endif // DCA_WITH_QMC_BIT
 
   writer.execute(visited_expansion_order_k);
 
@@ -349,7 +370,8 @@ void CtauxAccumulator<device_t, Parameters, Data>::write(Writer& writer) {
 }
 
 /*!
- *  \brief Get all the information from the walker in order to start a measurement.
+ *  \brief Get all the information from the walker in order to start a
+ * measurement.
  *
  *   \f{eqnarray}{
  *    M_{i,j} &=& (e^{V_i}-1) N_{i,j}
@@ -357,19 +379,21 @@ void CtauxAccumulator<device_t, Parameters, Data>::write(Writer& writer) {
  */
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
 template <typename walker_type>
-void CtauxAccumulator<device_t, Parameters, Data>::updateFrom(walker_type& walker) {
-  profiler_type profiler("update from", "CT-AUX accumulator", __LINE__, thread_id);
+void CtauxAccumulator<device_t, Parameters, Data>::updateFrom(
+    walker_type &walker) {
+  profiler_type profiler("update from", "CT-AUX accumulator", __LINE__,
+                         thread_id);
 
   GFLOP += walker.get_Gflop();
 
   current_sign = walker.get_sign();
 
-  const linalg::util::CudaEvent* event = walker.compute_M(M_);
+  const linalg::util::CudaEvent *event = walker.compute_M(M_);
 
   single_particle_accumulator_obj.synchronizeCopy();
   two_particle_accumulator_.synchronizeCopy();
 
-  configuration_type& full_configuration = walker.get_configuration();
+  configuration_type &full_configuration = walker.get_configuration();
   hs_configuration_[0] = full_configuration.get(e_UP);
   hs_configuration_[1] = full_configuration.get(e_DN);
 
@@ -380,7 +404,7 @@ void CtauxAccumulator<device_t, Parameters, Data>::updateFrom(walker_type& walke
 #ifdef DCA_WITH_QMC_BIT
   error += walker.get_error_distribution();
   walker.get_error_distribution() = 0;
-#endif  // DCA_WITH_QMC_BIT
+#endif // DCA_WITH_QMC_BIT
 
   single_particle_accumulator_obj.syncStreams(*event);
   two_particle_accumulator_.syncStreams(*event);
@@ -406,21 +430,26 @@ void CtauxAccumulator<device_t, Parameters, Data>::measure() {
 /*!
  *  \brief Output and store standard deviation and error.
  *
- *  It computes and write to the given files the standard deviation of the measurements of the one
+ *  It computes and write to the given files the standard deviation of the
+ * measurements of the one
  * particle accumulator.
- *  It outputs the L1-Norm, i.e. \f$\sum_{i=1}^N \left|x_i\right|/N\f$, the L2-Norm, i.e.
+ *  It outputs the L1-Norm, i.e. \f$\sum_{i=1}^N \left|x_i\right|/N\f$, the
+ * L2-Norm, i.e.
  * \f$\sqrt{\sum_{i=1}^N \left|x_i\right|^2/N}\f$,
- *  and the Linf-Norm, i.e. \f$\max_{i=1}^N \left|x_i\right|\f$ of the standard deviation and of the
+ *  and the Linf-Norm, i.e. \f$\max_{i=1}^N \left|x_i\right|\f$ of the standard
+ * deviation and of the
  * error.
  */
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
 void CtauxAccumulator<device_t, Parameters, Data>::store_standard_deviation(
-    int nr_measurements, std::ofstream& points_file, std::ofstream& norm_file) {
-  single_particle_accumulator_obj.store_standard_deviation(nr_measurements, points_file, norm_file);
+    int nr_measurements, std::ofstream &points_file, std::ofstream &norm_file) {
+  single_particle_accumulator_obj.store_standard_deviation(
+      nr_measurements, points_file, norm_file);
 }
 
 /*!
- *  \brief Update the sum of the squares of the measurements of the single particle accumulator.
+ *  \brief Update the sum of the squares of the measurements of the single
+ * particle accumulator.
  *         It has to be called after each measurement.
  */
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
@@ -436,10 +465,13 @@ void CtauxAccumulator<device_t, Parameters, Data>::update_sum_squares() {
  *************************************************************/
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::accumulate_single_particle_quantities() {
-  profiler_type profiler("sp-accumulation", "CT-AUX accumulator", __LINE__, thread_id);
+void CtauxAccumulator<device_t, Parameters,
+                      Data>::accumulate_single_particle_quantities() {
+  profiler_type profiler("sp-accumulation", "CT-AUX accumulator", __LINE__,
+                         thread_id);
 
-  single_particle_accumulator_obj.accumulate(M_, hs_configuration_, current_sign);
+  single_particle_accumulator_obj.accumulate(M_, hs_configuration_,
+                                             current_sign);
 
   GFLOP += 2. * 8. * M_[1].size().first * M_[1].size().first * (1.e-9);
   GFLOP += 2. * 8. * M_[0].size().first * M_[0].size().first * (1.e-9);
@@ -452,15 +484,18 @@ void CtauxAccumulator<device_t, Parameters, Data>::accumulate_single_particle_qu
  *************************************************************/
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::accumulate_equal_time_quantities() {
-  profiler_type profiler("equal-time-measurements", "CT-AUX accumulator", __LINE__, thread_id);
+void CtauxAccumulator<device_t, Parameters,
+                      Data>::accumulate_equal_time_quantities() {
+  profiler_type profiler("equal-time-measurements", "CT-AUX accumulator",
+                         __LINE__, thread_id);
 
   return accumulate_equal_time_quantities(M_);
 }
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::accumulate_equal_time_quantities(
-    const std::array<linalg::Matrix<AccumType, linalg::GPU>, 2>& M) {
+void CtauxAccumulator<device_t, Parameters, Data>::
+    accumulate_equal_time_quantities(
+        const std::array<linalg::Matrix<AccumType, linalg::GPU>, 2> &M) {
   for (int s = 0; s < 2; ++s)
     M_host_[s].setAsync(M[s], thread_id, s);
   for (int s = 0; s < 2; ++s)
@@ -470,16 +505,18 @@ void CtauxAccumulator<device_t, Parameters, Data>::accumulate_equal_time_quantit
 }
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::accumulate_equal_time_quantities(
-    const std::array<linalg::Matrix<AccumType, linalg::CPU>, 2>& M) {
-  MC_two_particle_equal_time_accumulator_obj.compute_G_r_t(hs_configuration_[0], M[0],
-                                                           hs_configuration_[1], M[1]);
+void CtauxAccumulator<device_t, Parameters, Data>::
+    accumulate_equal_time_quantities(
+        const std::array<linalg::Matrix<AccumType, linalg::CPU>, 2> &M) {
+  MC_two_particle_equal_time_accumulator_obj.compute_G_r_t(
+      hs_configuration_[0], M[0], hs_configuration_[1], M[1]);
 
   MC_two_particle_equal_time_accumulator_obj.accumulate_G_r_t(current_sign);
 
   MC_two_particle_equal_time_accumulator_obj.accumulate_moments(current_sign);
 
-  MC_two_particle_equal_time_accumulator_obj.accumulate_dwave_pp_correlator(current_sign);
+  MC_two_particle_equal_time_accumulator_obj.accumulate_dwave_pp_correlator(
+      current_sign);
 
   GFLOP += MC_two_particle_equal_time_accumulator_obj.get_GFLOP();
 }
@@ -491,13 +528,16 @@ void CtauxAccumulator<device_t, Parameters, Data>::accumulate_equal_time_quantit
  *************************************************************/
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::accumulate_two_particle_quantities() {
-  profiler_type profiler("tp-accumulation", "CT-AUX accumulator", __LINE__, thread_id);
-  /*GFLOP +=*/two_particle_accumulator_.accumulate(M_, hs_configuration_, current_sign);
+void CtauxAccumulator<device_t, Parameters,
+                      Data>::accumulate_two_particle_quantities() {
+  profiler_type profiler("tp-accumulation", "CT-AUX accumulator", __LINE__,
+                         thread_id);
+  /*GFLOP +=*/two_particle_accumulator_.accumulate(M_, hs_configuration_,
+                                                   current_sign);
 }
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::sumTo(this_type& other) {
+void CtauxAccumulator<device_t, Parameters, Data>::sumTo(this_type &other) {
   other.get_Gflop() += get_Gflop();
 
   other.accumulated_sign += accumulated_sign;
@@ -506,24 +546,23 @@ void CtauxAccumulator<device_t, Parameters, Data>::sumTo(this_type& other) {
   other.get_visited_expansion_order_k() += visited_expansion_order_k;
   other.get_error_distribution() += error;
 
-  // equal time measurements
-  other.get_G_r_t() += G_r_t;
-  other.get_G_r_t_stddev() += G_r_t_stddev;
-  other.get_charge_cluster_moment() += charge_cluster_moment;
-  other.get_magnetic_cluster_moment() += magnetic_cluster_moment;
-  other.get_dwave_pp_correlator() += dwave_pp_correlator;
-
   // sp-measurements
   single_particle_accumulator_obj.sumTo(other.single_particle_accumulator_obj);
+
+  // equal time measurements
+  if (DCA_iteration == parameters_.get_dca_iterations() - 1 &&
+      parameters_.additional_time_measurements())
+    MC_two_particle_equal_time_accumulator_obj.sumTo(
+        other.MC_two_particle_equal_time_accumulator_obj);
 
   // tp-measurements
   if (perform_tp_accumulation_)
     two_particle_accumulator_.sumTo(other.two_particle_accumulator_);
 }
 
-}  // ctaux
-}  // solver
-}  // phys
-}  // dca
+} // ctaux
+} // solver
+} // phys
+} // dca
 
-#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_CTAUX_ACCUMULATOR_HPP
+#endif // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_CTAUX_ACCUMULATOR_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_accumulator.hpp
@@ -3,11 +3,11 @@
 // All rights reserved.
 //
 // See LICENSE for terms of usage.
-// See CITATION.md for citation guidelines, if DCA++ is used for scientific
-// publications.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
 //         Raffaele Solca' (rasolca@itp.phys.ethz.ch)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This class organizes the measurements in the CT-AUX QMC.
 
@@ -43,7 +43,7 @@
 #ifdef DCA_HAVE_CUDA
 #include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/sp/sp_accumulator_gpu.hpp"
 #include "dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu.hpp"
-#endif // DCA_HAVE_CUDA
+#endif  // DCA_HAVE_CUDA
 
 namespace dca {
 namespace phys {
@@ -64,12 +64,11 @@ public:
 
   using t = func::dmn_0<domains::time_domain>;
   using w = func::dmn_0<domains::frequency_domain>;
-  using w_VERTEX =
-      func::dmn_0<domains::vertex_frequency_domain<domains::COMPACT>>;
+  using w_VERTEX = func::dmn_0<domains::vertex_frequency_domain<domains::COMPACT>>;
 
   using b = func::dmn_0<domains::electron_band_domain>;
   using s = func::dmn_0<domains::electron_spin_domain>;
-  using nu = func::dmn_variadic<b, s>; // orbital-spin index
+  using nu = func::dmn_variadic<b, s>;  // orbital-spin index
 
   using CDA = ClusterDomainAliases<Parameters::lattice_type::DIMENSION>;
   using RClusterDmn = typename CDA::RClusterDmn;
@@ -83,77 +82,73 @@ public:
 
   typedef CT_AUX_HS_configuration<Parameters> configuration_type;
 
-  CtauxAccumulator(Parameters &parameters_ref, Data &data_ref, int id);
+  CtauxAccumulator(Parameters& parameters_ref, Data& data_ref, int id);
 
-  template <typename Writer> void write(Writer &writer);
+  template <typename Writer>
+  void write(Writer& writer);
 
   void initialize(int dca_iteration);
 
-  template <typename walker_type> void updateFrom(walker_type &walker);
+  template <typename walker_type>
+  void updateFrom(walker_type& walker);
 
   void measure();
 
   // Sums all accumulated objects of this accumulator to the equivalent objects
-  // of the 'other'
-  // accumulator.
-  void sumTo(this_type &other);
+  // of the 'other' accumulator.
+  void sumTo(this_type& other);
 
   void finalize();
 
-  std::vector<vertex_singleton_type> &
-  get_configuration(e_spin_states_type e_spin = e_UP);
+  std::vector<vertex_singleton_type>& get_configuration(e_spin_states_type e_spin = e_UP);
 
-  func::function<double, func::dmn_0<domains::numerical_error_domain>> &
-  get_error_distribution() {
+  func::function<double, func::dmn_0<domains::numerical_error_domain>>& get_error_distribution() {
     return error;
   }
 
-  func::function<double, func::dmn_0<Feynman_expansion_order_domain>> &
-  get_visited_expansion_order_k() {
+  func::function<double, func::dmn_0<Feynman_expansion_order_domain>>& get_visited_expansion_order_k() {
     return visited_expansion_order_k;
   }
 
   // equal time-measurements
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &get_G_r_t() {
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& get_G_r_t() {
     return G_r_t;
   }
-  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> &
-  get_G_r_t_stddev() {
+  func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>>& get_G_r_t_stddev() {
     return G_r_t_stddev;
   }
 
-  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
-  get_charge_cluster_moment() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_charge_cluster_moment() {
     return charge_cluster_moment;
   }
-  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
-  get_magnetic_cluster_moment() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_magnetic_cluster_moment() {
     return magnetic_cluster_moment;
   }
-  func::function<double, func::dmn_variadic<b, r_dmn_t>> &
-  get_dwave_pp_correlator() {
+  func::function<double, func::dmn_variadic<b, r_dmn_t>>& get_dwave_pp_correlator() {
     return dwave_pp_correlator;
   }
 
   // sp-measurements
-  const auto &get_sign_times_M_r_w() const {
+  const auto& get_sign_times_M_r_w() const {
     return single_particle_accumulator_obj.get_sign_times_M_r_w();
   }
 
-  const auto &get_sign_times_M_r_w_sqr() const {
+  const auto& get_sign_times_M_r_w_sqr() const {
     return single_particle_accumulator_obj.get_sign_times_M_r_w_sqr();
   }
 
   // tp-measurements
-  const auto &get_sign_times_G4() {
+  const auto& get_sign_times_G4() {
     return two_particle_accumulator_.get_sign_times_G4();
   }
 
-  bool compute_std_deviation() const { return compute_std_deviation_; }
+  bool compute_std_deviation() const {
+    return compute_std_deviation_;
+  }
 
 #ifdef MEASURE_ERROR_BARS
-  void store_standard_deviation(int nr_measurements, std::ofstream &points_file,
-                                std::ofstream &norm_file);
+  void store_standard_deviation(int nr_measurements, std::ofstream& points_file,
+                                std::ofstream& norm_file);
   void update_sum_squares();
 #endif
 
@@ -164,8 +159,7 @@ public:
   }
 
   static std::size_t staticDeviceFingerprint() {
-    return accumulator::TpAccumulator<Parameters,
-                                      device_t>::staticDeviceFingerprint();
+    return accumulator::TpAccumulator<Parameters, device_t>::staticDeviceFingerprint();
   }
 
 private:
@@ -173,17 +167,15 @@ private:
 
   void accumulate_equal_time_quantities();
   using AccumType = typename Parameters::MC_measurement_scalar_type;
-  void accumulate_equal_time_quantities(
-      const std::array<linalg::Matrix<AccumType, linalg::GPU>, 2> &M);
-  void accumulate_equal_time_quantities(
-      const std::array<linalg::Matrix<AccumType, linalg::CPU>, 2> &M);
+  void accumulate_equal_time_quantities(const std::array<linalg::Matrix<AccumType, linalg::GPU>, 2>& M);
+  void accumulate_equal_time_quantities(const std::array<linalg::Matrix<AccumType, linalg::CPU>, 2>& M);
 
   void accumulate_two_particle_quantities();
 
 protected:
-  Parameters &parameters_;
-  Data &data_;
-  concurrency_type &concurrency;
+  Parameters& parameters_;
+  Data& data_;
+  concurrency_type& concurrency;
 
   int thread_id;
 
@@ -203,25 +195,20 @@ protected:
   std::array<dca::linalg::Matrix<AccumType, linalg::CPU>, 2> M_host_;
 
   func::function<double, func::dmn_0<domains::numerical_error_domain>> error;
-  func::function<double, func::dmn_0<Feynman_expansion_order_domain>>
-      visited_expansion_order_k;
+  func::function<double, func::dmn_0<Feynman_expansion_order_domain>> visited_expansion_order_k;
 
   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> G_r_t;
   func::function<double, func::dmn_variadic<nu, nu, r_dmn_t, t>> G_r_t_stddev;
 
   func::function<double, func::dmn_variadic<b, r_dmn_t>> charge_cluster_moment;
-  func::function<double, func::dmn_variadic<b, r_dmn_t>>
-      magnetic_cluster_moment;
+  func::function<double, func::dmn_variadic<b, r_dmn_t>> magnetic_cluster_moment;
   func::function<double, func::dmn_variadic<b, r_dmn_t>> dwave_pp_correlator;
 
-  func::function<std::complex<double>, func::dmn_variadic<nu, nu, r_dmn_t, w>>
-      M_r_w_stddev;
+  func::function<std::complex<double>, func::dmn_variadic<nu, nu, r_dmn_t, w>> M_r_w_stddev;
 
-  accumulator::SpAccumulator<Parameters, device_t>
-      single_particle_accumulator_obj;
+  accumulator::SpAccumulator<Parameters, device_t> single_particle_accumulator_obj;
 
-  ctaux::TpEqualTimeAccumulator<Parameters, Data>
-      MC_two_particle_equal_time_accumulator_obj;
+  ctaux::TpEqualTimeAccumulator<Parameters, Data> MC_two_particle_equal_time_accumulator_obj;
 
   accumulator::TpAccumulator<Parameters, device_t> two_particle_accumulator_;
 
@@ -229,11 +216,12 @@ protected:
 };
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-CtauxAccumulator<device_t, Parameters, Data>::CtauxAccumulator(
-    Parameters &parameters_ref, Data &data_ref, int id)
+CtauxAccumulator<device_t, Parameters, Data>::CtauxAccumulator(Parameters& parameters_ref,
+                                                               Data& data_ref, int id)
     : MC_accumulator_data(),
 
-      parameters_(parameters_ref), data_(data_ref),
+      parameters_(parameters_ref),
+      data_(data_ref),
       concurrency(parameters_.get_concurrency()),
 
       thread_id(id),
@@ -244,7 +232,8 @@ CtauxAccumulator<device_t, Parameters, Data>::CtauxAccumulator(
       error("numerical-error-distribution-of-N-matrices"),
       visited_expansion_order_k("<k>"),
 
-      G_r_t("G_r_t_measured"), G_r_t_stddev("G_r_t_stddev"),
+      G_r_t("G_r_t_measured"),
+      G_r_t_stddev("G_r_t_stddev"),
 
       charge_cluster_moment("charge-cluster-moment"),
       magnetic_cluster_moment("magnetic-cluster-moment"),
@@ -259,8 +248,7 @@ CtauxAccumulator<device_t, Parameters, Data>::CtauxAccumulator(
       two_particle_accumulator_(data_.G0_k_w_cluster_excluded, parameters_) {}
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::initialize(
-    int dca_iteration) {
+void CtauxAccumulator<device_t, Parameters, Data>::initialize(int dca_iteration) {
   // Note: profiling this function breaks the PAPI profiler as both the master
   // thread and the first
   // worker call this with the same thread_id.
@@ -290,7 +278,7 @@ void CtauxAccumulator<device_t, Parameters, Data>::initialize(
     magnetic_cluster_moment = 0;
     dwave_pp_correlator = 0;
 
-    MC_two_particle_equal_time_accumulator_obj.initialize();
+    MC_two_particle_equal_time_accumulator_obj.resetAccumulation();
   }
 }
 
@@ -302,12 +290,10 @@ void CtauxAccumulator<device_t, Parameters, Data>::finalize() {
   single_particle_accumulator_obj.finalize();
 
   if (compute_std_deviation_) {
-    const auto &M_r_w = single_particle_accumulator_obj.get_sign_times_M_r_w();
-    const auto &M_r_w_squared =
-        single_particle_accumulator_obj.get_sign_times_M_r_w_sqr();
+    const auto& M_r_w = single_particle_accumulator_obj.get_sign_times_M_r_w();
+    const auto& M_r_w_squared = single_particle_accumulator_obj.get_sign_times_M_r_w_sqr();
     for (int l = 0; l < M_r_w_stddev.size(); l++)
-      M_r_w_stddev(l) =
-          std::sqrt(abs(M_r_w_squared(l)) - std::pow(abs(M_r_w(l)), 2));
+      M_r_w_stddev(l) = std::sqrt(abs(M_r_w_squared(l)) - std::pow(abs(M_r_w(l)), 2));
 
     double factor = 1. / std::sqrt(parameters_.get_measurements() - 1);
 
@@ -318,15 +304,12 @@ void CtauxAccumulator<device_t, Parameters, Data>::finalize() {
     MC_two_particle_equal_time_accumulator_obj.finalize();
 
     G_r_t = MC_two_particle_equal_time_accumulator_obj.get_G_r_t();
-    G_r_t_stddev =
-        MC_two_particle_equal_time_accumulator_obj.get_G_r_t_stddev();
+    G_r_t_stddev = MC_two_particle_equal_time_accumulator_obj.get_G_r_t_stddev();
 
-    charge_cluster_moment =
-        MC_two_particle_equal_time_accumulator_obj.get_charge_cluster_moment();
-    magnetic_cluster_moment = MC_two_particle_equal_time_accumulator_obj
-                                  .get_magnetic_cluster_moment();
-    dwave_pp_correlator =
-        MC_two_particle_equal_time_accumulator_obj.get_dwave_pp_correlator();
+    charge_cluster_moment = MC_two_particle_equal_time_accumulator_obj.get_charge_cluster_moment();
+    magnetic_cluster_moment =
+        MC_two_particle_equal_time_accumulator_obj.get_magnetic_cluster_moment();
+    dwave_pp_correlator = MC_two_particle_equal_time_accumulator_obj.get_dwave_pp_correlator();
   }
 
   if (perform_tp_accumulation_)
@@ -334,8 +317,7 @@ void CtauxAccumulator<device_t, Parameters, Data>::finalize() {
 }
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-std::vector<vertex_singleton> &
-CtauxAccumulator<device_t, Parameters, Data>::get_configuration(
+std::vector<vertex_singleton>& CtauxAccumulator<device_t, Parameters, Data>::get_configuration(
     e_spin_states_type e_spin) {
   if (e_spin == e_UP)
     return hs_configuration_[0];
@@ -345,12 +327,12 @@ CtauxAccumulator<device_t, Parameters, Data>::get_configuration(
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
 template <typename Writer>
-void CtauxAccumulator<device_t, Parameters, Data>::write(Writer &writer) {
-//       writer.open_group("CT-AUX-SOLVER-functions");
+void CtauxAccumulator<device_t, Parameters, Data>::write(Writer& writer) {
+  //       writer.open_group("CT-AUX-SOLVER-functions");
 
 #ifdef DCA_WITH_QMC_BIT
   writer.execute(error);
-#endif // DCA_WITH_QMC_BIT
+#endif  // DCA_WITH_QMC_BIT
 
   writer.execute(visited_expansion_order_k);
 
@@ -379,21 +361,19 @@ void CtauxAccumulator<device_t, Parameters, Data>::write(Writer &writer) {
  */
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
 template <typename walker_type>
-void CtauxAccumulator<device_t, Parameters, Data>::updateFrom(
-    walker_type &walker) {
-  profiler_type profiler("update from", "CT-AUX accumulator", __LINE__,
-                         thread_id);
+void CtauxAccumulator<device_t, Parameters, Data>::updateFrom(walker_type& walker) {
+  profiler_type profiler("update from", "CT-AUX accumulator", __LINE__, thread_id);
 
   GFLOP += walker.get_Gflop();
 
   current_sign = walker.get_sign();
 
-  const linalg::util::CudaEvent *event = walker.compute_M(M_);
+  const linalg::util::CudaEvent* event = walker.compute_M(M_);
 
   single_particle_accumulator_obj.synchronizeCopy();
   two_particle_accumulator_.synchronizeCopy();
 
-  configuration_type &full_configuration = walker.get_configuration();
+  configuration_type& full_configuration = walker.get_configuration();
   hs_configuration_[0] = full_configuration.get(e_UP);
   hs_configuration_[1] = full_configuration.get(e_DN);
 
@@ -404,7 +384,7 @@ void CtauxAccumulator<device_t, Parameters, Data>::updateFrom(
 #ifdef DCA_WITH_QMC_BIT
   error += walker.get_error_distribution();
   walker.get_error_distribution() = 0;
-#endif // DCA_WITH_QMC_BIT
+#endif  // DCA_WITH_QMC_BIT
 
   single_particle_accumulator_obj.syncStreams(*event);
   two_particle_accumulator_.syncStreams(*event);
@@ -442,9 +422,8 @@ void CtauxAccumulator<device_t, Parameters, Data>::measure() {
  */
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
 void CtauxAccumulator<device_t, Parameters, Data>::store_standard_deviation(
-    int nr_measurements, std::ofstream &points_file, std::ofstream &norm_file) {
-  single_particle_accumulator_obj.store_standard_deviation(
-      nr_measurements, points_file, norm_file);
+    int nr_measurements, std::ofstream& points_file, std::ofstream& norm_file) {
+  single_particle_accumulator_obj.store_standard_deviation(nr_measurements, points_file, norm_file);
 }
 
 /*!
@@ -465,13 +444,10 @@ void CtauxAccumulator<device_t, Parameters, Data>::update_sum_squares() {
  *************************************************************/
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters,
-                      Data>::accumulate_single_particle_quantities() {
-  profiler_type profiler("sp-accumulation", "CT-AUX accumulator", __LINE__,
-                         thread_id);
+void CtauxAccumulator<device_t, Parameters, Data>::accumulate_single_particle_quantities() {
+  profiler_type profiler("sp-accumulation", "CT-AUX accumulator", __LINE__, thread_id);
 
-  single_particle_accumulator_obj.accumulate(M_, hs_configuration_,
-                                             current_sign);
+  single_particle_accumulator_obj.accumulate(M_, hs_configuration_, current_sign);
 
   GFLOP += 2. * 8. * M_[1].size().first * M_[1].size().first * (1.e-9);
   GFLOP += 2. * 8. * M_[0].size().first * M_[0].size().first * (1.e-9);
@@ -484,18 +460,15 @@ void CtauxAccumulator<device_t, Parameters,
  *************************************************************/
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters,
-                      Data>::accumulate_equal_time_quantities() {
-  profiler_type profiler("equal-time-measurements", "CT-AUX accumulator",
-                         __LINE__, thread_id);
+void CtauxAccumulator<device_t, Parameters, Data>::accumulate_equal_time_quantities() {
+  profiler_type profiler("equal-time-measurements", "CT-AUX accumulator", __LINE__, thread_id);
 
   return accumulate_equal_time_quantities(M_);
 }
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::
-    accumulate_equal_time_quantities(
-        const std::array<linalg::Matrix<AccumType, linalg::GPU>, 2> &M) {
+void CtauxAccumulator<device_t, Parameters, Data>::accumulate_equal_time_quantities(
+    const std::array<linalg::Matrix<AccumType, linalg::GPU>, 2>& M) {
   for (int s = 0; s < 2; ++s)
     M_host_[s].setAsync(M[s], thread_id, s);
   for (int s = 0; s < 2; ++s)
@@ -505,18 +478,10 @@ void CtauxAccumulator<device_t, Parameters, Data>::
 }
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::
-    accumulate_equal_time_quantities(
-        const std::array<linalg::Matrix<AccumType, linalg::CPU>, 2> &M) {
-  MC_two_particle_equal_time_accumulator_obj.compute_G_r_t(
-      hs_configuration_[0], M[0], hs_configuration_[1], M[1]);
-
-  MC_two_particle_equal_time_accumulator_obj.accumulate_G_r_t(current_sign);
-
-  MC_two_particle_equal_time_accumulator_obj.accumulate_moments(current_sign);
-
-  MC_two_particle_equal_time_accumulator_obj.accumulate_dwave_pp_correlator(
-      current_sign);
+void CtauxAccumulator<device_t, Parameters, Data>::accumulate_equal_time_quantities(
+    const std::array<linalg::Matrix<AccumType, linalg::CPU>, 2>& M) {
+  MC_two_particle_equal_time_accumulator_obj.accumulateAll(
+      hs_configuration_[0], M[0], hs_configuration_[1], M[1], current_sign);
 
   GFLOP += MC_two_particle_equal_time_accumulator_obj.get_GFLOP();
 }
@@ -528,16 +493,13 @@ void CtauxAccumulator<device_t, Parameters, Data>::
  *************************************************************/
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters,
-                      Data>::accumulate_two_particle_quantities() {
-  profiler_type profiler("tp-accumulation", "CT-AUX accumulator", __LINE__,
-                         thread_id);
-  /*GFLOP +=*/two_particle_accumulator_.accumulate(M_, hs_configuration_,
-                                                   current_sign);
+void CtauxAccumulator<device_t, Parameters, Data>::accumulate_two_particle_quantities() {
+  profiler_type profiler("tp-accumulation", "CT-AUX accumulator", __LINE__, thread_id);
+  /*GFLOP +=*/two_particle_accumulator_.accumulate(M_, hs_configuration_, current_sign);
 }
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
-void CtauxAccumulator<device_t, Parameters, Data>::sumTo(this_type &other) {
+void CtauxAccumulator<device_t, Parameters, Data>::sumTo(this_type& other) {
   other.get_Gflop() += get_Gflop();
 
   other.accumulated_sign += accumulated_sign;
@@ -552,8 +514,7 @@ void CtauxAccumulator<device_t, Parameters, Data>::sumTo(this_type &other) {
   // equal time measurements
   if (DCA_iteration == parameters_.get_dca_iterations() - 1 &&
       parameters_.additional_time_measurements())
-    MC_two_particle_equal_time_accumulator_obj.sumTo(
-        other.MC_two_particle_equal_time_accumulator_obj);
+    MC_two_particle_equal_time_accumulator_obj.sumTo(other.MC_two_particle_equal_time_accumulator_obj);
 
   // tp-measurements
   if (perform_tp_accumulation_)
@@ -565,4 +526,4 @@ void CtauxAccumulator<device_t, Parameters, Data>::sumTo(this_type &other) {
 } // phys
 } // dca
 
-#endif // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_CTAUX_ACCUMULATOR_HPP
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_CTAUX_ACCUMULATOR_HPP

--- a/test/unit/phys/dca_step/cluster_solver/CMakeLists.txt
+++ b/test/unit/phys/dca_step/cluster_solver/CMakeLists.txt
@@ -1,5 +1,5 @@
 # test/unit/phys/dca_step/cluster_solver
 
-add_subdirectory(ctaux/structs)
+add_subdirectory(ctaux)
 add_subdirectory(shared_tools)
 add_subdirectory(thread_qmci)

--- a/test/unit/phys/dca_step/cluster_solver/ctaux/CMakeLists.txt
+++ b/test/unit/phys/dca_step/cluster_solver/ctaux/CMakeLists.txt
@@ -1,0 +1,4 @@
+# test/unit/phys/dca_step/cluster_solver/ctaux
+
+add_subdirectory(accumulator/tp)
+add_subdirectory(structs)

--- a/test/unit/phys/dca_step/cluster_solver/ctaux/accumulator/tp/CMakeLists.txt
+++ b/test/unit/phys/dca_step/cluster_solver/ctaux/accumulator/tp/CMakeLists.txt
@@ -1,0 +1,6 @@
+dca_add_gtest(tp_equal_time_accumulator_test
+  FAST
+  GTEST_MAIN
+  INCLUDE_DIRS ${DCA_INCLUDE_DIRS};${PROJECT_SOURCE_DIR}
+  LIBS     ${DCA_LIBS}
+  )

--- a/test/unit/phys/dca_step/cluster_solver/ctaux/accumulator/tp/input.json
+++ b/test/unit/phys/dca_step/cluster_solver/ctaux/accumulator/tp/input.json
@@ -1,0 +1,37 @@
+{
+  "physics" :
+  {
+    "beta"                      :  2,
+    "chemical-potential"        : 0
+  },
+
+  "bilayer-Hubbard-model":
+  {
+    "t"       : 1,
+    "U"       : 2
+  },
+
+  "DCA": {
+    "interacting-orbitals": [0, 1]
+  },
+
+  "domains": {
+    "real-space-grids": {
+      "cluster": [[4, 0],
+        [0, 4]]
+    },
+
+    "imaginary-time": {
+      "sp-time-intervals": 128,
+      "time-intervals-for-time-measurements" : 8
+    },
+
+    "imaginary-frequency": {
+      "sp-fermionic-frequencies": 128
+    }
+  },
+
+  "CT-AUX" : {
+    "additional-time-measurements" : true
+  }
+}

--- a/test/unit/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator_test.cpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific
+// publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file tests the summation of equal time two particle results.
+
+#include "dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp"
+
+#include "gtest/gtest.h"
+
+#include "dca/function/util/difference.hpp"
+#include "test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/accumulation_test.hpp"
+#include "test/unit/phys/dca_step/cluster_solver/test_setup.hpp"
+
+constexpr char input_file[] =
+    DCA_SOURCE_DIR "/test/unit/phys/dca_step/cluster_solver/ctaux/accumulator/tp/input.json";
+
+using TpEqualTimeAccumulatorTest =
+    dca::testing::G0Setup<dca::testing::LatticeBilayer, dca::phys::solver::CT_AUX, input_file>;
+
+using Configuration = std::array<std::vector<dca::phys::solver::ctaux::vertex_singleton>, 2>;
+using Sample = std::array<dca::linalg::Matrix<double, dca::linalg::CPU>, 2>;
+
+void buildConfiguration(Configuration& config, Sample& sample, int b_size, int r_size, double beta,
+                        std::array<int, 2> n);
+
+TEST_F(TpEqualTimeAccumulatorTest, AccumulateAndSum) {
+  const std::array<int, 2> n{7, 5};
+  Sample M1, M2;
+  Configuration config1, config2;
+
+  buildConfiguration(config1, M1, TpEqualTimeAccumulatorTest::BDmn::dmn_size(),
+                     TpEqualTimeAccumulatorTest::RDmn::dmn_size(), parameters_.get_beta(), n);
+  buildConfiguration(config2, M2, TpEqualTimeAccumulatorTest::BDmn::dmn_size(),
+                     TpEqualTimeAccumulatorTest::RDmn::dmn_size(), parameters_.get_beta(), n);
+
+  using Accumulator =
+      dca::phys::solver::ctaux::TpEqualTimeAccumulator<G0Setup::Parameters, G0Setup::Data>;
+
+  Accumulator accumulator_sum(parameters_, *data_, 0);
+  Accumulator accumulator1(parameters_, *data_, 1);
+  Accumulator accumulator2(parameters_, *data_, 2);
+  Accumulator accumulator3(parameters_, *data_, 3);
+  const int sign = -1;
+
+  accumulator1.accumulateAll(config1[0], M1[0], config1[1], M1[1], sign);
+  accumulator2.accumulateAll(config2[0], M2[0], config2[1], M2[1], sign);
+  accumulator1.sumTo(accumulator_sum);
+  accumulator2.sumTo(accumulator_sum);
+  accumulator_sum.finalize();
+
+  accumulator3.accumulateAll(config1[0], M1[0], config1[1], M1[1], sign);
+  accumulator3.accumulateAll(config2[0], M2[0], config2[1], M2[1], sign);
+  accumulator3.finalize();
+
+  auto expect_near = [](const auto& f1, const auto f2) {
+    auto diff = dca::func::util::difference(f1, f2);
+    EXPECT_GE(5e-7, diff.l_inf);
+
+    auto zero(f1);
+    zero = 0;
+    auto norm = dca::func::util::difference(f1, zero);
+    EXPECT_GE(norm.l_inf, 0);
+  };
+
+  expect_near(accumulator_sum.get_G_r_t(), accumulator3.get_G_r_t());
+  expect_near(accumulator_sum.get_charge_cluster_moment(), accumulator3.get_charge_cluster_moment());
+  expect_near(accumulator_sum.get_magnetic_cluster_moment(),
+              accumulator3.get_magnetic_cluster_moment());
+  expect_near(accumulator_sum.get_dwave_pp_correlator(), accumulator3.get_dwave_pp_correlator());
+}
+
+void buildConfiguration(Configuration& config, Sample& sample, int b_size, int r_size, double beta,
+                        std::array<int, 2> n) {
+  static dca::math::random::StdRandomWrapper<std::ranlux48_base> rng(0, 1, 0);
+  using namespace dca::phys;
+  using namespace dca::phys::solver::ctaux;
+
+  for (int s = 0; s < 2; ++s) {
+    sample[s].resizeNoCopy(n[s]);
+
+    const int band = rng() * b_size;
+    const int r = rng() * r_size;
+    const int dr = rng() * r_size;
+    const double tau = rng() * beta;
+    const auto field = rng() > 0.5 ? 1 : -1;
+
+    for (int j = 0; j < n[s]; ++j) {
+      auto vertex = dca::phys::solver::ctaux::vertex_singleton(
+          band, s == 0 ? e_UP : e_DN, /*spin_orbitals.first*/ 0,
+          /*spin_orbitals.second,=*/0, r, dr, tau, field ? HS_UP : HS_DN,
+          field ? HS_FIELD_UP : HS_FIELD_DN, j);
+
+      config[s].push_back(vertex);
+      for (int i = 0; i < n[s]; ++i)
+        sample[s](i, j) = 2 * rng() - 1;
+    }
+  }
+}


### PR DESCRIPTION
- Fixes #107.
- Moves book-keeping from CT-AUX accumulator to the equal time accumulator.
- Removes a copy of the results.
- Performs a test that checks if accumulate and sumTo are consistent (for the equal time accumulator)
  and if they update all functions.