### PR TITLE
Optimize summit mpi

### DIFF
--- a/include/dca/function/domains/local_domain.hpp
+++ b/include/dca/function/domains/local_domain.hpp
@@ -1,0 +1,99 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file implements a class to store a subset of a domain distributed among different MPI ranks.
+//
+// INTERNAL: This class can only be used with dmn_variadic when it's wrapped with dmn_0.
+
+#ifndef DCA_FUNCTION_DOMAINS_LOCAL_DOMAIN_HPP
+#define DCA_FUNCTION_DOMAINS_LOCAL_DOMAIN_HPP
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "dca/util/integer_division.hpp"
+
+namespace dca {
+namespace func {
+// dca::func::
+
+template <typename BaseDomain, int id = 0>
+class LocalDomain {
+public:
+  using element_type = typename BaseDomain::element_type;  // For putting LocalDomain in dmn_0.
+  using this_type = LocalDomain<BaseDomain>;
+
+  template <class Grouping>
+  static void initialize(const Grouping& group);
+
+  static std::size_t get_physical_size() {
+    return elements_.size();
+  }
+  static std::size_t get_offset() {
+    return offset_;
+  }
+
+  static std::size_t get_size() {
+    assert(initialized_);
+    return padded_size_;
+  }
+  static std::string get_name() {
+    return "Local_" + BaseDomain::get_name();
+  }
+  static const std::vector<element_type>& get_elements() {
+    assert(initialized_);
+    return elements_;
+  }
+  static bool is_initialized() {
+    return initialized_;
+  }
+
+private:
+  static bool initialized_;
+  static std::vector<element_type> elements_;
+  static std::size_t padded_size_;
+  static std::size_t offset_;
+};
+
+template <class BaseDomain, int id>
+bool LocalDomain<BaseDomain, id>::initialized_ = false;
+template <class BaseDomain, int id>
+std::vector<typename LocalDomain<BaseDomain, id>::element_type> LocalDomain<BaseDomain, id>::elements_;
+template <class BaseDomain, int id>
+std::size_t LocalDomain<BaseDomain, id>::padded_size_ = 0;
+template <class BaseDomain, int id>
+std::size_t LocalDomain<BaseDomain, id>::offset_ = 0;
+
+template <class BaseDomain, int id>
+template <class Grouping>
+void LocalDomain<BaseDomain, id>::initialize(const Grouping& group) {
+  if (initialized_) {
+    throw(std::logic_error("Domain " + get_name() + " is already initialized."));
+  }
+
+  const std::size_t global_size = BaseDomain::get_size();
+  padded_size_ = dca::util::ceilDiv(global_size, std::size_t(group.get_size()));
+
+  const std::size_t start = std::min(padded_size_ * group.get_id(), global_size);
+  const std::size_t end = std::min(start + padded_size_, global_size);
+
+  const auto physical_size = end - start;
+  offset_ = start;
+  elements_.resize(physical_size);
+  std::copy_n(BaseDomain::get_elements().data() + start, physical_size, elements_.data());
+
+  initialized_ = true;
+}
+
+}  // namespace func
+}  // namespace dca
+
+#endif  // DCA_FUNCTION_DOMAINS_LOCAL_DOMAIN_HPP

--- a/include/dca/io/buffer.hpp
+++ b/include/dca/io/buffer.hpp
@@ -24,6 +24,10 @@ class Buffer : public std::vector<unsigned char> {
 public:
   using Container = std::vector<unsigned char>;
 
+  Buffer() = default;
+
+  Buffer(std::size_t n) : Container(n) {}
+
   // Copies obj in the buffer as a plain sequence of bytes.
   template <class T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
   Buffer& operator<<(const T& obj);
@@ -46,6 +50,13 @@ public:
   template <class T1, class T2>
   Buffer& operator>>(std::pair<T1, T2>& p);
 
+  // Copies n objects of type T in the buffer as a plain sequence of bytes.
+  template <class T>
+  void write(const T* ptr, std::size_t n = 1);
+  // Read n objects o f type T from the buffer as a plain sequence of bytes.
+  template <class T>
+  void read(T* ptr, std::size_t n = 1);
+
   // Retrieves the position of the next read.
   std::size_t tellg() const {
     return read_idx_;
@@ -55,14 +66,12 @@ public:
     read_idx_ = idx;
   }
 
-private:
-  // Copies n objects of type T in the buffer as a plain sequence of bytes.
-  template <class T>
-  void write(const T* ptr, std::size_t n = 1);
-  // Read n objects o f type T from the buffer as a plain sequence of bytes.
-  template <class T>
-  void read(T* ptr, std::size_t n = 1);
+  void clear() {
+    Container::clear();
+    read_idx_ = 0;
+  }
 
+private:
   std::size_t read_idx_ = 0;
 };
 
@@ -152,7 +161,7 @@ Buffer& Buffer::operator>>(std::pair<T1, T2>& p) {
   return (*this) >> p.first >> p.second;
 }
 
-}  // io
-}  // dca
+}  // namespace io
+}  // namespace dca
 
 #endif  // DCA_IO_BUFFER_HPP

--- a/include/dca/linalg/matrix_view.hpp
+++ b/include/dca/linalg/matrix_view.hpp
@@ -29,6 +29,7 @@ template <typename ScalarType, DeviceType device_name = linalg::CPU>
 class MatrixView {
 public:
   using Pair = std::pair<int, int>;
+  MatrixView(ScalarType* data, Pair size);
   MatrixView(ScalarType* data, Pair size, int ld);
   MatrixView(ScalarType* data, int size, int ld);
   MatrixView(ScalarType* data, int size);
@@ -92,6 +93,10 @@ private:
   const int ldm_;
   const std::pair<int, int> size_;
 };
+
+template <typename ScalarType, DeviceType device_t>
+MatrixView<ScalarType, device_t>::MatrixView(ScalarType* const data, const Pair size)
+    : MatrixView(data, size, size.first) {}
 
 template <typename ScalarType, DeviceType device_t>
 MatrixView<ScalarType, device_t>::MatrixView(ScalarType* const data, const Pair size, const int ld)
@@ -189,7 +194,7 @@ auto inline makeConstantView(const Matrix<ScalarType, device_t>& mat, const int 
                                                 mat.leadingDimension());
 }
 
-}  // linalg
-}  // dca
+}  // namespace linalg
+}  // namespace dca
 
 #endif  // DCA_LINALG_MATRIX_VIEW_HPP

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
@@ -591,16 +591,15 @@ void MPICollectiveSum::delayedSum(T* in, std::size_t n) {
 
 // TODO: move to .cpp file.
 inline void MPICollectiveSum::resolveSums() {
-  switch (current_type_) {
-    case MPI_DOUBLE:
-      return resolveSumsImplementation<double>();
-    case MPI_FLOAT:
-      return resolveSumsImplementation<float>();
-    case MPI_UNSIGNED_LONG:
-      return resolveSumsImplementation<unsigned long int>();
-    default:
-      throw(std::logic_error("Type not supported."));
-  }
+  // Note: we can not use a switch statement as MPI_Datatype is not integer on the Summit system.
+  if (current_type_ == MPI_DOUBLE)
+    return resolveSumsImplementation<double>();
+  else if (current_type_ == MPI_FLOAT)
+    return resolveSumsImplementation<float>();
+  else if (current_type_ == MPI_UNSIGNED_LONG)
+    return resolveSumsImplementation<unsigned long int>();
+  else
+    throw(std::logic_error("Type not supported."));
 }
 
 template <typename T>

--- a/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
@@ -25,6 +25,8 @@
 #include "dca/parallel/mpi_concurrency/mpi_collective_min.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_collective_sum.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_initializer.hpp"
+#include "dca/parallel/mpi_concurrency/mpi_gang.hpp"
+#include "dca/parallel/mpi_concurrency/mpi_gather.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_packing.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp"
 #include "dca/parallel/util/get_bounds.hpp"
@@ -34,12 +36,15 @@ namespace parallel {
 // dca::parallel::
 
 class MPIConcurrency final : public virtual MPIInitializer,
-                             private virtual MPIProcessorGrouping,
+                             public virtual MPIProcessorGrouping,
                              public MPIPacking,
                              public MPICollectiveMax,
                              public MPICollectiveMin,
-                             public MPICollectiveSum {
+                             public MPICollectiveSum,
+                             public MPIGather {
 public:
+  using Gang = MPIGang;
+
   MPIConcurrency(int argc, char** argv);
 
   inline int id() const {
@@ -67,6 +72,12 @@ public:
   std::pair<int, int> get_bounds(const domain_type& dmn) const {
     return util::getBounds(id(), number_of_processors(), dmn);
   }
+
+  // Using gather with no gang uses the entire concurrency.
+//  template <class Scalar, class DmnIn, class DmnOut>
+//  void gather(const func::function<Scalar, DmnIn>& f_in, func::function<Scalar, DmnOut>& f_out) const {
+//    gather(f_in, f_out, *this);
+//  }
 
   friend std::ostream& operator<<(std::ostream& some_ostream, const MPIConcurrency& this_concurrency);
 
@@ -147,7 +158,7 @@ bool MPIConcurrency::broadcast_object(object_type& object, int root_id) const {
   return true;
 }
 
-}  // parallel
-}  // dca
+}  // namespace parallel
+}  // namespace dca
 
 #endif  // DCA_PARALLEL_MPI_CONCURRENCY_MPI_CONCURRENCY_HPP

--- a/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
@@ -73,12 +73,6 @@ public:
     return util::getBounds(id(), number_of_processors(), dmn);
   }
 
-  // Using gather with no gang uses the entire concurrency.
-//  template <class Scalar, class DmnIn, class DmnOut>
-//  void gather(const func::function<Scalar, DmnIn>& f_in, func::function<Scalar, DmnOut>& f_out) const {
-//    gather(f_in, f_out, *this);
-//  }
-
   friend std::ostream& operator<<(std::ostream& some_ostream, const MPIConcurrency& this_concurrency);
 
 private:

