### PR TITLE
Correct anitoperiodic interpolation for G0, vertex_pair.delta_r no longer  dropped

### DIFF
--- a/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/accumulator/tp/tp_equal_time_accumulator.hpp
@@ -867,13 +867,16 @@ inline double TpEqualTimeAccumulator<parameters_type, MOMS_type>::interpolate_ak
   const static double N_div_beta = parameters.get_sp_time_intervals() / beta;
 
   int sign = 1;
+  // Map tau to [0, beta).
   if (tau < 0) {
     tau += beta;
     sign = -1;
   }
+  assert(0 <= tau && tau < beta);
 
   const double scaled_tau = tau * N_div_beta;
-  const int t_ind = scaled_tau;
+  // Find interpolation index of on the left of tau.
+  const int t_ind = static_cast<int>(scaled_tau);
 
 #ifndef NDEBUG
   const double* positive_times =

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/structs/read_write_config.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/structs/read_write_config.hpp
@@ -24,16 +24,20 @@ namespace ctaux {
 
 template <class Parameters>
 io::Buffer& operator<<(io::Buffer& buff, const vertex_pair<Parameters>& v) {
-  return buff << v.bands << v.e_spins << v.spin_orbitals << v.r_sites << v.HS_spin << v.tau;
+  return buff << v.bands << v.e_spins << v.spin_orbitals << v.r_sites << v.delta_r << v.HS_spin
+              << v.tau;
 }
 
 template <class Parameters>
 io::Buffer& operator>>(io::Buffer& buff, vertex_pair<Parameters>& v) {
   v.creatable = false;
   v.annihilatable = true;
+  v.successfully_flipped = false;
+  v.Bennett = false;
   v.shuffled = true;
 
-  return buff >> v.bands >> v.e_spins >> v.spin_orbitals >> v.r_sites >> v.HS_spin >> v.tau;
+  return buff >> v.bands >> v.e_spins >> v.spin_orbitals >> v.r_sites >> v.delta_r >> v.HS_spin >>
+         v.tau;
 }
 
 template <class Parameters>
@@ -74,9 +78,9 @@ io::Buffer& operator>>(io::Buffer& buff, CT_AUX_HS_configuration<Parameters>& co
   return buff;
 }
 
-}  // ctaux
-}  // solver
-}  // phys
-}  // dca
+}  // namespace ctaux
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTAUX_STRUCTS_READ_WRITE_CONFIG_HPP

--- a/test/unit/phys/dca_step/cluster_solver/ctaux/structs/input.json
+++ b/test/unit/phys/dca_step/cluster_solver/ctaux/structs/input.json
@@ -17,8 +17,8 @@
 
     "domains": {
         "real-space-grids": {
-            "cluster": [[2, 0],
-                [0, 2]]
+            "cluster": [[2, 2],
+                [-4, 2]]
         }
     },
 


### PR DESCRIPTION
Solves the problem reported by @maierta by fixing the read of the CT-AUX configuration.
In addition, the initialization of the equal time accumulator is fixed, as it was triggering an assertion while running the input file relative to #127.