### PR TITLE
Configuration storage between iterations is optional. Default: off.

### DIFF
--- a/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_cluster_solver.hpp
@@ -281,7 +281,10 @@ void StdThreadQmciClusterSolver<QmciSolver>::startWalker(int id) {
     walker.printSummary();
   }
 
-  config_dump_[walker_index] = walker.dumpConfig();
+  if (parameters_.store_configuration() || (parameters_.get_directory_config_write() != "" &&
+                                            dca_iteration_ == parameters_.get_dca_iterations() - 1))
+    config_dump_[walker_index] = walker.dumpConfig();
+
   walker_fingerprints_[walker_index] = walker.deviceFingerprint();
 
   Profiler::stop_threading(id);
@@ -296,8 +299,10 @@ void StdThreadQmciClusterSolver<QmciSolver>::initializeAndWarmUp(Walker& walker,
   Profiler profiler("thermalization", "stdthread-MC-walker", __LINE__, id);
 
   // Read previous configuration.
-  if (config_dump_[walker_id].size())
+  if (config_dump_[walker_id].size()) {
     walker.readConfig(config_dump_[walker_id]);
+    config_dump_[walker_id].setg(0); // Ready to read again if it is not overwritten.
+  }
 
   walker.initialize();
 
@@ -439,7 +444,11 @@ void StdThreadQmciClusterSolver<QmciSolver>::startWalkerAndAccumulator(int id) {
     std::lock_guard<std::mutex> lock(mutex_merge_);
     accumulator_obj.sumTo(QmciSolver::accumulator_);
   }
-  config_dump_[id] = walker.dumpConfig();
+
+  if (parameters_.store_configuration() || (parameters_.get_directory_config_write() != "" &&
+                                            dca_iteration_ == parameters_.get_dca_iterations() - 1))
+    config_dump_[id] = walker.dumpConfig();
+
   walker_fingerprints_[id] = walker.deviceFingerprint();
   accum_fingerprints_[id] = accumulator_obj.deviceFingerprint();
 

--- a/include/dca/phys/parameters/parameters.hpp
+++ b/include/dca/phys/parameters/parameters.hpp
@@ -427,8 +427,8 @@ std::string Parameters<Concurrency, Threading, Profiler, Model, RandomNumberGene
   return str;
 }
 
-}  // params
-}  // phys
-}  // dca
+}  // namespace params
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_PARAMETERS_PARAMETERS_HPP

--- a/test/system-level/dca/input.dca_sp_DCA+_mpi_test.json
+++ b/test/system-level/dca/input.dca_sp_DCA+_mpi_test.json
@@ -58,7 +58,8 @@
         "seed": 985456376,
         "warm-up-sweeps": 20,
         "sweeps-per-measurement": 1,
-        "measurements": 800
+        "measurements": 800,
+        "store-configuration" : true
     },
 
     "CT-AUX": {

--- a/test/system-level/dca/input.dca_sp_DCA+_thread_test.json
+++ b/test/system-level/dca/input.dca_sp_DCA+_thread_test.json
@@ -59,6 +59,7 @@
         "warm-up-sweeps": 20,
         "sweeps-per-measurement": 1,
         "measurements": 800,
+        "store-configuration" : true,
 
         "threaded-solver": {
             "walkers": 1,

--- a/test/unit/phys/parameters/mci_parameters/input_read_all.json
+++ b/test/unit/phys/parameters/mci_parameters/input_read_all.json
@@ -5,6 +5,7 @@
         "sweeps-per-measurement": 4.,
         "measurements": 200,
         "error-computation-type" : "JACK_KNIFE",
+        "store-configuration" : true,
 
         "threaded-solver": {
             "walkers": 3,

--- a/test/unit/phys/parameters/mci_parameters/mci_parameters_test.cpp
+++ b/test/unit/phys/parameters/mci_parameters/mci_parameters_test.cpp
@@ -35,6 +35,7 @@ TEST(MciParametersTest, DefaultValues) {
   EXPECT_EQ(1, pars.get_accumulators());
   EXPECT_EQ(false, pars.shared_walk_and_accumulation_thread());
   EXPECT_FALSE(pars.adjust_self_energy_for_double_counting());
+  EXPECT_FALSE(pars.store_configuration());
 }
 
 TEST(MciParametersTest, ReadAll) {
@@ -53,6 +54,7 @@ TEST(MciParametersTest, ReadAll) {
   EXPECT_EQ(3, pars.get_walkers());
   EXPECT_EQ(5, pars.get_accumulators());
   EXPECT_EQ(true, pars.shared_walk_and_accumulation_thread());
+  EXPECT_TRUE(pars.store_configuration());
 }
 
 TEST(MciParametersTest, ReadPositiveIntegerSeed) {

--- a/tools/complete_input.json
+++ b/tools/complete_input.json
@@ -105,6 +105,7 @@
         "sweeps-per-measurement": 1.,
         "measurements": 100,
         "error-computation-type" : "NONE",
+        "store-configuration" : false,
 
         "threaded-solver": {
             "walkers": 1,


### PR DESCRIPTION
Reading the configuration from the previous iteration is now optional.