--- a/include/dca/parallel/mpi_concurrency/mpi_gang.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_gang.hpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This class represent a subgroup of MPIProcessorGrouping.
+
+#ifndef DCA_PARALLEL_MPI_CONCURRENCY_MPI_GANG_HPP
+#define DCA_PARALLEL_MPI_CONCURRENCY_MPI_GANG_HPP
+
+#include <mpi.h>
+
+#include "dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp"
+
+namespace dca {
+namespace parallel {
+// dca::parallel::
+
+class MPIGang {
+public:
+  MPIGang(const MPIProcessorGrouping& group, int min_size);
+  ~MPIGang();
+
+  MPIGang(const MPIGang& other) = delete;
+
+  int get_id() const {
+    return id_;
+  }
+  int get_size() const {
+    return size_;
+  }
+
+  auto get() const {
+    return communicator_;
+  }
+
+private:
+  MPI_Comm communicator_;
+  int id_;
+  int size_;
+};
+
+}  // namespace parallel
+}  // namespace dca
+
+#endif  // DCA_PARALLEL_MPI_CONCURRENCY_MPI_GANG_HPP

--- a/include/dca/parallel/mpi_concurrency/mpi_gather.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_gather.hpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This class provides an interface to gather functions with MPI.
+
+#ifndef DCA_PARALLEL_MPI_CONCURRENCY_MPI_GATHER_HPP
+#define DCA_PARALLEL_MPI_CONCURRENCY_MPI_GATHER_HPP
+
+#include <vector>
+
+#include <mpi.h>
+
+#include "dca/function/domains.hpp"
+#include "dca/function/function.hpp"
+#include "dca/parallel/mpi_concurrency/mpi_gang.hpp"
+#include "dca/parallel/mpi_concurrency/mpi_type_map.hpp"
+#include "dca/util/integer_division.hpp"
+
+namespace dca {
+namespace parallel {
+// dca::parallel::
+
+class MPIGather {
+public:
+  MPIGather() = default;
+
+  // Gather the function 'f_in' on all processes in 'gang' and copy the result into 'f_out',
+  // discarding eventual padding.
+  // Precondition: gang.get_size() * f_in.size() >= f_out.size()
+  template <class Scalar, class DmnIn, class DmnOut, class Gang>
+  void gather(const func::function<Scalar, DmnIn>& f_in, func::function<Scalar, DmnOut>& f_out,
+              const Gang& gang) const;
+
+private:
+  template <class T, class Gang>
+  void gather(const T* in, T* out, int local_n, const Gang& gang) const;
+};
+
+template <class Scalar, class DmnIn, class DmnOut, class Gang>
+void MPIGather::gather(const func::function<Scalar, DmnIn>& f_in,
+                       func::function<Scalar, DmnOut>& f_out, const Gang& gang) const {
+  std::vector<Scalar> gathered(f_in.size() * gang.get_size());
+  gather(f_in.values(), gathered.data(), f_in.size(), gang);
+
+  if (f_out.size() > gathered.size())
+    throw(std::logic_error("Output function is too large."));
+
+  // TODO: move.
+  std::copy_n(gathered.data(), f_out.size(), f_out.values());
+}
+
+template <class T, class Gang>
+void MPIGather::gather(const T* in, T* out, int local_n, const Gang& gang) const {
+  MPI_Allgather(in, local_n, MPITypeMap<T>::value(), out, local_n, MPITypeMap<T>::value(),
+                gang.get());
+}
+
+}  // namespace parallel
+}  // namespace dca
+
+#endif  // DCA_PARALLEL_MPI_CONCURRENCY_MPI_GATHER_HPP

--- a/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
@@ -54,7 +54,6 @@ struct MPITypeMap<std::uint8_t> {
   }
 };
 
-
 template <>
 struct MPITypeMap<int> {
   static MPI_Datatype value() {

--- a/include/dca/parallel/no_concurrency/no_concurrency.hpp
+++ b/include/dca/parallel/no_concurrency/no_concurrency.hpp
@@ -15,13 +15,17 @@
 
 #include <utility>
 #include "dca/parallel/no_concurrency/serial_collective_sum.hpp"
+#include "dca/parallel/no_concurrency/serial_gang.hpp"
+#include "dca/parallel/no_concurrency/serial_gather.hpp"
 
 namespace dca {
 namespace parallel {
 // dca::parallel::
 
-class NoConcurrency : public SerialCollectiveSum {
+class NoConcurrency : public SerialCollectiveSum, public SerialProcessorGrouping, public SerialGather {
 public:
+  using Gang = SerialGang;
+
   NoConcurrency(int /*argc*/, char** /*argv*/){};
 
   void abort() const;
@@ -63,7 +67,7 @@ private:
   constexpr static char parallel_type_str_[] = "NoConcurrency";
 };
 
-}  // parallel
-}  // dca
+}  // namespace parallel
+}  // namespace dca
 
 #endif  // DCA_PARALLEL_NO_CONCURRENCY_NO_CONCURRENCY_HPP

--- a/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
+++ b/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
@@ -36,6 +36,9 @@ public:
   template <class T1, class T2>
   void sum(const T1&, T2&) const {}
 
+  template<class T>
+  void localSum(const T& , int ){}
+
   template <class T>
   void delayedSum(T&) const {}
   void resolveSums() const {}

--- a/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
+++ b/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
@@ -31,23 +31,14 @@ namespace parallel {
 
 class SerialCollectiveSum {
 public:
-  template <typename Scalar>
-  void sum(Scalar&) const {}
-  template <typename Scalar>
-  void sum(std::vector<Scalar>&) const {}
-  template <typename Scalar>
-  void sum(std::map<std::string, std::vector<Scalar>>&) const {}
-  template <typename Scalar, class Domain>
-  void sum(func::function<Scalar, Domain>&) const {}
-  template <typename Scalar, class Domain>
-  void sum(func::function<Scalar, Domain>& /*f_in*/, func::function<Scalar, Domain>& /*f_out*/) const {
-  }
-  template <typename Scalar, class Domain>
-  void sum(func::function<std::vector<Scalar>, Domain>&) const {}
-  template <typename Scalar>
-  void sum(linalg::Vector<Scalar, linalg::CPU>&) const {}
-  template <typename Scalar>
-  void sum(dca::linalg::Matrix<Scalar, linalg::CPU>&) const {}
+  template <class T>
+  void sum(T&) const {}
+  template <class T1, class T2>
+  void sum(const T1&, T2&) const {}
+
+  template <class T>
+  void delayedSum(T&) const {}
+  void resolveSums() const {}
 
   template <typename T>
   void sum_and_average(T& obj, int measurements) const {
@@ -60,7 +51,7 @@ public:
   template <typename T>
   void leaveOneOutAvg(T&) const {}
   template <typename T>
-  void leaveOneOutSum(T&) const {}
+  void leaveOneOutSum(T&, bool = false) const {}
 
   template <typename Scalar, class Domain>
   func::function<Scalar, Domain> jackknifeError(func::function<Scalar, Domain>&,
@@ -80,7 +71,7 @@ public:
   }
 };
 
-}  // parallel
-}  // dca
+}  // namespace parallel
+}  // namespace dca
 
 #endif  // DCA_PARALLEL_NO_CONCURRENCY_SERIAL_COLLECTIVE_SUM_HPP

--- a/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
+++ b/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
@@ -52,9 +52,9 @@ public:
   void sum_and_average(T& /*obj*/) const {}
 
   template <typename T>
-  void leaveOneOutAvg(T&) const {}
+  void leaveOneOutAvg(T& /*obj*/) const {}
   template <typename T>
-  void leaveOneOutSum(T&, bool = false) const {}
+  void leaveOneOutSum(T& /*obj*/, bool /*delay*/ = false) const {}
 
   template <typename Scalar, class Domain>
   func::function<Scalar, Domain> jackknifeError(func::function<Scalar, Domain>&,

--- a/include/dca/parallel/no_concurrency/serial_gang.hpp
+++ b/include/dca/parallel/no_concurrency/serial_gang.hpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This class represent a subgroup of MPIProcessorGrouping.
+
+#ifndef DCA_PARALLEL_MPI_CONCURRENCY_SERIAL_GANG_HPP
+#define DCA_PARALLEL_MPI_CONCURRENCY_SERIAL_GANG_HPP
+
+#include "dca/parallel/no_concurrency/serial_processor_grouping.hpp"
+
+namespace dca {
+namespace parallel {
+// dca::parallel::
+
+class SerialGang {
+public:
+  SerialGang(const SerialProcessorGrouping& /*group*/, int /*target_size*/) {}
+  SerialGang(const SerialGang& other) = delete;
+
+  int get_id() const {
+    return 0;
+  }
+  int get_size() const {
+    return 1;
+  }
+
+  auto get() const {
+    return nullptr;
+  }
+};
+
+}  // namespace parallel
+}  // namespace dca
+
+#endif  // DCA_PARALLEL_MPI_CONCURRENCY_SERIAL_GANG_HPP

--- a/include/dca/parallel/no_concurrency/serial_gather.hpp
+++ b/include/dca/parallel/no_concurrency/serial_gather.hpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This class provides a no-op interface for gather functions without MPI.
+
+#ifndef DCA_PARALLEL_MPI_CONCURRENCY_SERIAL_GATHER_HPP
+#define DCA_PARALLEL_MPI_CONCURRENCY_SERIAL_GATHER_HPP
+
+#include <vector>
+
+#include <mpi.h>
+
+#include "dca/function/domains.hpp"
+#include "dca/function/function.hpp"
+#include "dca/parallel/mpi_concurrency/mpi_gang.hpp"
+#include "dca/parallel/mpi_concurrency/mpi_type_map.hpp"
+#include "dca/util/integer_division.hpp"
+
+namespace dca {
+namespace parallel {
+// dca::parallel::
+
+class SerialGather {
+public:
+  SerialGather() = default;
+
+  template <class Scalar, class DmnIn, class DmnOut, class Gang>
+  void gather(const func::function<Scalar, DmnIn>& f_in, func::function<Scalar, DmnOut>& f_out,
+              const Gang& /*gang*/) const {
+    // TODO: move.
+    if (f_in.size() != f_out.size())
+      throw(std::logic_error("Size mismatch."));
+    std::copy_n(f_in.values(), f_in.size(), f_out.values());
+  }
+};
+
+}  // namespace parallel
+}  // namespace dca
+
+#endif  // DCA_PARALLEL_MPI_CONCURRENCY_SERIAL_GATHER_HPP

--- a/include/dca/parallel/no_concurrency/serial_processor_grouping.hpp
+++ b/include/dca/parallel/no_concurrency/serial_processor_grouping.hpp
@@ -35,12 +35,16 @@ public:
     return nr_threads_ - 1;
   }
 
