### PR TITLE
Thread affinity workaround for MacOS

### DIFF
--- a/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
+++ b/include/dca/parallel/no_concurrency/serial_collective_sum.hpp
@@ -78,9 +78,15 @@ public:
                                   func::function<Scalar, Domain>& f_stddev) const {
     f_stddev = Scalar(0);
   }
+
+  template <typename ScalarOrComplex, typename Scalar, class Domain, class CovDomain>
+  void computeCovarianceAndAvg(func::function<ScalarOrComplex, Domain>& /*f*/,
+                               func::function<Scalar, CovDomain>& cov) const {
+    cov = Scalar(0);
+  }
 };
 
-}  // parallel
-}  // dca
+}  // namespace parallel
+}  // namespace dca
 
 #endif  // DCA_PARALLEL_NO_CONCURRENCY_SERIAL_COLLECTIVE_SUM_HPP

--- a/src/parallel/stdthread/thread_pool/affinity.cpp
+++ b/src/parallel/stdthread/thread_pool/affinity.cpp
@@ -17,16 +17,20 @@
 
 #include "dca/parallel/stdthread/thread_pool/affinity.hpp"
 
-#include <pthread.h>
-#include <mach/thread_act.h>
 #include <sched.h>
-#include <sys/sysctl.h>
 
-#include <bitset>
 #include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <stdexcept>
+
+// Includes for MacOS workaround
+#ifdef __APPLE__
+#include <pthread.h>
+#include <mach/thread_act.h>
+#include <sys/sysctl.h>
+#include <bitset>
+#include <limits>
+#endif  // __APPLE__
 
 namespace dca {
 namespace parallel {

--- a/src/parallel/stdthread/thread_pool/thread_pool.cpp
+++ b/src/parallel/stdthread/thread_pool/thread_pool.cpp
@@ -12,8 +12,6 @@
 
 #include "dca/parallel/stdthread/thread_pool/thread_pool.hpp"
 
-#include "mpi.h"
-
 #include "dca/parallel/stdthread/thread_pool/affinity.hpp"
 
 namespace dca {

--- a/test/unit/parallel/stdthread/thread_pool/affinity_test.cpp
+++ b/test/unit/parallel/stdthread/thread_pool/affinity_test.cpp
@@ -46,6 +46,6 @@ TEST(AffinityTest, All) {
   f.get();
 }
 
- TEST(AffinityTest, Count) {
+TEST(AffinityTest, Count) {
   EXPECT_EQ(std::thread::hardware_concurrency(), dca::parallel::get_core_count());
 }


### PR DESCRIPTION
This is a possible fix for #139.
AffinityTest.All still fails on MacOS since I didn't find a way to bind a thread to more the one core.