+  auto get() {
+    return nullptr;
+  }
+
 private:
   const int id_;
   const int nr_threads_;
 };
 
-}  // parallel
-}  // dca
+}  // namespace parallel
+}  // namespace dca
 
 #endif  // DCA_PARALLEL_NO_CONCURRENCY_SERIAL_PROCESSOR_GROUPING_HPP

--- a/include/dca/phys/dca_algorithms/compute_free_greens_function.hpp
+++ b/include/dca/phys/dca_algorithms/compute_free_greens_function.hpp
@@ -26,19 +26,18 @@ namespace phys {
 
 // Computes the free Matsubara Green's function G_0(\vec{k}, i\omega_n) from the non-interacting
 // Hamiltonian H_0(\vec{k}).
-template <typename Scalar, typename OrbitalSpinDmn, typename KDmn, typename MatsubaraFreqDmn,
-          typename ConcurrencyType>
+template <typename Scalar, typename OrbitalSpinDmn, typename KDmn, typename MatsubaraFreqDmn>
 void compute_G0_k_w(
     const func::function<std::complex<Scalar>,
                          func::dmn_variadic<OrbitalSpinDmn, OrbitalSpinDmn, KDmn>>& H0_k,
-    const Scalar mu, const ConcurrencyType& concurrency,
+    const Scalar mu, const int n_threads,
     func::function<std::complex<Scalar>,
                    func::dmn_variadic<OrbitalSpinDmn, OrbitalSpinDmn, KDmn, MatsubaraFreqDmn>>& G0_k_w) {
   // Call compute_G_k_w with vanishing self-energy.
   const func::function<std::complex<Scalar>,
                        func::dmn_variadic<OrbitalSpinDmn, OrbitalSpinDmn, KDmn, MatsubaraFreqDmn>>
       zero;
-  compute_G_k_w(H0_k, zero, mu, concurrency, G0_k_w);
+  compute_G_k_w(H0_k, zero, mu, n_threads, G0_k_w);
 }
 
 // Computes the free imaginary time Green's function G_0(\vec{k}, \tau) from the non-interacting

--- a/include/dca/phys/dca_data/dca_data.hpp
+++ b/include/dca/phys/dca_data/dca_data.hpp
@@ -547,7 +547,8 @@ void DcaData<Parameters>::initialize_G0() {
   util::Timer("G_0 initialization", concurrency_.id() == concurrency_.first());
 
   // Compute G0_k_w.
-  compute_G0_k_w(H_DCA, parameters_.get_chemical_potential(), concurrency_, G0_k_w);
+  compute_G0_k_w(H_DCA, parameters_.get_chemical_potential(),
+                 parameters_.get_coarsegraining_threads(), G0_k_w);
   symmetrize::execute(G0_k_w, H_symmetry, true);
 
   // Compute G0_k_t.

--- a/include/dca/phys/dca_loop/dca_loop.hpp
+++ b/include/dca/phys/dca_loop/dca_loop.hpp
@@ -253,8 +253,8 @@ void DcaLoop<ParametersType, DcaDataType, MCIntegratorType>::perform_cluster_map
 
   // Finite-size QMC
   if (parameters.do_finite_size_qmc())
-    compute_G_k_w(MOMS.H_DCA, MOMS.Sigma, parameters.get_chemical_potential(), concurrency,
-                  MOMS.G_k_w);
+    compute_G_k_w(MOMS.H_DCA, MOMS.Sigma, parameters.get_chemical_potential(),
+                  parameters.get_coarsegraining_threads(), MOMS.G_k_w);
   // DCA+
   else if (parameters.do_dca_plus())
     cluster_mapping_obj.compute_G_K_w(MOMS.Sigma_lattice, MOMS.G_k_w);

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_routines.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_routines.hpp
@@ -275,8 +275,7 @@ void coarsegraining_routines<parameters_type, K_dmn>::wannier_interpolation(
   if (!interpolation_matrices_type::is_initialized())
     interpolation_matrices_type::initialize(concurrency);
 
-  const dca::linalg::Matrix<scalar_type, dca::linalg::CPU>& T =
-      interpolation_matrices_type::get(K_ind);
+  const auto T = interpolation_matrices_type::get(K_ind);
 
   scalar_type alpha(1.);
   scalar_type beta(0.);

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_routines.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_routines.hpp
@@ -272,9 +272,6 @@ void coarsegraining_routines<parameters_type, K_dmn>::wannier_interpolation(
     func::function<std::complex<scalar_type>, func::dmn_variadic<nu, nu, q_dmn_t>>& f_q) const {
   typedef interpolation_matrices<scalar_type, k_dmn_t, q_dmn_t> interpolation_matrices_type;
 
-  if (!interpolation_matrices_type::is_initialized())
-    interpolation_matrices_type::initialize(concurrency);
-
   const auto T = interpolation_matrices_type::get(K_ind);
 
   scalar_type alpha(1.);

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_sp.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_sp.hpp
@@ -304,40 +304,36 @@ void CoarsegrainingSp<Parameters>::updateSigmaInterpolated(const LatticeFreqFunc
 template <typename Parameters>
 template <typename RDmn>
 void CoarsegrainingSp<Parameters>::compute_phi_r(func::function<ScalarType, RDmn>& phi_r) const {
+  phi_r = 0.;
+
   using KCluster = typename KClusterDmn::parameter_type;
   math::geometry::tetrahedron_mesh<KCluster> mesh(parameters_.get_k_mesh_recursion());
-
   using tetrahedron_dmn = func::dmn_0<math::geometry::tetrahedron_mesh<KClusterDmn>>;
   using quadrature_dmn = math::geometry::gaussian_quadrature_domain<tetrahedron_dmn>;
   quadrature_dmn::translate_according_to_period(parameters_.get_coarsegraining_periods(), mesh);
-
   std::vector<math::geometry::tetrahedron<dimension>>& tetrahedra = mesh.get_tetrahedra();
-
-  phi_r = 0.;
-
-  RDmn r_domain;
-  std::pair<int, int> bounds = concurrency_.get_bounds(r_domain);
-
   std::vector<std::vector<double>> super_basis = RDmn::parameter_type::get_super_basis_vectors();
-
-  for (int l = bounds.first; l < bounds.second; l++) {
-    std::vector<double> r_vec = RDmn::get_elements()[l];
-    std::vector<std::vector<double>> r_vecs =
-        domains::cluster_operations::equivalent_vectors(r_vec, super_basis);
-    for (int r_ind = 0; r_ind < r_vecs.size(); r_ind++)
-      for (int tet_ind = 0; tet_ind < tetrahedra.size(); tet_ind++)
-        phi_r(l) += std::real(tetrahedron_routines_harmonic_function::execute(
-                        r_vecs[0], tetrahedra[tet_ind])) /
-                    r_vecs.size();
-  }
-
-  concurrency_.sum(phi_r);
 
   double tot_weight = 0;
   for (auto w : QDmn::parameter_type::get_weights())
     tot_weight += w;
 
-  phi_r /= tot_weight;
+  Threading().execute(parameters_.get_coarsegraining_threads(), [&](int id, int threads) {
+    const std::pair<int, int> bounds = parallel::util::getBounds(id, threads, RDmn());
+
+    for (int l = bounds.first; l < bounds.second; l++) {
+      std::vector<double> r_vec = RDmn::get_elements()[l];
+      std::vector<std::vector<double>> r_vecs =
+          domains::cluster_operations::equivalent_vectors(r_vec, super_basis);
+      for (int r_ind = 0; r_ind < r_vecs.size(); r_ind++)
+        for (int tet_ind = 0; tet_ind < tetrahedra.size(); tet_ind++)
+          phi_r(l) += std::real(tetrahedron_routines_harmonic_function::execute(
+                          r_vecs[0], tetrahedra[tet_ind])) /
+                      r_vecs.size();
+
+      phi_r(l) /= tot_weight;
+    }
+  });
 }
 
 }  // namespace clustermapping

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_sp.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_sp.hpp
@@ -21,6 +21,7 @@
 
 #include "dca/function/domains.hpp"
 #include "dca/function/function.hpp"
+#include "dca/function/domains/local_domain.hpp"
 #include "dca/math/geometry/gaussian_quadrature/gaussian_quadrature_domain.hpp"
 #include "dca/math/geometry/tetrahedron_mesh/tetrahedron_mesh.hpp"
 #include "dca/phys/dca_algorithms/compute_greens_function.hpp"
@@ -48,6 +49,7 @@ class CoarsegrainingSp : private coarsegraining_routines<Parameters>,
                          private tetrahedron_integration<Parameters> {
 public:
   using Concurrency = typename Parameters::concurrency_type;
+  using Gang = typename Concurrency::Gang;
   using Threading = typename Parameters::ThreadingType;
   using ThisType = CoarsegrainingSp<Parameters>;
 
@@ -78,6 +80,10 @@ private:
   using NuNuDmn = func::dmn_variadic<NuDmn, NuDmn, QDmn>;
   using NuNuTetDmn = func::dmn_variadic<NuDmn, NuDmn, TetDmn>;
 
+  using LocalWDmn = func::LocalDomain<domains::frequency_domain>;
+  using LocalClusterFunction =
+      func::function<Complex, func::dmn_variadic<NuDmn, NuDmn, KClusterDmn, func::dmn_0<LocalWDmn>>>;
+
 public:
   CoarsegrainingSp(Parameters& parameters_ref);
 
@@ -107,6 +113,7 @@ private:
 
   Parameters& parameters_;
   Concurrency& concurrency_;
+  Gang gang_;
 
   std::vector<func::function<std::complex<ScalarType>, NuNuDmn>> H0_q_;
 
@@ -120,6 +127,11 @@ private:
   LatticeFreqFunction Sigma_old_;
 
   bool spin_symmetric_;
+
+  // Limit the number of processes contributing to this computation to limit communication latency.
+  // Internal: This number was selected for running on Summit, but a different value < 1000 could
+  //           be optimal.
+  constexpr static int gang_size_ = 100;
 };
 
 template <typename Parameters>
@@ -129,6 +141,7 @@ CoarsegrainingSp<Parameters>::CoarsegrainingSp(Parameters& parameters_ref)
 
       parameters_(parameters_ref),
       concurrency_(parameters_.get_concurrency()),
+      gang_(concurrency_, gang_size_),
 
       H0_q_(KClusterDmn::dmn_size()),
 
@@ -143,6 +156,9 @@ CoarsegrainingSp<Parameters>::CoarsegrainingSp(Parameters& parameters_ref)
 
   for (int l = 0; l < w_q_.size(); ++l)
     w_tot_ += w_q_(l) = QDmn::parameter_type::get_weights()[l];
+
+  if (!LocalWDmn::is_initialized())
+    LocalWDmn::initialize(gang_);
 }
 
 template <typename Parameters>
@@ -168,14 +184,12 @@ template <class SigmaType, typename>
 void CoarsegrainingSp<Parameters>::compute_G_K_w(const SigmaType& S_K_w, ClusterFreqFunction& G_K_w) {
   // Computes G_K_w(k,w) = 1/N_q \sum_q 1/(i w + mu - H0(k+q,w) - Sigma(k+q,w)).
   updateSigmaInterpolated(S_K_w);
-  G_K_w = 0.;
+  LocalClusterFunction G_local;
 
-  func::dmn_variadic<KClusterDmn, WDmn> K_wm_dmn;
-  const std::pair<int, int> external_bounds = concurrency_.get_bounds(K_wm_dmn);
-
-  const int n_threads = parameters_.get_coarsegraining_threads();
-  Threading().execute(n_threads, [&](int id, int n_threads) {
-    const auto bounds = parallel::util::getBounds(id, n_threads, external_bounds);
+  Threading().execute(parameters_.get_coarsegraining_threads(), [&](int id, int n_threads) {
+    func::dmn_variadic<KClusterDmn, func::dmn_0<LocalWDmn>> K_wm_dmn;
+    const auto bounds = parallel::util::getBounds(id, n_threads, K_wm_dmn);
+    const int w_offset = LocalWDmn::get_offset();
     constexpr int n_bands = Parameters::bands;
     const int indep_spin_sectors = spin_symmetric_ ? 1 : 2;
 
@@ -183,14 +197,15 @@ void CoarsegrainingSp<Parameters>::compute_G_K_w(const SigmaType& S_K_w, Cluster
     linalg::Vector<int, linalg::CPU> ipiv;
     linalg::Vector<Complex, linalg::CPU> work;
     int coor[2];
-    func::dmn_variadic<KClusterDmn, WDmn> K_wm_dmn;
     const Complex im(0., 1.);
 
     for (int l = bounds.first; l < bounds.second; l++) {
       K_wm_dmn.linind_2_subind(l, coor);
       const int k(coor[0]), w(coor[1]);
+      if (w >= LocalWDmn::get_physical_size())  // Padding region.
+        break;
 
-      const auto w_val = WDmn::get_elements()[w];
+      const auto w_val = LocalWDmn::get_elements().at(w);
       const auto& H0 = H0_q_[k];
 
       for (int q = 0; q < QDmn::dmn_size(); ++q)
@@ -198,9 +213,10 @@ void CoarsegrainingSp<Parameters>::compute_G_K_w(const SigmaType& S_K_w, Cluster
           for (int j = 0; j < n_bands; j++)
             for (int i = 0; i < n_bands; i++) {
               if (std::is_same<SigmaType, ClusterFreqFunction>::value)
-                G_inv(i, j) = -H0(i, s, j, s, q) - S_K_w(i, s, j, s, k, w);
+                G_inv(i, j) = -H0(i, s, j, s, q) - S_K_w(i, s, j, s, k, w + w_offset);
               else
-                G_inv(i, j) = -H0(i, s, j, s, q) - (*Sigma_interpolated_)(i, s, j, s, q, k, w);
+                G_inv(i, j) =
+                    -H0(i, s, j, s, q) - (*Sigma_interpolated_)(i, s, j, s, q, k, w + w_offset);
               if (i == j)
                 G_inv(i, j) += im * w_val + parameters_.get_chemical_potential();
             }
@@ -209,20 +225,19 @@ void CoarsegrainingSp<Parameters>::compute_G_K_w(const SigmaType& S_K_w, Cluster
 
           for (int j = 0; j < n_bands; ++j)
             for (int i = 0; i < n_bands; ++i) {
-              G_K_w(i, s, j, s, k, w) += G_inv(i, j) * w_q_(q);
+              G_local(i, s, j, s, k, w) += G_inv(i, j) * w_q_(q);
             }
         }
 
       if (spin_symmetric_) {  // apply symmetry
         for (int j = 0; j < n_bands; ++j)
           for (int i = 0; i < n_bands; ++i)
-            G_K_w(i, 1, j, 1, k, w) = G_K_w(i, 0, j, 0, k, w);
+            G_local(i, 1, j, 1, k, w) = G_local(i, 0, j, 0, k, w);
       }
     }
   });
 
-  concurrency_.sum(G_K_w);
-
+  concurrency_.gather(G_local, G_K_w, gang_);
   G_K_w /= w_tot_;
 }
 

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_sp.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_sp.hpp
@@ -135,8 +135,6 @@ CoarsegrainingSp<Parameters>::CoarsegrainingSp(Parameters& parameters_ref)
       w_q_("w_q_"),
       w_tot_(0.),
       spin_symmetric_(checkSpinSymmetry()) {
-  interpolation_matrices<ScalarType, KClusterDmn, QDmn>::initialize(concurrency_);
-
   // Compute H0(k+q) for each value of k and q.
   for (int k = 0; k < H0_q_.size(); ++k) {
     QDmn::parameter_type::set_elements(k);

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_tp.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_tp.hpp
@@ -203,21 +203,18 @@ void coarsegraining_tp<parameters_type, K_dmn>::execute(
     func::function<std::complex<scalar_type>, func::dmn_variadic<b_b, b_b, K_dmn, w_dmn_t>>& chi) {
   int Q_ind = domains::cluster_operations::index(parameters.get_four_point_momentum_transfer(),
                                                  K_dmn::get_elements(), K_dmn::parameter_type::SHAPE);
+  interpolation_matrices<scalar_type, k_HOST, q_plus_Q_dmn>::set_q_idx(Q_ind);
 
   switch (parameters.get_four_point_type()) {
     case PARTICLE_HOLE_CHARGE:
     case PARTICLE_HOLE_MAGNETIC:
     case PARTICLE_HOLE_TRANSVERSE: {
-      interpolation_matrices<scalar_type, k_HOST, q_dmn>::initialize(concurrency);
-      interpolation_matrices<scalar_type, k_HOST, q_plus_Q_dmn>::initialize(concurrency, Q_ind);
-
+      interpolation_matrices<scalar_type, k_HOST, q_plus_Q_dmn>::set_q_idx(Q_ind);
       compute_tp(H_k, Sigma, chi);
     } break;
 
     case PARTICLE_PARTICLE_UP_DOWN: {
-      interpolation_matrices<scalar_type, k_HOST, q_dmn>::initialize(concurrency);
-      interpolation_matrices<scalar_type, k_HOST, Q_min_q_dmn>::initialize(concurrency, Q_ind);
-
+      interpolation_matrices<scalar_type, k_HOST, Q_min_q_dmn>::set_q_idx(Q_ind);
       compute_phi(H_k, Sigma, chi);
     } break;
 
@@ -240,16 +237,12 @@ void coarsegraining_tp<parameters_type, K_dmn>::execute(
     case PARTICLE_HOLE_CHARGE:
     case PARTICLE_HOLE_MAGNETIC:
     case PARTICLE_HOLE_TRANSVERSE: {
-      interpolation_matrices<scalar_type, k_HOST, q_dmn>::initialize(concurrency);
-      interpolation_matrices<scalar_type, k_HOST, q_plus_Q_dmn>::initialize(concurrency, Q_ind);
-
+      interpolation_matrices<scalar_type, k_HOST, q_plus_Q_dmn>::set_q_idx(Q_ind);
       compute_tp(H_k, Sigma, chi);
     } break;
 
     case PARTICLE_PARTICLE_UP_DOWN: {
-      interpolation_matrices<scalar_type, k_HOST, q_dmn>::initialize(concurrency);
-      interpolation_matrices<scalar_type, k_HOST, Q_min_q_dmn>::initialize(concurrency, Q_ind);
-
+      interpolation_matrices<scalar_type, k_HOST, Q_min_q_dmn>::set_q_idx(Q_ind);
       compute_phi(H_k, Sigma, chi);
     } break;
 
@@ -709,8 +702,8 @@ double coarsegraining_tp<parameters_type, K_dmn>::get_integration_factor() {
   }
 }
 
-}  // clustermapping
-}  // phys
-}  // dca
+}  // namespace clustermapping
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_STEP_CLUSTER_MAPPING_COARSEGRAINING_COARSEGRAINING_TP_HPP

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/interpolation_matrices.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/interpolation_matrices.hpp
@@ -29,7 +29,6 @@
 #include "dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegrain_domain_names.hpp"
 #include "dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_domain.hpp"
 #include "dca/phys/domains/cluster/centered_cluster_domain.hpp"
-#include "dca/util/print_time.hpp"
 
 namespace dca {
 namespace phys {
@@ -54,35 +53,22 @@ public:
   using Matrix = dca::linalg::Matrix<scalar_type, dca::linalg::CPU>;
   using MatrixView = dca::linalg::MatrixView<scalar_type, dca::linalg::CPU>;
 
-public:
-  // Interpolation matrices concatenated column-wise.
-  static auto& get() {
-    static func::function<scalar_type, func::dmn_variadic<q_dmn, k_dmn, K_dmn>> k_to_q(
-        "k_to_q (" + q_dmn::parameter_type::get_name() + ")");
-    return k_to_q;
-  }
-
   static MatrixView get(int k_ind) {
     auto& k_to_q = get();
     return MatrixView(&k_to_q(0, 0, k_ind), std::make_pair(q_dmn::dmn_size(), k_dmn::dmn_size()));
   }
 
-  static bool is_initialized() {
-    return initialized_;
+  static void set_q_idx(int q_idx) {
+    assert(q_idx >= 0 && q_idx < q_dmn::dmn_size());
+    q_idx_ = q_idx;
   }
 
-  template <typename concurrency_type>
-  static void initialize(concurrency_type& concurrency);
-
-  template <typename concurrency_type>
-  static void initialize(concurrency_type& concurrency, int Q_ind);
-
 private:
-  template <typename concurrency_type>
-  static void resize_matrices(concurrency_type& concurrency);
+  // Interpolation matrices concatenated column-wise.
+  using Matrices = func::function<scalar_type, func::dmn_variadic<q_dmn, k_dmn, K_dmn>>;
+  static auto get() -> Matrices&;
 
-  template <typename concurrency_type>
-  static void print_memory_used(concurrency_type& concurrency);
+  static auto initialize() -> Matrices;
 
   template <typename scalar_type_1, typename scalar_type_2>
   inline static void cast(scalar_type_1& x, scalar_type_2& y);
@@ -90,123 +76,59 @@ private:
   template <typename scalar_type_1, typename scalar_type_2>
   inline static void cast(scalar_type_1& x, std::complex<scalar_type_2>& y);
 
-  static bool initialized_;
+  static int q_idx_;
 };
 template <typename scalar_type, typename k_dmn, typename K_dmn, COARSEGRAIN_DOMAIN_NAMES NAME>
-bool interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::initialized_ =
-    false;
+int interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::q_idx_ =
+    -1;
 
 template <typename scalar_type, typename k_dmn, typename K_dmn, COARSEGRAIN_DOMAIN_NAMES NAME>
-template <typename concurrency_type>
-// TODO: rename.
-void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::resize_matrices(
-    concurrency_type& concurrency) {
-  if (concurrency.id() == concurrency.first())
-    std::cout << "\n\n\t interpolation-matrices " << to_str(NAME) << " initialization started ... ";
+auto interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::get()
+    -> Matrices& {
+  static Matrices k_to_q(initialize(), "k_to_q (" + q_dmn::parameter_type::get_name() + ")");
+  return k_to_q;
+}
 
-  get().reset();
+template <typename scalar_type, typename k_dmn, typename K_dmn, COARSEGRAIN_DOMAIN_NAMES NAME>
+auto interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::initialize()
+    -> Matrices {
+  Profiler profiler(__FUNCTION__, "Interpolation matrices", __LINE__);
 
+  Matrices matrices;
   r_centered_dmn::parameter_type::initialize();
-}
-
-template <typename scalar_type, typename k_dmn, typename K_dmn, COARSEGRAIN_DOMAIN_NAMES NAME>
-template <typename concurrency_type>
-void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::print_memory_used(
-    concurrency_type& concurrency) {
-  if (concurrency.id() == concurrency.first()) {
-    std::cout << " stopped ( " << sizeof(scalar_type) * get().size() * 1.e-6 << " Mbytes) \n\n";
-  }
-}
-
-template <typename scalar_type, typename k_dmn, typename K_dmn, COARSEGRAIN_DOMAIN_NAMES NAME>
-template <typename concurrency_type>
-void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::initialize(
-    concurrency_type& concurrency) {
-  assert(NAME == K or NAME == TETRAHEDRON_K);
-
-  static std::once_flag flag;
-
-  std::call_once(flag, [&]() {
-    resize_matrices(concurrency);
-
-    K_dmn K_dmn_obj;
-    std::pair<int, int> bounds = concurrency.get_bounds(K_dmn_obj);
-
-    trafo_matrix_type trafo_k_to_q;
-    trafo_k_to_q.resizeNoCopy(std::pair<int, int>(q_dmn::dmn_size(), k_dmn::dmn_size()));
-
-    for (int K_ind = bounds.first; K_ind < bounds.second; K_ind++) {
-      {
-        q_dmn::parameter_type::set_elements(K_ind);
-
-        // trafo_k_to_r_type::is_initialized() = false;
-        trafo_r_to_q_type::is_initialized() = false;
-
-        trafo_matrix_type& trafo_r_to_q = trafo_r_to_q_type::get_transformation_matrix();
-        trafo_matrix_type& trafo_k_to_r = trafo_k_to_r_type::get_transformation_matrix();
-
-        dca::linalg::matrixop::gemm(trafo_r_to_q, trafo_k_to_r, trafo_k_to_q);
-      }
-
-      {
-        MatrixView T_k_to_q = get(K_ind);
-
-        for (int j = 0; j < k_dmn::dmn_size(); j++)
-          for (int i = 0; i < q_dmn::dmn_size(); i++)
-            cast(T_k_to_q(i, j), trafo_k_to_q(i, j));
-      }
-    }
-
-    concurrency.sum(get());
-
-    print_memory_used(concurrency);
-    initialized_ = true;
-  });
-}
-
-template <typename scalar_type, typename k_dmn, typename K_dmn, COARSEGRAIN_DOMAIN_NAMES NAME>
-template <typename concurrency_type>
-void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::initialize(
-    concurrency_type& concurrency, int Q_ind) {
-  assert(NAME == K_PLUS_Q or NAME == Q_MINUS_K);
-
-  if (is_initialized())
-    return;
-
-  resize_matrices(concurrency);
-
-  K_dmn K_dmn_obj;
-  std::pair<int, int> bounds = concurrency.get_bounds(K_dmn_obj);
 
   trafo_matrix_type trafo_k_to_q;
   trafo_k_to_q.resizeNoCopy(std::pair<int, int>(q_dmn::dmn_size(), k_dmn::dmn_size()));
 
-  for (int K_ind = bounds.first; K_ind < bounds.second; K_ind++) {
-    {
-      q_dmn::parameter_type::set_elements(K_ind, Q_ind);
-
-      // trafo_k_to_r_type::is_initialized() = false;
-      trafo_r_to_q_type::is_initialized() = false;
-
-      trafo_matrix_type& trafo_r_to_q = trafo_r_to_q_type::get_transformation_matrix();
-      trafo_matrix_type& trafo_k_to_r = trafo_k_to_r_type::get_transformation_matrix();
-
-      dca::linalg::matrixop::gemm(trafo_r_to_q, trafo_k_to_r, trafo_k_to_q);
+  for (int K_ind = 0; K_ind < K_dmn::dmn_size(); ++K_ind) {
+    if (NAME == K || NAME == TETRAHEDRON_K) {
+      q_dmn::parameter_type::set_elements(K_ind);
+    }
+    else if (NAME == K_PLUS_Q || NAME == Q_MINUS_K) {
+      if (q_idx_ == -1)
+        throw(std::logic_error("q index not set."));
+      q_dmn::parameter_type::set_elements(K_ind, q_idx_);
+    }
+    else {
+      throw(std::logic_error("Non matching NAME."));
     }
 
-    {
-      MatrixView T_k_to_q = get(K_ind);
+    trafo_r_to_q_type::is_initialized() = false;
 
-      for (int j = 0; j < k_dmn::dmn_size(); j++)
-        for (int i = 0; i < q_dmn::dmn_size(); i++)
-          cast(T_k_to_q(i, j), trafo_k_to_q(i, j));
-    }
+    trafo_matrix_type& trafo_r_to_q = trafo_r_to_q_type::get_transformation_matrix();
+    trafo_matrix_type& trafo_k_to_r = trafo_k_to_r_type::get_transformation_matrix();
+
+    dca::linalg::matrixop::gemm(trafo_r_to_q, trafo_k_to_r, trafo_k_to_q);
+
+    MatrixView T_k_to_q =
+        MatrixView(&matrices(0, 0, K_ind), std::make_pair(q_dmn::dmn_size(), k_dmn::dmn_size()));
+
+    for (int j = 0; j < k_dmn::dmn_size(); j++)
+      for (int i = 0; i < q_dmn::dmn_size(); i++)
+        cast(T_k_to_q(i, j), trafo_k_to_q(i, j));
   }
 
-  concurrency.sum(get());
-
-  initialized_ = true;
-  print_memory_used(concurrency);
+  return matrices;
 }
 
 template <typename scalar_type, typename k_dmn, typename K_dmn, COARSEGRAIN_DOMAIN_NAMES NAME>

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/interpolation_matrices.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/interpolation_matrices.hpp
@@ -19,14 +19,17 @@
 #include <mutex>
 #include <utility>
 
+#include "dca/config/profiler.hpp"
 #include "dca/function/domains.hpp"
 #include "dca/function/function.hpp"
 #include "dca/linalg/matrix.hpp"
+#include "dca/linalg/matrix_view.hpp"
 #include "dca/linalg/matrixop.hpp"
 #include "dca/math/function_transform/basis_transform/basis_transform.hpp"
 #include "dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegrain_domain_names.hpp"
 #include "dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_domain.hpp"
 #include "dca/phys/domains/cluster/centered_cluster_domain.hpp"
+#include "dca/util/print_time.hpp"
 
 namespace dca {
 namespace phys {
@@ -48,18 +51,20 @@ public:
   using trafo_r_to_q_type = math::transform::basis_transform<r_centered_dmn, q_dmn>;
   using trafo_matrix_type = typename trafo_k_to_r_type::matrix_type;
 
-  using matrix_type = dca::linalg::Matrix<scalar_type, dca::linalg::CPU>;
+  using Matrix = dca::linalg::Matrix<scalar_type, dca::linalg::CPU>;
+  using MatrixView = dca::linalg::MatrixView<scalar_type, dca::linalg::CPU>;
 
 public:
-  static func::function<matrix_type, K_dmn>& get() {
-    static func::function<matrix_type, K_dmn> k_to_q("k_to_q (" +
-                                                     q_dmn::parameter_type::get_name() + ")");
+  // Interpolation matrices concatenated column-wise.
+  static auto& get() {
+    static func::function<scalar_type, func::dmn_variadic<q_dmn, k_dmn, K_dmn>> k_to_q(
+        "k_to_q (" + q_dmn::parameter_type::get_name() + ")");
     return k_to_q;
   }
 
-  static matrix_type& get(int k_ind) {
-    static func::function<matrix_type, K_dmn>& k_to_q = get();
-    return k_to_q(k_ind);
+  static MatrixView get(int k_ind) {
+    auto& k_to_q = get();
+    return MatrixView(&k_to_q(0, 0, k_ind), std::make_pair(q_dmn::dmn_size(), k_dmn::dmn_size()));
   }
 
   static bool is_initialized() {
@@ -93,20 +98,13 @@ bool interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domai
 
 template <typename scalar_type, typename k_dmn, typename K_dmn, COARSEGRAIN_DOMAIN_NAMES NAME>
 template <typename concurrency_type>
+// TODO: rename.
 void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::resize_matrices(
     concurrency_type& concurrency) {
   if (concurrency.id() == concurrency.first())
     std::cout << "\n\n\t interpolation-matrices " << to_str(NAME) << " initialization started ... ";
 
-  for (int K_ind = 0; K_ind < K_dmn::dmn_size(); K_ind++) {
-    matrix_type& T_k_to_q = get(K_ind);
-
-    T_k_to_q.resizeNoCopy(std::pair<int, int>(q_dmn::dmn_size(), k_dmn::dmn_size()));
-
-    for (int j = 0; j < k_dmn::dmn_size(); j++)
-      for (int i = 0; i < q_dmn::dmn_size(); i++)
-        T_k_to_q(i, j) = 0;
-  }
+  get().reset();
 
   r_centered_dmn::parameter_type::initialize();
 }
@@ -116,10 +114,7 @@ template <typename concurrency_type>
 void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domain<K_dmn, NAME>>>::print_memory_used(
     concurrency_type& concurrency) {
   if (concurrency.id() == concurrency.first()) {
-    std::pair<int, int> capacity = get(0).capacity();
-    std::cout << " stopped ( "
-              << sizeof(scalar_type) * capacity.first * capacity.second * 1.e-6 * K_dmn::dmn_size()
-              << " Mbytes) \n\n";
+    std::cout << " stopped ( " << sizeof(scalar_type) * get().size() * 1.e-6 << " Mbytes) \n\n";
   }
 }
 
@@ -154,9 +149,7 @@ void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domai
       }
 
       {
-        matrix_type& T_k_to_q = get(K_ind);
-
-        T_k_to_q.resize(std::pair<int, int>(q_dmn::dmn_size(), k_dmn::dmn_size()));
+        MatrixView T_k_to_q = get(K_ind);
 
         for (int j = 0; j < k_dmn::dmn_size(); j++)
           for (int i = 0; i < q_dmn::dmn_size(); i++)
@@ -164,8 +157,7 @@ void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domai
       }
     }
 
-    for (int K_ind = 0; K_ind < K_dmn::dmn_size(); K_ind++)
-      concurrency.sum(get(K_ind));
+    concurrency.sum(get());
 
     print_memory_used(concurrency);
     initialized_ = true;
@@ -203,9 +195,7 @@ void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domai
     }
 
     {
-      matrix_type& T_k_to_q = get(K_ind);
-
-      T_k_to_q.resize(std::pair<int, int>(q_dmn::dmn_size(), k_dmn::dmn_size()));
+      MatrixView T_k_to_q = get(K_ind);
 
       for (int j = 0; j < k_dmn::dmn_size(); j++)
         for (int i = 0; i < q_dmn::dmn_size(); i++)
@@ -213,8 +203,7 @@ void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domai
     }
   }
 
-  for (int K_ind = 0; K_ind < K_dmn::dmn_size(); K_ind++)
-    concurrency.sum(get(K_ind));
+  concurrency.sum(get());
 
   initialized_ = true;
   print_memory_used(concurrency);
@@ -235,8 +224,8 @@ void interpolation_matrices<scalar_type, k_dmn, func::dmn_0<coarsegraining_domai
   x = std::real(y);
 }
 
-}  // clustermapping
-}  // phys
-}  // dca
+}  // namespace clustermapping
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_STEP_CLUSTER_MAPPING_COARSEGRAINING_INTERPOLATION_MATRICES_HPP

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/tetrahedron_routines_harmonic_function.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/tetrahedron_routines_harmonic_function.hpp
@@ -25,20 +25,20 @@ namespace clustermapping {
 class tetrahedron_routines_harmonic_function {
 public:
   // 1D
-  static std::complex<double> execute(std::vector<double>& r_vec,
-                                      math::geometry::tetrahedron<1>& tetrahedron);
+  static std::complex<double> execute(const std::vector<double>& r_vec,
+                                      const math::geometry::tetrahedron<1>& tetrahedron);
   // 2D
-  static std::complex<double> execute(std::vector<double>& r_vec,
-                                      math::geometry::tetrahedron<2>& tetrahedron);
+  static std::complex<double> execute(const std::vector<double>& r_vec,
+                                      const math::geometry::tetrahedron<2>& tetrahedron);
 
   // 3D
-  static std::complex<double> execute(std::vector<double>& r_vec,
-                                      math::geometry::tetrahedron<3>& tetrahedron);
+  static std::complex<double> execute(const std::vector<double>& r_vec,
+                                      const math::geometry::tetrahedron<3>& tetrahedron);
 
 private:
   // 2D cases:
   static void permute(math::geometry::tetrahedron<2>& tetrahedron_new,
-                      math::geometry::tetrahedron<2>& tetrahedron_old);
+                      const math::geometry::tetrahedron<2>& tetrahedron_old);
 
   static std::complex<double> case_2D(double dotRD1, double dotRD2, double dotRD2minD1);
   static std::complex<double> case_d1_2D(double dotRD1, double dotRD2, double dotRD2minD1);
@@ -46,7 +46,7 @@ private:
 
   // 3D
   static void permute(math::geometry::tetrahedron<3>& tetrahedron_new,
-                      math::geometry::tetrahedron<3>& tetrahedron_old);
+                      const math::geometry::tetrahedron<3>& tetrahedron_old);
 
   static std::complex<double> case_3D(double dotRD1, double dotRD2, double dotRD3,
                                       double dotRD2minD1, double dotRD3minD2, double dotRD1minD3);
@@ -73,8 +73,8 @@ private:
                                             double dotRD1minD3);
 };
 
-}  // clustermapping
-}  // phys
-}  // dca
+}  // namespace clustermapping
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_STEP_CLUSTER_MAPPING_COARSEGRAINING_TETRAHEDRON_ROUTINES_HARMONIC_FUNCTION_HPP

--- a/include/dca/phys/dca_step/cluster_mapping/update_chemical_potential.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/update_chemical_potential.hpp
@@ -224,8 +224,8 @@ void update_chemical_potential<parameters_type, MOMS_type, coarsegraining_type>:
 template <typename parameters_type, typename MOMS_type, typename coarsegraining_type>
 double update_chemical_potential<parameters_type, MOMS_type, coarsegraining_type>::compute_density() {
   if (parameters.do_finite_size_qmc())
-    compute_G_k_w(MOMS.H_DCA, MOMS.Sigma, parameters.get_chemical_potential(), concurrency,
-                  MOMS.G_k_w);
+    compute_G_k_w(MOMS.H_DCA, MOMS.Sigma, parameters.get_chemical_potential(),
+                  parameters.get_coarsegraining_threads(), MOMS.G_k_w);
   else if (parameters.do_dca_plus())
     coarsegraining.compute_G_K_w(MOMS.Sigma_lattice, MOMS.G_k_w);
   else
@@ -354,8 +354,8 @@ void update_chemical_potential<parameters_type, MOMS_type, coarsegraining_type>:
   }
 }
 
-}  // clustermapping
-}  // phys
-}  // dca
+}  // namespace clustermapping
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_STEP_CLUSTER_MAPPING_UPDATE_CHEMICAL_POTENTIAL_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -144,7 +144,7 @@ private:
   func::function<std::complex<double>, NuNuKClusterWDmn> Sigma_old_;
   func::function<std::complex<double>, NuNuKClusterWDmn> Sigma_new_;
 
-  int accumulated_sign_;
+  double accumulated_sign_;
   func::function<std::complex<double>, NuNuRClusterWDmn> M_r_w_;
   func::function<std::complex<double>, NuNuRClusterWDmn> M_r_w_squared_;
 
@@ -413,20 +413,69 @@ void CtauxClusterSolver<device_t, Parameters, Data>::computeErrorBars() {
 
 template <dca::linalg::DeviceType device_t, class Parameters, class Data>
 void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
-  auto collect = [&](auto& f) {
+  auto collect_delayed = [&](auto& f) {
     if (compute_jack_knife_)
-      concurrency_.leaveOneOutSum(f);
+      concurrency_.leaveOneOutSum(f, true);
     else
-      concurrency_.sum(f);
+      concurrency_.delayedSum(f);
   };
 
   const double local_time = total_time_;
+
   {
-    Profiler profiler("Scalars", "QMC-collectives", __LINE__);
-    concurrency_.sum(total_time_);
-    concurrency_.sum(accumulator_.get_Gflop());
+    Profiler profiler("QMC-collectives", "CT-AUX solver", __LINE__);
+    concurrency_.delayedSum(total_time_);
+    concurrency_.delayedSum(accumulator_.get_Gflop());
     accumulated_sign_ = accumulator_.get_accumulated_sign();
-    collect(accumulated_sign_);
+    collect_delayed(accumulated_sign_);
+
+    M_r_w_ = accumulator_.get_sign_times_M_r_w();
+    collect_delayed(M_r_w_);
+
+    if (accumulator_.compute_std_deviation()) {
+      M_r_w_squared_ = accumulator_.get_sign_times_M_r_w_sqr();
+      concurrency_.delayedSum(M_r_w_squared_);
+    }
+
+    if (parameters_.additional_time_measurements()) {
+      Profiler profiler("Additional time measurements.", "QMC-collectives", __LINE__);
+      concurrency_.delayedSum(accumulator_.get_G_r_t());
+      concurrency_.delayedSum(accumulator_.get_G_r_t_stddev());
+      concurrency_.delayedSum(accumulator_.get_charge_cluster_moment());
+      concurrency_.delayedSum(accumulator_.get_magnetic_cluster_moment());
+      concurrency_.delayedSum(accumulator_.get_dwave_pp_correlator());
+    }
+
+    // sum G4
+    if (parameters_.accumulateG4() && dca_iteration_ == parameters_.get_dca_iterations() - 1) {
+      for (int g4_idx = 0; g4_idx < data_.get_G4().size(); ++g4_idx) {
+        auto& G4 = data_.get_G4()[g4_idx];
+        G4 = accumulator_.get_sign_times_G4()[g4_idx];
+        if (compute_jack_knife_)
+          concurrency_.leaveOneOutSum(G4, true);
+        else
+          concurrency_.delayedSum(G4);  // TODO: reduce only on rank 0.
+      }
+    }
+
+    concurrency_.delayedSum(accumulator_.get_visited_expansion_order_k());
+    concurrency_.delayedSum(accumulator_.get_error_distribution());
+
+    concurrency_.resolveSums();
+  }
+
+  M_r_w_ /= accumulated_sign_;
+  M_r_w_squared_ /= accumulated_sign_;
+  for (auto& G4 : data_.get_G4())
+    G4 /= accumulated_sign_ * parameters_.get_beta() * parameters_.get_beta();
+
+  if (parameters_.additional_time_measurements()) {
+    accumulator_.get_G_r_t() /= accumulated_sign_;
+    data_.G_r_t = accumulator_.get_G_r_t();
+    accumulator_.get_G_r_t_stddev() /= accumulated_sign_ * std::sqrt(parameters_.get_measurements());
+    accumulator_.get_charge_cluster_moment() /= accumulated_sign_;
+    accumulator_.get_magnetic_cluster_moment() /= accumulated_sign_;
+    accumulator_.get_dwave_pp_correlator() /= accumulated_sign_;
   }
 
   if (concurrency_.id() == concurrency_.first())
@@ -437,59 +486,6 @@ void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
               << "\n\t\t\t Gflop/s   : " << accumulator_.get_Gflop() / local_time << " [Gf/s]"
               << "\n\t\t\t sign     : " << accumulated_sign_ / parameters_.get_measurements()
               << " \n";
-
-  // sum M_r_w
-  M_r_w_ = accumulator_.get_sign_times_M_r_w();
-  {
-    Profiler profiler("QMC-self-energy", "QMC-collectives", __LINE__);
-    collect(M_r_w_);
-  }
-  M_r_w_ /= accumulated_sign_;
-
-  if (accumulator_.compute_std_deviation()) {
-    M_r_w_squared_ = accumulator_.get_sign_times_M_r_w_sqr();
-    {
-      Profiler profiler("QMC-self-energy", "QMC-collectives", __LINE__);
-      concurrency_.sum(M_r_w_squared_);
-    }
-    M_r_w_squared_ /= accumulated_sign_;
-  }
-
-  if (parameters_.additional_time_measurements()) {
-    Profiler profiler("Additional time measurements.", "QMC-collectives", __LINE__);
-    concurrency_.sum(accumulator_.get_G_r_t());
-    concurrency_.sum(accumulator_.get_G_r_t_stddev());
-
-    accumulator_.get_G_r_t() /= accumulated_sign_;
-    accumulator_.get_G_r_t_stddev() /= accumulated_sign_ * std::sqrt(parameters_.get_measurements());
-
-    concurrency_.sum(accumulator_.get_charge_cluster_moment());
-    concurrency_.sum(accumulator_.get_magnetic_cluster_moment());
-    concurrency_.sum(accumulator_.get_dwave_pp_correlator());
-
-    accumulator_.get_charge_cluster_moment() /= accumulated_sign_;
-    accumulator_.get_magnetic_cluster_moment() /= accumulated_sign_;
-    accumulator_.get_dwave_pp_correlator() /= accumulated_sign_;
-
-    data_.G_r_t = accumulator_.get_G_r_t();
-  }
-
-  // sum G4
-  if (dca_iteration_ == parameters_.get_dca_iterations() - 1 && parameters_.accumulateG4()) {
-    Profiler profiler("QMC-two-particle-Greens-function", "QMC-collectives", __LINE__);
-
-    auto& G4 = data_.get_G4();
-    G4 = accumulator_.get_sign_times_G4();
-
-    for (auto& G4_channel : G4) {
-      collect(G4_channel);
-      G4_channel /= accumulated_sign_;
-    }
-  }
-
-  concurrency_.sum(accumulator_.get_visited_expansion_order_k());
-
-  concurrency_.sum(accumulator_.get_error_distribution());
 
   averaged_ = true;
 }

--- a/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_cluster_solver.hpp
@@ -481,6 +481,8 @@ void StdThreadQmciClusterSolver<QmciSolver>::readConfigurations() {
   if (parameters_.get_directory_config_read() == "")
     return;
 
+  Profiler profiler(__FUNCTION__, "stdthread-MC", __LINE__);
+
   try {
     const std::string inp_name = parameters_.get_directory_config_read() + "/process_" +
                                  std::to_string(concurrency_.id()) + ".hdf5";

--- a/src/parallel/mpi_concurrency/CMakeLists.txt
+++ b/src/parallel/mpi_concurrency/CMakeLists.txt
@@ -1,6 +1,6 @@
 # parallel mpi_concurrency
 add_library(parallel_mpi_concurrency STATIC mpi_concurrency.cpp mpi_processor_grouping.cpp
-            mpi_initializer.cpp)
+            mpi_initializer.cpp mpi_gang.cpp)
 
 if(DCA_HAVE_CUDA)
   cuda_add_library(kernel_test kernel_test.cu)

--- a/src/parallel/mpi_concurrency/mpi_gang.cpp
+++ b/src/parallel/mpi_concurrency/mpi_gang.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// Implementation of mpi_gang.hpp.
+
+#include "dca/parallel/mpi_concurrency/mpi_gang.hpp"
+
+#include <cmath>
+
+#include "dca/util/integer_division.hpp"
+
+namespace dca {
+namespace parallel {
+// dca::parallel::
+
+MPIGang::MPIGang(const dca::parallel::MPIProcessorGrouping& group, int min_size) {
+  min_size = std::min(min_size, group.get_size());
+
+
+  const int n_gangs = group.get_size() / min_size;
+  const int gang_id = std::min(group.get_id() / min_size, n_gangs - 1);
+
+  MPI_Comm_split(group.get(), gang_id, 0, &communicator_);
+  MPI_Comm_size(communicator_, &size_);
+  MPI_Comm_rank(communicator_, &id_);
+}
+
+MPIGang::~MPIGang() {
+  MPI_Comm_free(&communicator_);
+}
+
+}  // namespace parallel
+}  // namespace dca

--- a/src/phys/dca_step/cluster_mapping/coarsegraining/tetrahedron_routines_harmonic_function.cpp
+++ b/src/phys/dca_step/cluster_mapping/coarsegraining/tetrahedron_routines_harmonic_function.cpp
@@ -28,7 +28,7 @@ namespace clustermapping {
  ************************************/
 
 std::complex<double> tetrahedron_routines_harmonic_function::execute(
-    std::vector<double>& r_vec, math::geometry::tetrahedron<1>& tetrahedron) {
+    const std::vector<double>& r_vec, const math::geometry::tetrahedron<1>& tetrahedron) {
   assert(r_vec.size() == 1);
 
   double r = r_vec[0];
@@ -87,7 +87,7 @@ std::complex<double> tetrahedron_routines_harmonic_function::execute(
  *
  */
 std::complex<double> tetrahedron_routines_harmonic_function::execute(
-    std::vector<double>& r_vec, math::geometry::tetrahedron<2>& tetrahedron) {
+    const std::vector<double>& r_vec, const math::geometry::tetrahedron<2>& tetrahedron) {
   assert(r_vec.size() == 2);
 
   const static std::complex<double> I(0, 1);
@@ -148,7 +148,7 @@ std::complex<double> tetrahedron_routines_harmonic_function::execute(
 }
 
 void tetrahedron_routines_harmonic_function::permute(math::geometry::tetrahedron<2>& tetrahedron_new,
-                                                     math::geometry::tetrahedron<2>& tetrahedron_old) {
+                                                     const math::geometry::tetrahedron<2> &tetrahedron_old) {
   tetrahedron_new.vec_1 = tetrahedron_old.vec_0;
   tetrahedron_new.vec_2 = tetrahedron_old.vec_1;
   tetrahedron_new.vec_0 = tetrahedron_old.vec_2;
@@ -234,7 +234,7 @@ std::complex<double> tetrahedron_routines_harmonic_function::case_d2_2D(double d
  ************************************/
 
 void tetrahedron_routines_harmonic_function::permute(math::geometry::tetrahedron<3>& tetrahedron_new,
-                                                     math::geometry::tetrahedron<3>& tetrahedron_old) {
+                                                     const math::geometry::tetrahedron<3> &tetrahedron_old) {
   tetrahedron_new.vec_1 = tetrahedron_old.vec_0;
   tetrahedron_new.vec_2 = tetrahedron_old.vec_1;
   tetrahedron_new.vec_3 = tetrahedron_old.vec_2;
@@ -461,7 +461,7 @@ std::complex<double> tetrahedron_routines_harmonic_function::case_d3_d1_3D(
 }
 
 std::complex<double> tetrahedron_routines_harmonic_function::execute(
-    std::vector<double>& r_vec, math::geometry::tetrahedron<3>& tetrahedron) {
+    const std::vector<double>& r_vec, const math::geometry::tetrahedron<3>& tetrahedron) {
   assert(r_vec.size() == 3);
 
   const static std::complex<double> I(0, 1);
@@ -509,8 +509,7 @@ std::complex<double> tetrahedron_routines_harmonic_function::execute(
 
     if (std::abs(dot_R_D1) > EPSILON and std::abs(dot_R_D2) > EPSILON and
         std::abs(dot_R_D3) > EPSILON and std::abs(dot_R_D2_min_D1) > EPSILON and
-        std::abs(dot_R_D3_min_D2) > EPSILON and
-        std::abs(dot_R_D1_min_D3) > EPSILON)  // general case
+        std::abs(dot_R_D3_min_D2) > EPSILON and std::abs(dot_R_D1_min_D3) > EPSILON)  // general case
     {
       result =
           case_3D(dot_R_D1, dot_R_D2, dot_R_D3, dot_R_D2_min_D1, dot_R_D3_min_D2, dot_R_D1_min_D3) *
@@ -580,6 +579,6 @@ std::complex<double> tetrahedron_routines_harmonic_function::execute(
   return result;
 }
 
-}  // clustermapping
-}  // phys
-}  // dca
+}  // namespace clustermapping
+}  // namespace phys
+}  // namespace dca

--- a/test/integration/phys/lattice_mapping/CMakeLists.txt
+++ b/test/integration/phys/lattice_mapping/CMakeLists.txt
@@ -3,6 +3,7 @@
 dca_add_gtest(lattice_mapping_sp_test EXTENSIVE
   GTEST_MAIN
   INCLUDE_DIRS ${SIMPLEX_GM_RULE_INCLUDE_DIR} ${FFTW_INCLUDE_DIR}
-  LIBS json function cluster_domains time_and_frequency_domains quantum_domains gaussian_quadrature
+  LIBS json function cluster_domains parallel_stdthread parallel_util time_and_frequency_domains
+       quantum_domains gaussian_quadrature
        tetrahedron_mesh coarsegraining enumerations dca_hdf5 ${LAPACK_LIBRARIES} ${HDF5_LIBRARIES}
        lapack)

--- a/test/unit/parallel/mpi_concurrency/CMakeLists.txt
+++ b/test/unit/parallel/mpi_concurrency/CMakeLists.txt
@@ -21,3 +21,6 @@ dca_add_gtest(mpi_type_map_test
 dca_add_gtest(mpi_concurrency_test
   MPI MPI_NUMPROC 4
   LIBS parallel_mpi_concurrency)
+dca_add_gtest(mpi_gather_test
+  MPI MPI_NUMPROC 8
+  LIBS parallel_mpi_concurrency function)

--- a/test/unit/parallel/mpi_concurrency/mpi_gather_test.cpp
+++ b/test/unit/parallel/mpi_concurrency/mpi_gather_test.cpp
@@ -1,0 +1,80 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file tests mpi_collective_sum.hpp.
+//
+// This test only passes for 8 MPI processes.
+
+#include "dca/parallel/mpi_concurrency/mpi_gather.hpp"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "dca/parallel/mpi_concurrency/mpi_concurrency.hpp"
+#include "dca/parallel/mpi_concurrency/mpi_gang.hpp"
+#include "dca/function/function.hpp"
+#include "dca/function/domains/dmn.hpp"
+#include "dca/function/domains/dmn_0.hpp"
+#include "dca/function/domains/dmn_variadic.hpp"
+#include "dca/function/domains/local_domain.hpp"
+#include "dca/testing/minimalist_printer.hpp"
+
+std::unique_ptr<dca::parallel::MPIConcurrency> concurrency;
+
+TEST(MPIGatherTest, GatherLocalDmn) {
+  using Dmn1 = dca::func::dmn<4>;
+  using Dmn2 = dca::func::dmn<10>;
+  using LocalDmn = dca::func::LocalDomain<Dmn2>;
+
+  std::vector<int> val1(Dmn1::get_size());
+  for (int i = 0; i < val1.size(); ++i)
+    val1[i] = i;
+  Dmn1::set_elements(val1);
+
+  std::vector<int> val2(Dmn2::get_size());
+  for (int i = 0; i < val2.size(); ++i)
+    val2[i] = i;
+  Dmn2::set_elements(val2);
+
+  dca::parallel::MPIGang gang(*concurrency, 4);
+
+  LocalDmn::initialize(gang);
+
+  dca::func::function<int, dca::func::dmn_variadic<dca::func::dmn_0<Dmn1>, dca::func::dmn_0<LocalDmn>>> local_f;
+  dca::func::function<int, dca::func::dmn_variadic<dca::func::dmn_0<Dmn1>, dca::func::dmn_0<Dmn2>>> f;
+
+  for (int i2 = 0; i2 < LocalDmn::get_physical_size(); ++i2)
+    for (int i1 = 0; i1 < Dmn1::get_size(); ++i1)
+      local_f(i1, i2) = Dmn1::get_elements()[i1] * LocalDmn::get_elements()[i2];
+
+
+  concurrency->gather(local_f, f, gang);
+
+  for (int i2 = 0; i2 < Dmn2::get_size(); ++i2)
+    for (int i1 = 0; i1 < Dmn1::get_size(); ++i1)
+      EXPECT_EQ(Dmn1::get_elements()[i1] * Dmn2::get_elements()[i2], f(i1, i2));
+}
+
+int main(int argc, char** argv) {
+  int result = 0;
+
+  concurrency = std::make_unique<dca::parallel::MPIConcurrency>(argc, argv);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+  if (concurrency->id() != 0) {
+    delete listeners.Release(listeners.default_result_printer());
+    listeners.Append(new dca::testing::MinimalistPrinter);
+  }
+
+  result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/test/unit/phys/dca_algorithms/CMakeLists.txt
+++ b/test/unit/phys/dca_algorithms/CMakeLists.txt
@@ -9,9 +9,9 @@ dca_add_gtest(compute_band_structure_test
 dca_add_gtest(compute_free_greens_function_test
   GTEST_MAIN
   INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
-  LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
+  LIBS function parallel_stdthread parallel_util ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
 
 dca_add_gtest(compute_greens_function_test
   GTEST_MAIN
   INCLUDE_DIRS ${FFTW_INCLUDE_DIR}
-  LIBS function ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})
+  LIBS function parallel_stdthread parallel_util ${LAPACK_LIBRARIES} ${DCA_CUDA_LIBS})

--- a/test/unit/phys/dca_algorithms/compute_free_greens_function_test.cpp
+++ b/test/unit/phys/dca_algorithms/compute_free_greens_function_test.cpp
@@ -88,7 +88,7 @@ TEST_F(ComputeFreeGreensFunctionTest, SquareLattice) {
                                                           func::dmn_0<MatsubaraFreqDmn>>>
       G0_k_w;
 
-  phys::compute_G0_k_w(H_0, mu, concurrency_, G0_k_w);
+  phys::compute_G0_k_w(H_0, mu, 3, G0_k_w);
 
   // Check spin symmetry and that off-diagonal elements vanish.
   for (int wn = 0; wn < MatsubaraFreqDmn::get_size(); ++wn) {
@@ -216,7 +216,7 @@ TEST_F(ComputeFreeGreensFunctionTest, BilayerLattice) {
                                                           func::dmn_0<MatsubaraFreqDmn>>>
       G0_k_w;
 
-  phys::compute_G0_k_w(H_0, mu, concurrency_, G0_k_w);
+  phys::compute_G0_k_w(H_0, mu, 3, G0_k_w);
 
   // Check spin symmetry and that off-diagonal (in spin) elements vanish.
   for (int wn = 0; wn < MatsubaraFreqDmn::get_size(); ++wn) {

--- a/test/unit/phys/dca_algorithms/compute_greens_function_test.cpp
+++ b/test/unit/phys/dca_algorithms/compute_greens_function_test.cpp
@@ -83,8 +83,8 @@ TEST_F(ComputeGreensFunctionTest, SquareLatticeNoninteracting) {
   const double mu = 0.9;  // chemical potential
 
   // Vanishing self-energy: G = G_0.
-  phys::compute_G0_k_w(H0_k, mu, concurrency_, G0_k_w);
-  phys::compute_G_k_w(H0_k, S_k_w, mu, concurrency_, G_k_w);
+  phys::compute_G0_k_w(H0_k, mu, 1, G0_k_w);
+  phys::compute_G_k_w(H0_k, S_k_w, mu, 2, G_k_w);
 
   for (int i = 0; i < G_k_w.size(); ++i) {
     EXPECT_DOUBLE_EQ(G0_k_w(i).real(), G_k_w(i).real());
@@ -128,8 +128,8 @@ TEST_F(ComputeGreensFunctionTest, BilayerLattice) {
   //
   // Vanishing self-energy: G = G_0
   //
-  phys::compute_G0_k_w(H0_k, mu, concurrency_, G0_k_w);
-  phys::compute_G_k_w(H0_k, S_k_w, mu, concurrency_, G_k_w);
+  phys::compute_G0_k_w(H0_k, mu, 2, G0_k_w);
+  phys::compute_G_k_w(H0_k, S_k_w, mu, 4, G_k_w);
 
   for (int i = 0; i < G_k_w.size(); ++i) {
     EXPECT_DOUBLE_EQ(G0_k_w(i).real(), G_k_w(i).real());
@@ -174,7 +174,7 @@ TEST_F(ComputeGreensFunctionTest, BilayerLattice) {
     }
   }
 
-  phys::compute_G_k_w(H0_k, S_k_w, mu, concurrency_, G_k_w);
+  phys::compute_G_k_w(H0_k, S_k_w, mu, 1, G_k_w);
 
   const double tol = 1.e-14;
   for (int i = 0; i < G_k_w.size(); ++i) {

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/CMakeLists.txt
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/CMakeLists.txt
@@ -19,7 +19,7 @@ dca_add_gtest(tp_accumulator_particle_hole_test
   GTEST_MAIN
   INCLUDE_DIRS ${PROJECT_SOURCE_DIR} ${FFTW_INCLUDE_DIR} ${HDF5_INCLUDE_DIR}
   LIBS function cluster_domains time_and_frequency_domains quantum_domains timer json random
-       enumerations dca_algorithms ${LAPACK_LIBRARIES})
+       enumerations dca_algorithms parallel_stdthread parallel_util ${LAPACK_LIBRARIES})
 
 dca_add_gtest(tp_accumulator_gpu_test
   CUDA

--- a/test/unit/phys/dca_step/lattice_mapping/deconvolution/CMakeLists.txt
+++ b/test/unit/phys/dca_step/lattice_mapping/deconvolution/CMakeLists.txt
@@ -3,5 +3,6 @@
 dca_add_gtest(deconvolution_routines_test
   GTEST_MAIN
   INCLUDE_DIRS ${SIMPLEX_GM_RULE_INCLUDE_DIR} ${FFTW_INCLUDE_DIR}
-  LIBS json function cluster_domains time_and_frequency_domains quantum_domains gaussian_quadrature
-       tetrahedron_mesh coarsegraining enumerations ${LAPACK_LIBRARIES} lapack)
+  LIBS json function cluster_domains  parallel_stdthread parallel_util time_and_frequency_domains
+       quantum_domains gaussian_quadrature tetrahedron_mesh coarsegraining enumerations
+       ${LAPACK_LIBRARIES} lapack)

--- a/test/unit/phys/dca_step/symmetrization/symmetrize_test.cpp
+++ b/test/unit/phys/dca_step/symmetrization/symmetrize_test.cpp
@@ -96,7 +96,7 @@ TEST_F(SymmetrizeTest, G0_w) {
   // Compute the Green's functions in imaginary time.
   function<std::complex<double>, dmn_variadic<NuDmn, NuDmn, KClusterDmn, WDmn>> G0_k_w;
 
-  dca::phys::compute_G0_k_w(H0_, parameters_.get_chemical_potential(), concurrency_, G0_k_w);
+  dca::phys::compute_G0_k_w(H0_, parameters_.get_chemical_potential(), 1, G0_k_w);
 
   function<std::complex<double>, dmn_variadic<NuDmn, NuDmn, RClusterDmn, WDmn>> G0_r_w;
   dca::math::transform::FunctionTransform<KClusterDmn, RClusterDmn>::execute(G0_k_w, G0_r_w);


### PR DESCRIPTION
Latest mpi optimizations for the PACT19 paper.
- perform small computations (phi_r and G0) over threads instead of processes
- Limit the number of processes concurring to the coarse-graining computation. Otherwise, on Summit, the communication time surpasses the computation time.
-  pack small functions and metadata together performing fewer calls to MPI.
-  If no error computation is performed, reduce G4 only on the master process