### PR TITLE
Properly store multiple G4 channel in the parameters.

### DIFF
--- a/include/dca/function/function.hpp
+++ b/include/dca/function/function.hpp
@@ -50,17 +50,26 @@ public:
   function(const std::string& name = default_name_);
 
   // Copy constructor
-  // Constructs the function with the name name and a copy of the elements of other.
+  // Constructs the function with the a copy of elements and name of other.
   // Precondition: The other function has been resetted, if the domain had been initialized after
   //               the other function's construction.
-  function(const function<scalartype, domain>& other, const std::string& name = default_name_);
+  function(const function<scalartype, domain>& other);
+  // Same as above, but with name = 'name'.
+  function(const function<scalartype, domain>& other, const std::string& name) : function(other) {
+    name_ = name;
+  }
 
   // Move constructor
-  // Constructs the function with the name name and the elements of other using move semantics.
+  // Constructs the function with elements and name of other using move semantics.
   // Precondition: The other function has been resetted, if the domain had been initialized after
   //               the other function's construction.
   // Postcondition: The other function is in a non-specified state.
-  function(function<scalartype, domain>&& other, const std::string& name = default_name_);
+  function(function<scalartype, domain>&& other);
+  // Same as above, but with name = 'name'.
+  function(function<scalartype, domain>&& other, const std::string& name)
+      : function(std::move(other)) {
+    name_ = name;
+  }
 
   // Copy assignment operator
   // Replaces the function's elements with a copy of the elements of other.
@@ -191,7 +200,6 @@ public:
   void operator*=(const function<scalartype, domain>& other);
   void operator/=(const function<scalartype, domain>& other);
 
-
   void operator=(scalartype c);
   void operator+=(scalartype c);
   void operator-=(scalartype c);
@@ -267,9 +275,8 @@ function<scalartype, domain>::function(const std::string& name)
 }
 
 template <typename scalartype, class domain>
-function<scalartype, domain>::function(const function<scalartype, domain>& other,
-                                       const std::string& name)
-    : name_(name),
+function<scalartype, domain>::function(const function<scalartype, domain>& other)
+    : name_(other.name_),
       function_type(__PRETTY_FUNCTION__),
       dmn(),
       Nb_elements(dmn.get_size()),
@@ -286,8 +293,8 @@ function<scalartype, domain>::function(const function<scalartype, domain>& other
 }
 
 template <typename scalartype, class domain>
-function<scalartype, domain>::function(function<scalartype, domain>&& other, const std::string& name)
-    : name_(name),
+function<scalartype, domain>::function(function<scalartype, domain>&& other)
+    : name_(std::move(other.name_)),
       function_type(__PRETTY_FUNCTION__),
       dmn(),
       Nb_elements(dmn.get_size()),
@@ -463,7 +470,7 @@ void function<scalartype, domain>::operator*=(const scalartype c) {
 
 template <typename scalartype, class domain>
 void function<scalartype, domain>::operator/=(const scalartype c) {
-    for (int linind = 0; linind < Nb_elements; linind++)
+  for (int linind = 0; linind < Nb_elements; linind++)
     fnc_values[linind] /= c;
 }
 
@@ -623,7 +630,7 @@ void function<scalartype, domain>::unpack(const concurrency_t& concurrency, char
   concurrency.unpack(buffer, buffer_size, position, *this);
 }
 
-}  // func
-}  // dca
+}  // namespace func
+}  // namespace dca
 
 #endif  // DCA_FUNCTION_FUNCTION_HPP

--- a/include/dca/phys/dca_analysis/bse_solver/bse_cluster_solver.hpp
+++ b/include/dca/phys/dca_analysis/bse_solver/bse_cluster_solver.hpp
@@ -233,7 +233,8 @@ void BseClusterSolver<ParametersType, DcaDataType, ScalarType>::load_G_II_0(
       for (int n2 = 0; n2 < b::dmn_size(); n2++) {
         for (int m1 = 0; m1 < b::dmn_size(); m1++) {
           for (int m2 = 0; m2 < b::dmn_size(); m2++) {
-            switch (parameters.get_four_point_type()) {
+            // TODO: allow more than one channel.
+            switch (parameters.get_channels()[0]) {
               case PARTICLE_HOLE_TRANSVERSE: {
                 G_II_0(n1, n2, k, w_vertex, m1, m2, k, w_vertex) =
                     -data_.G_k_w(n1, e_UP, m2, e_UP, k, w) *

--- a/include/dca/phys/dca_analysis/bse_solver/bse_cluster_solver.hpp
+++ b/include/dca/phys/dca_analysis/bse_solver/bse_cluster_solver.hpp
@@ -234,7 +234,7 @@ void BseClusterSolver<ParametersType, DcaDataType, ScalarType>::load_G_II_0(
         for (int m1 = 0; m1 < b::dmn_size(); m1++) {
           for (int m2 = 0; m2 < b::dmn_size(); m2++) {
             // TODO: allow more than one channel.
-            switch (parameters.get_channels()[0]) {
+            switch (parameters.get_four_point_channels()[0]) {
               case PARTICLE_HOLE_TRANSVERSE: {
                 G_II_0(n1, n2, k, w_vertex, m1, m2, k, w_vertex) =
                     -data_.G_k_w(n1, e_UP, m2, e_UP, k, w) *

--- a/include/dca/phys/dca_analysis/bse_solver/bse_lattice_solver.hpp
+++ b/include/dca/phys/dca_analysis/bse_solver/bse_lattice_solver.hpp
@@ -402,7 +402,7 @@ void BseLatticeSolver<ParametersType, DcaDataType, ScalarType>::diagonalizeGamma
     // Diagonalize the symmetric matrix \sqrt{\chi_0}\Gamma\sqrt{\chi_0}.
     // The origin in momentum space has always index = 0.
     // TODO: loop over multiple channels.
-    if (parameters.get_channel()[0] == PARTICLE_PARTICLE_UP_DOWN &&
+    if (parameters.get_channels()[0] == PARTICLE_PARTICLE_UP_DOWN &&
         parameters.get_four_point_momentum_transfer_index() == 0 &&
         parameters.get_four_point_frequency_transfer() == 0) {
       diagonalizeGammaChi0Symmetric();
@@ -619,8 +619,7 @@ void BseLatticeSolver<ParametersType, DcaDataType, ScalarType>::diagonalize_fold
 
   {
     if (concurrency.id() == concurrency.first())
-      std::cout << "\n\n\t diagonalize P_Gamma_chi_0_lattice_P " << dca::util::print_time()
-                << " ...";
+      std::cout << "\n\n\t diagonalize P_Gamma_chi_0_lattice_P " << dca::util::print_time() << " ...";
 
     dca::linalg::Vector<std::complex<ScalarType>, dca::linalg::CPU> L("L (BseLatticeSolver)", M);
 
@@ -925,8 +924,8 @@ void BseLatticeSolver<ParametersType, DcaDataType, ScalarType>::characterizeLead
   }
 }
 
-}  // analysis
-}  // phys
-}  // dca
+}  // namespace analysis
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_ANALYSIS_BSE_SOLVER_BSE_LATTICE_SOLVER_HPP

--- a/include/dca/phys/dca_analysis/bse_solver/bse_lattice_solver.hpp
+++ b/include/dca/phys/dca_analysis/bse_solver/bse_lattice_solver.hpp
@@ -402,7 +402,7 @@ void BseLatticeSolver<ParametersType, DcaDataType, ScalarType>::diagonalizeGamma
     // Diagonalize the symmetric matrix \sqrt{\chi_0}\Gamma\sqrt{\chi_0}.
     // The origin in momentum space has always index = 0.
     // TODO: loop over multiple channels.
-    if (parameters.get_channels()[0] == PARTICLE_PARTICLE_UP_DOWN &&
+    if (parameters.get_four_point_channels()[0] == PARTICLE_PARTICLE_UP_DOWN &&
         parameters.get_four_point_momentum_transfer_index() == 0 &&
         parameters.get_four_point_frequency_transfer() == 0) {
       diagonalizeGammaChi0Symmetric();

--- a/include/dca/phys/dca_analysis/bse_solver/bse_lattice_solver.hpp
+++ b/include/dca/phys/dca_analysis/bse_solver/bse_lattice_solver.hpp
@@ -401,7 +401,8 @@ void BseLatticeSolver<ParametersType, DcaDataType, ScalarType>::diagonalizeGamma
 #ifndef DCA_ANALYSIS_TEST_WITH_FULL_DIAGONALIZATION
     // Diagonalize the symmetric matrix \sqrt{\chi_0}\Gamma\sqrt{\chi_0}.
     // The origin in momentum space has always index = 0.
-    if (parameters.get_four_point_type() == PARTICLE_PARTICLE_UP_DOWN &&
+    // TODO: loop over multiple channels.
+    if (parameters.get_channel()[0] == PARTICLE_PARTICLE_UP_DOWN &&
         parameters.get_four_point_momentum_transfer_index() == 0 &&
         parameters.get_four_point_frequency_transfer() == 0) {
       diagonalizeGammaChi0Symmetric();

--- a/include/dca/phys/dca_analysis/bse_solver/bse_solver.hpp
+++ b/include/dca/phys/dca_analysis/bse_solver/bse_solver.hpp
@@ -101,6 +101,10 @@ BseSolver<ParametersType, DcaDataType>::BseSolver(ParametersType& parameters, Dc
 
       wave_functions_names_("wave-functions-names"),
       harmonics_("harmonics") {
+  if (parameters_.get_four_point_channels().size() != 1) {
+    throw(std::logic_error("The analysis code can analyze exactly one channel."));
+  }
+
   initialize_wave_functions();
 
   {
@@ -227,8 +231,8 @@ void BseSolver<ParametersType, DcaDataType>::calculateSusceptibilities() {
   bse_lattice_solver_.diagonalizeGammaChi0();
 }
 
-}  // analysis
-}  // phys
-}  // dca
+}  // namespace analysis
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_DCA_ANALYSIS_BSE_SOLVER_BSE_SOLVER_HPP

--- a/include/dca/phys/dca_data/dca_data.hpp
+++ b/include/dca/phys/dca_data/dca_data.hpp
@@ -287,7 +287,7 @@ DcaData<Parameters>::DcaData(Parameters& parameters_ref)
   // Reserve storage in advance such that we don't have to copy elements when we fill the vector.
   // We want to avoid copies because function's copy ctor does not copy the name (and because copies
   // are expensive).
-  for (auto channel : parameters_.get_channels()) {
+  for (auto channel : parameters_.get_four_point_channels()) {
     // Allocate memory for G4.
     G4_.emplace_back("G4_" + toString(channel));
     // Allocate memory for error on G4.
@@ -325,7 +325,7 @@ void DcaData<Parameters>::read(std::string filename) {
 
   concurrency_.broadcast_object(Sigma);
 
-  if (parameters_.accumulateG4()) {
+  if (parameters_.isAccumulatingG4()) {
     concurrency_.broadcast_object(G_k_w);
 
     for (auto& G4_channel : G4_)
@@ -348,11 +348,11 @@ void DcaData<Parameters>::read(Reader& reader) {
 
   reader.execute(Sigma);
 
-  if (parameters_.accumulateG4()) {
+  if (parameters_.isAccumulatingG4()) {
     reader.execute(G_k_w);
 
     // Try to read G4 with a legacy name.
-    if (parameters_.get_channels().size() == 1) {
+    if (parameters_.get_four_point_channels().size() == 1) {
       reader.execute("G4", G4_[0]);
     }
 
@@ -454,7 +454,7 @@ void DcaData<Parameters>::write(Writer& writer) {
     writer.execute(G0_r_t_cluster_excluded);
   }
 
-  if (parameters_.accumulateG4()) {
+  if (parameters_.isAccumulatingG4()) {
     if (!(parameters_.dump_cluster_Greens_functions())) {
       writer.execute(G_k_w);
       writer.execute(G_k_w_err_);

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_tp.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_tp.hpp
@@ -205,7 +205,8 @@ void coarsegraining_tp<parameters_type, K_dmn>::execute(
                                                  K_dmn::get_elements(), K_dmn::parameter_type::SHAPE);
   interpolation_matrices<scalar_type, k_HOST, q_plus_Q_dmn>::set_q_idx(Q_ind);
 
-  switch (parameters.get_four_point_type()) {
+  // TODO: allow more than one channel.
+  switch (parameters.get_channels()[0]) {
     case PARTICLE_HOLE_CHARGE:
     case PARTICLE_HOLE_MAGNETIC:
     case PARTICLE_HOLE_TRANSVERSE: {
@@ -233,7 +234,8 @@ void coarsegraining_tp<parameters_type, K_dmn>::execute(
   int Q_ind = domains::cluster_operations::index(parameters.get_four_point_momentum_transfer(),
                                                  K_dmn::get_elements(), K_dmn::parameter_type::SHAPE);
 
-  switch (parameters.get_four_point_type()) {
+  // TODO: allow more than one channel.
+  switch (parameters.get_channels()[0]) {
     case PARTICLE_HOLE_CHARGE:
     case PARTICLE_HOLE_MAGNETIC:
     case PARTICLE_HOLE_TRANSVERSE: {
@@ -620,7 +622,8 @@ void coarsegraining_tp<parameters_type, K_dmn>::find_w1_and_w2(std::vector<doubl
 
   assert(std::abs(w::get_elements()[w1] - elements[w_ind]) < 1.e-6);
 
-  switch (parameters.get_four_point_type()) {
+  // TODO: allow more than one channel.
+  switch (parameters.get_channels()[0]) {
     case PARTICLE_HOLE_CHARGE:
     case PARTICLE_HOLE_MAGNETIC:
     case PARTICLE_HOLE_TRANSVERSE: {
@@ -647,7 +650,8 @@ void coarsegraining_tp<parameters_type, K_dmn>::compute_bubble(
       for (int n2 = 0; n2 < b::dmn_size(); n2++) {
         for (int m1 = 0; m1 < b::dmn_size(); m1++) {
           for (int m2 = 0; m2 < b::dmn_size(); m2++) {
-            switch (parameters.get_four_point_type()) {
+            // TODO: allow more than one channel.
+            switch (parameters.get_channels()[0]) {
               case PARTICLE_HOLE_TRANSVERSE:
                 bubble(n1, n2, m1, m2, q_ind) +=
                     G_q(n1, e_UP, m2, e_UP, q_ind) * G_q_plus_Q(n2, e_UP, m1, e_UP, q_ind);
@@ -680,7 +684,8 @@ void coarsegraining_tp<parameters_type, K_dmn>::compute_bubble(
 
 template <typename parameters_type, typename K_dmn>
 double coarsegraining_tp<parameters_type, K_dmn>::get_integration_factor() {
-  switch (parameters.get_four_point_type()) {
+  // TODO: allow more than one channel.
+  switch (parameters.get_channels()[0]) {
     case PARTICLE_HOLE_TRANSVERSE:
       return -1.;
       break;

--- a/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_tp.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/coarsegraining/coarsegraining_tp.hpp
@@ -206,7 +206,7 @@ void coarsegraining_tp<parameters_type, K_dmn>::execute(
   interpolation_matrices<scalar_type, k_HOST, q_plus_Q_dmn>::set_q_idx(Q_ind);
 
   // TODO: allow more than one channel.
-  switch (parameters.get_channels()[0]) {
+  switch (parameters.get_four_point_channels()[0]) {
     case PARTICLE_HOLE_CHARGE:
     case PARTICLE_HOLE_MAGNETIC:
     case PARTICLE_HOLE_TRANSVERSE: {
@@ -235,7 +235,7 @@ void coarsegraining_tp<parameters_type, K_dmn>::execute(
                                                  K_dmn::get_elements(), K_dmn::parameter_type::SHAPE);
 
   // TODO: allow more than one channel.
-  switch (parameters.get_channels()[0]) {
+  switch (parameters.get_four_point_channels()[0]) {
     case PARTICLE_HOLE_CHARGE:
     case PARTICLE_HOLE_MAGNETIC:
     case PARTICLE_HOLE_TRANSVERSE: {
@@ -623,7 +623,7 @@ void coarsegraining_tp<parameters_type, K_dmn>::find_w1_and_w2(std::vector<doubl
   assert(std::abs(w::get_elements()[w1] - elements[w_ind]) < 1.e-6);
 
   // TODO: allow more than one channel.
-  switch (parameters.get_channels()[0]) {
+  switch (parameters.get_four_point_channels()[0]) {
     case PARTICLE_HOLE_CHARGE:
     case PARTICLE_HOLE_MAGNETIC:
     case PARTICLE_HOLE_TRANSVERSE: {
@@ -651,7 +651,7 @@ void coarsegraining_tp<parameters_type, K_dmn>::compute_bubble(
         for (int m1 = 0; m1 < b::dmn_size(); m1++) {
           for (int m2 = 0; m2 < b::dmn_size(); m2++) {
             // TODO: allow more than one channel.
-            switch (parameters.get_channels()[0]) {
+            switch (parameters.get_four_point_channels()[0]) {
               case PARTICLE_HOLE_TRANSVERSE:
                 bubble(n1, n2, m1, m2, q_ind) +=
                     G_q(n1, e_UP, m2, e_UP, q_ind) * G_q_plus_Q(n2, e_UP, m1, e_UP, q_ind);
@@ -685,7 +685,7 @@ void coarsegraining_tp<parameters_type, K_dmn>::compute_bubble(
 template <typename parameters_type, typename K_dmn>
 double coarsegraining_tp<parameters_type, K_dmn>::get_integration_factor() {
   // TODO: allow more than one channel.
-  switch (parameters.get_channels()[0]) {
+  switch (parameters.get_four_point_channels()[0]) {
     case PARTICLE_HOLE_TRANSVERSE:
       return -1.;
       break;

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_accumulator.hpp
@@ -244,7 +244,7 @@ void CtauxAccumulator<device_t, Parameters, Data>::initialize(int dca_iteration)
 
   MC_accumulator_data::initialize(dca_iteration);
 
-  if (dca_iteration == parameters_.get_dca_iterations() - 1 && parameters_.accumulateG4())
+  if (dca_iteration == parameters_.get_dca_iterations() - 1 && parameters_.isAccumulatingG4())
     perform_tp_accumulation_ = true;
 
   for (int i = 0; i < visited_expansion_order_k.size(); i++)

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -280,7 +280,7 @@ double CtauxClusterSolver<device_t, Parameters, Data>::finalize(dca_info_struct_
     }
   }
 
-  if (compute_jack_knife_ && parameters_.accumulateG4()) {
+  if (compute_jack_knife_ && parameters_.isAccumulatingG4()) {
     for (std::size_t channel = 0; channel < data_.get_G4_error().size(); ++channel)
       data_.get_G4_error()[channel] = concurrency_.jackknifeError(data_.get_G4()[channel], true);
   }
@@ -392,7 +392,7 @@ void CtauxClusterSolver<device_t, Parameters, Data>::computeErrorBars() {
   concurrency_.average_and_compute_stddev(G_k_w_new, data_.get_G_k_w_stdv());
 
   // sum G4
-  if (dca_iteration_ == parameters_.get_dca_iterations() - 1 && parameters_.accumulateG4()) {
+  if (dca_iteration_ == parameters_.get_dca_iterations() - 1 && parameters_.isAccumulatingG4()) {
     if (concurrency_.id() == concurrency_.first())
       std::cout << "\n\t\t compute-error-bars on G4\t" << dca::util::print_time() << "\n\n";
 
@@ -418,7 +418,7 @@ void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
 
   const double local_time = total_time_;
   const bool accumulate_g4 =
-      parameters_.accumulateG4() && dca_iteration_ == parameters_.get_dca_iterations() - 1;
+      parameters_.isAccumulatingG4() && dca_iteration_ == parameters_.get_dca_iterations() - 1;
 
   {
     Profiler profiler("QMC-collectives", "CT-AUX solver", __LINE__);

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -281,7 +281,7 @@ double CtauxClusterSolver<device_t, Parameters, Data>::finalize(dca_info_struct_
   }
 
   if (compute_jack_knife_ && parameters_.accumulateG4()) {
-    for (std::size_t channel = 0; channel < parameters_.numG4Channels(); ++channel)
+    for (std::size_t channel = 0; channel < data_.get_G4_error().size(); ++channel)
       data_.get_G4_error()[channel] = concurrency_.jackknifeError(data_.get_G4()[channel], true);
   }
 
@@ -446,7 +446,7 @@ void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
 
     // sum G4
     if (accumulate_g4) {
-      for (int channel = 0; channel < parameters_.numG4Channels(); ++channel) {
+      for (int channel = 0; channel < data_.get_G4().size(); ++channel) {
         auto& G4 = data_.get_G4()[channel];
         G4 = accumulator_.get_sign_times_G4()[channel];
         if (compute_jack_knife_)
@@ -464,9 +464,9 @@ void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
 
   M_r_w_ /= accumulated_sign_;
   M_r_w_squared_ /= accumulated_sign_;
-  if(accumulate_g4) {
-      for (auto &G4 : data_.get_G4())
-          G4 /= accumulated_sign_ * parameters_.get_beta() * parameters_.get_beta();
+  if (accumulate_g4) {
+    for (auto& G4 : data_.get_G4())
+      G4 /= accumulated_sign_ * parameters_.get_beta() * parameters_.get_beta();
   }
 
   if (parameters_.additional_time_measurements()) {

--- a/include/dca/phys/dca_step/cluster_solver/exact_diagonalization_advanced/ed_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/exact_diagonalization_advanced/ed_cluster_solver.hpp
@@ -172,7 +172,7 @@ void EDClusterSolver<device_t, parameters_type, MOMS_type>::execute() {
 
     sp_Greens_function_obj.compute_all_sp_functions_slow(MOMS_imag, MOMS_real, false);
 
-    if (parameters.accumulateG4()) {
+    if (parameters.isAccumulatingG4()) {
       if (concurrency.id() == concurrency.first()) {
         std::cout << "\n" << dca::util::print_time() << "\n" << std::endl;
       }
@@ -202,7 +202,7 @@ void EDClusterSolver<device_t, parameters_type, MOMS_type>::execute() {
 
   sp_Greens_function_obj.compute_all_sp_functions_slow(MOMS_imag, MOMS_real, true);
 
-  if (parameters.accumulateG4()) {
+  if (parameters.isAccumulatingG4()) {
     if (concurrency.id() == concurrency.first()) {
       std::cout << "\n" << dca::util::print_time() << "\n" << std::endl;
     }
@@ -274,7 +274,7 @@ void EDClusterSolver<device_t, parameters_type, MOMS_type>::write(std::string fi
     MOMS_imag.write(writer);
     MOMS_real.write(writer);
 
-    if (parameters.accumulateG4()) {
+    if (parameters.isAccumulatingG4()) {
       std::cout << "\n\n\t\t start writing tp-Greens-function\n\n";
       tp_Greens_function_obj.write(writer);
     }
@@ -295,7 +295,7 @@ void EDClusterSolver<device_t, parameters_type, MOMS_type>::write(std::string fi
     std::cout << "\n\n\t\t start writing MOMS_real\n\n";
     MOMS_real.write(writer);
 
-    if (parameters.accumulateG4()) {
+    if (parameters.isAccumulatingG4()) {
       std::cout << "\n\n\t\t start writing tp-Greens-function\n\n";
       tp_Greens_function_obj.write(writer);
     }

--- a/include/dca/phys/dca_step/cluster_solver/exact_diagonalization_advanced/ed_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/exact_diagonalization_advanced/ed_cluster_solver.hpp
@@ -172,7 +172,7 @@ void EDClusterSolver<device_t, parameters_type, MOMS_type>::execute() {
 
     sp_Greens_function_obj.compute_all_sp_functions_slow(MOMS_imag, MOMS_real, false);
 
-    if (parameters.get_four_point_type() != NONE) {
+    if (parameters.accumulateG4()) {
       if (concurrency.id() == concurrency.first()) {
         std::cout << "\n" << dca::util::print_time() << "\n" << std::endl;
       }
@@ -202,7 +202,7 @@ void EDClusterSolver<device_t, parameters_type, MOMS_type>::execute() {
 
   sp_Greens_function_obj.compute_all_sp_functions_slow(MOMS_imag, MOMS_real, true);
 
-  if (parameters.get_four_point_type() != NONE) {
+  if (parameters.accumulateG4()) {
     if (concurrency.id() == concurrency.first()) {
       std::cout << "\n" << dca::util::print_time() << "\n" << std::endl;
     }
@@ -274,7 +274,7 @@ void EDClusterSolver<device_t, parameters_type, MOMS_type>::write(std::string fi
     MOMS_imag.write(writer);
     MOMS_real.write(writer);
 
-    if (parameters.get_four_point_type() != NONE) {
+    if (parameters.accumulateG4()) {
       std::cout << "\n\n\t\t start writing tp-Greens-function\n\n";
       tp_Greens_function_obj.write(writer);
     }
@@ -295,7 +295,7 @@ void EDClusterSolver<device_t, parameters_type, MOMS_type>::write(std::string fi
     std::cout << "\n\n\t\t start writing MOMS_real\n\n";
     MOMS_real.write(writer);
 
-    if (parameters.get_four_point_type() != NONE) {
+    if (parameters.accumulateG4()) {
       std::cout << "\n\n\t\t start writing tp-Greens-function\n\n";
       tp_Greens_function_obj.write(writer);
     }

--- a/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator.hpp
@@ -185,7 +185,7 @@ TpAccumulator<Parameters, linalg::CPU>::TpAccumulator(
       thread_id_(thread_id),
       multiple_accumulators_(pars.get_accumulators() > 1),
       beta_(pars.get_beta()),
-      channels_(pars.get_channels()),
+      channels_(pars.get_four_point_channels()),
       extension_index_offset_((WTpExtDmn::dmn_size() - WTpDmn::dmn_size()) / 2),
       n_pos_frqs_(WTpExtPosDmn::dmn_size()),
       G0_M_(n_bands_),

--- a/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator.hpp
@@ -136,7 +136,7 @@ protected:
   float computeM(const std::array<linalg::Matrix<double, linalg::CPU>, 2>& M_pair,
                  const std::array<Configuration, 2>& configs);
 
-  double updateG4(TpGreensFunction& G4_channel);
+  double updateG4(int channel_id);
 
   void inline updateG4Atomic(Complex* G4_ptr, int s_a, int k1_a, int k2_a, int w1_a, int w2_a,
                              int s_b, int k1_b, int k2_b, int w1_b, int w2_b, Real alpha,
@@ -163,6 +163,7 @@ protected:
   SpGreenFunction G_;
 
   std::vector<TpGreensFunction> G4_;
+  std::vector<FourPointType> channels_;
 
   func::function<Complex, func::dmn_variadic<BDmn, BDmn, SDmn, KDmn, WTpExtDmn>> G0_;
 
@@ -184,6 +185,7 @@ TpAccumulator<Parameters, linalg::CPU>::TpAccumulator(
       thread_id_(thread_id),
       multiple_accumulators_(pars.get_accumulators() > 1),
       beta_(pars.get_beta()),
+      channels_(pars.get_channels()),
       extension_index_offset_((WTpExtDmn::dmn_size() - WTpDmn::dmn_size()) / 2),
       n_pos_frqs_(WTpExtPosDmn::dmn_size()),
       G0_M_(n_bands_),
@@ -196,32 +198,8 @@ TpAccumulator<Parameters, linalg::CPU>::TpAccumulator(
   // Reserve storage in advance such that we don't have to copy elements when we fill the vector.
   // We want to avoid copies because function's copy ctor does not copy the name (and because copies
   // are expensive).
-  G4_.reserve(pars.numG4Channels());
-
-  // Ensure backward compatibility.
-  if (pars.get_four_point_type() != NONE) {
-    G4_.emplace_back("G4_" + toString(pars.get_four_point_type()));
-  }
-
-  // Check which four point types to accumulate.
-  else {
-    if (pars.accumulateG4ParticleHoleTransverse())
-      G4_.emplace_back("G4_" + toString(PARTICLE_HOLE_TRANSVERSE));
-
-    if (pars.accumulateG4ParticleHoleMagnetic())
-      G4_.emplace_back("G4_" + toString(PARTICLE_HOLE_MAGNETIC));
-
-    if (pars.accumulateG4ParticleHoleCharge())
-      G4_.emplace_back("G4_" + toString(PARTICLE_HOLE_CHARGE));
-
-    if (pars.accumulateG4ParticleHoleLongitudinalUpUp())
-      G4_.emplace_back("G4_" + toString(PARTICLE_HOLE_LONGITUDINAL_UP_UP));
-
-    if (pars.accumulateG4ParticleHoleLongitudinalUpDown())
-      G4_.emplace_back("G4_" + toString(PARTICLE_HOLE_LONGITUDINAL_UP_DOWN));
-
-    if (pars.accumulateG4ParticleParticleUpDown())
-      G4_.emplace_back("G4_" + toString(PARTICLE_PARTICLE_UP_DOWN));
+  for (auto channel : channels_) {
+    G4_.emplace_back("G4_" + toString(channel));
   }
 }
 
@@ -261,8 +239,8 @@ double TpAccumulator<Parameters, linalg::CPU>::accumulate(
   gflops += computeM(M_pair, configs);
   gflops += computeG();
 
-  for (auto& G4_channel : G4_)
-    gflops += updateG4(G4_channel);
+  for (int channel_id = 0; channel_id < G4_.size(); ++channel_id)
+    gflops += updateG4(channel_id);
 
   return gflops;
 }
@@ -402,7 +380,7 @@ void TpAccumulator<Parameters, linalg::CPU>::getGMultiband(int s, int k1, int k2
 }
 
 template <class Parameters>
-double TpAccumulator<Parameters, linalg::CPU>::updateG4(TpGreensFunction& G4) {
+double TpAccumulator<Parameters, linalg::CPU>::updateG4(const int channel_id) {
   // G4 is stored with the following band convention:
   // b1 ------------------------ b3
   //        |           |
@@ -429,9 +407,8 @@ double TpAccumulator<Parameters, linalg::CPU>::updateG4(TpGreensFunction& G4) {
   const auto& exchange_frq = domains::FrequencyExchangeDomain::get_elements();
   const auto& exchange_mom = domains::MomentumExchangeDomain::get_elements();
 
-  // Strip "G4_" prefix from G4 name and convert to FourPointType.
-  const std::string channel_str = G4.get_name().substr(3, G4.get_name().size() - 3);
-  const FourPointType channel = stringToFourPointType(channel_str);
+  auto& G4 = G4_[channel_id];
+  auto channel = channels_[channel_id];
 
   switch (channel) {
     case PARTICLE_HOLE_TRANSVERSE:
@@ -451,7 +428,7 @@ double TpAccumulator<Parameters, linalg::CPU>::updateG4(TpGreensFunction& G4) {
                                    momentum_sum(k1, k_ex), w_plus_w_ex(w2, w_ex),
                                    w_plus_w_ex(w1, w_ex), -sign_over_2, true);
                 }
-            }
+        }
       }
       flops += n_loops * 2 * flops_update_atomic;
       break;

--- a/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu.hpp
@@ -158,6 +158,7 @@ private:
   constexpr static int n_ndft_streams_ = config::AccumulationOptions::memory_savings ? 1 : 2;
 
   using BaseClass::beta_;
+  using BaseClass::channels_;
   using BaseClass::extension_index_offset_;
   using BaseClass::G0_ptr_;
   using BaseClass::G4_;
@@ -398,10 +399,8 @@ float TpAccumulator<Parameters, linalg::GPU>::updateG4(const std::size_t channel
   //  TODO: set stream only if this thread gets exclusive access to G4.
   //  get_G4().setStream(streams_[0]);
 
-  // Strip "G4_" prefix from G4 name and convert to FourPointType.
-  const std::string channel_str =
-      G4_[channel_index].get_name().substr(3, G4_[channel_index].get_name().size() - 3);
-  const FourPointType channel = stringToFourPointType(channel_str);
+
+  const FourPointType channel = channels_[channel_index];
 
   switch (channel) {
     case PARTICLE_HOLE_TRANSVERSE:

--- a/include/dca/phys/dca_step/symmetrization/diagrammatic_symmetries.hpp
+++ b/include/dca/phys/dca_step/symmetrization/diagrammatic_symmetries.hpp
@@ -253,7 +253,7 @@ void diagrammatic_symmetries<parameters_type>::execute(
     }
 
     // TODO: allow multiple channels.
-    switch (parameters.get_channels()[0]) {
+    switch (parameters.get_four_point_channels()[0]) {
       case PARTICLE_HOLE_TRANSVERSE:
         symmetrize_over_pi_rotations_ph(G);
         break;

--- a/include/dca/phys/dca_step/symmetrization/diagrammatic_symmetries.hpp
+++ b/include/dca/phys/dca_step/symmetrization/diagrammatic_symmetries.hpp
@@ -253,7 +253,7 @@ void diagrammatic_symmetries<parameters_type>::execute(
     }
 
     // TODO: allow multiple channels.
-    switch (parameters.get_channel()[0]) {
+    switch (parameters.get_channels()[0]) {
       case PARTICLE_HOLE_TRANSVERSE:
         symmetrize_over_pi_rotations_ph(G);
         break;

--- a/include/dca/phys/dca_step/symmetrization/diagrammatic_symmetries.hpp
+++ b/include/dca/phys/dca_step/symmetrization/diagrammatic_symmetries.hpp
@@ -252,7 +252,8 @@ void diagrammatic_symmetries<parameters_type>::execute(
       // cout << "\n\t q_vec is NOT reciprocal !!! \n\n";
     }
 
-    switch (parameters.get_four_point_type()) {
+    // TODO: allow multiple channels.
+    switch (parameters.get_channel()[0]) {
       case PARTICLE_HOLE_TRANSVERSE:
         symmetrize_over_pi_rotations_ph(G);
         break;

--- a/include/dca/phys/four_point_type.hpp
+++ b/include/dca/phys/four_point_type.hpp
@@ -6,6 +6,7 @@
 // See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Urs R. Haehner (haehneru@itp.phys.ethz.ch)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This file defines the types of four point functions.
 
@@ -19,7 +20,6 @@ namespace phys {
 // dca::phys::
 
 enum FourPointType : int {
-  NONE,
   PARTICLE_HOLE_TRANSVERSE,
   PARTICLE_HOLE_MAGNETIC,
   PARTICLE_HOLE_CHARGE,
@@ -32,7 +32,7 @@ FourPointType stringToFourPointType(const std::string& name);
 
 std::string toString(const FourPointType type);
 
-}  // phys
-}  // dca
+}  // namespace phys
+}  // namespace dca
 
 #endif  // DCA_PHYS_FOUR_POINT_TYPE_HPP

--- a/include/dca/phys/parameters/four_point_parameters.hpp
+++ b/include/dca/phys/parameters/four_point_parameters.hpp
@@ -7,6 +7,7 @@
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
 //         Urs R. Haehner (haehneru@itp.phys.ethz.ch)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This class reads, stores, and writes parameters for measurements of four-point functions.
 //
@@ -16,6 +17,7 @@
 #ifndef DCA_PHYS_PARAMETERS_FOUR_POINT_PARAMETERS_HPP
 #define DCA_PHYS_PARAMETERS_FOUR_POINT_PARAMETERS_HPP
 
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -37,14 +39,7 @@ public:
                               domains::BRILLOUIN_ZONE>;
 
   FourPointParameters()
-      : four_point_type_(NONE),
-        ph_transverse_(false),
-        ph_magnetic_(false),
-        ph_charge_(false),
-        ph_longitudinal_up_up_(false),
-        ph_longitudinal_up_down_(false),
-        pp_up_down_(false),
-        four_point_momentum_transfer_input_(lattice_dimension, 0.),
+      : four_point_momentum_transfer_input_(lattice_dimension, 0.),
         four_point_frequency_transfer_(0),
         compute_all_transfers_(false) {}
 
@@ -58,68 +53,21 @@ public:
   template <typename ReaderOrWriter>
   void readWrite(ReaderOrWriter& reader_or_writer);
 
-  // Returns true, if any G4 channel should be accumulated. Otherwise returns false.
-  bool accumulateG4() const {
-    return four_point_type_ != NONE || ph_transverse_ || ph_magnetic_ || ph_charge_ ||
-           ph_longitudinal_up_up_ || ph_longitudinal_up_down_ || pp_up_down_;
-  }
-
   // Returns the number of channels of G4 to accumulate.
-  std::size_t numG4Channels() const {
-    if (four_point_type_ != NONE)
-      return 1;
-    else
-      return ph_transverse_ + ph_magnetic_ + ph_charge_ + ph_longitudinal_up_up_ +
-             ph_longitudinal_up_down_ + pp_up_down_;
+  const auto& get_channels() const {
+    return channels_;
   }
 
-  FourPointType get_four_point_type() const {
-    return four_point_type_;
-  }
-  void set_four_point_type(FourPointType type) {
-    four_point_type_ = type;
+  // Returns true if at least one channel is accumulated.
+  bool accumulateG4() const {
+    return channels_.size();
   }
 
-  bool accumulateG4ParticleHoleTransverse() const {
-    return ph_transverse_;
+  void set_channel(FourPointType type) {
+    channels_ = std::vector<FourPointType>{type};
   }
-  void accumulateG4ParticleHoleTransverse(const bool accumulate_channel) {
-    ph_transverse_ = accumulate_channel;
-  }
-
-  bool accumulateG4ParticleHoleMagnetic() const {
-    return ph_magnetic_;
-  }
-  void accumulateG4ParticleHoleMagnetic(const bool accumulate_channel) {
-    ph_magnetic_ = accumulate_channel;
-  }
-
-  bool accumulateG4ParticleHoleCharge() const {
-    return ph_charge_;
-  }
-  void accumulateG4ParticleHoleCharge(const bool accumulate_channel) {
-    ph_charge_ = accumulate_channel;
-  }
-
-  bool accumulateG4ParticleHoleLongitudinalUpUp() const {
-    return ph_longitudinal_up_up_;
-  }
-  void accumulateG4ParticleHoleLongitudinalUpUp(const bool accumulate_channel) {
-    ph_longitudinal_up_up_ = accumulate_channel;
-  }
-
-  bool accumulateG4ParticleHoleLongitudinalUpDown() const {
-    return ph_longitudinal_up_down_;
-  }
-  void accumulateG4ParticleHoleLongitudinalUpDown(const bool accumulate_channel) {
-    ph_longitudinal_up_down_ = accumulate_channel;
-  }
-
-  bool accumulateG4ParticleParticleUpDown() const {
-    return pp_up_down_;
-  }
-  void accumulateG4ParticleParticleUpDown(const bool accumulate_channel) {
-    pp_up_down_ = accumulate_channel;
+  void set_channels(const std::vector<FourPointType>& channels) {
+    channels_ = channels;
   }
 
   const std::vector<double>& get_four_point_momentum_transfer_input() const {
@@ -159,17 +107,7 @@ public:
   }
 
 private:
-  // There is no utility to communicate enumerations over mpi, so four_point_type_ is stored
-  // as an int rather than a FourPointType.
-  FourPointType four_point_type_;
-
-  bool ph_transverse_;
-  bool ph_magnetic_;
-  bool ph_charge_;
-  bool ph_longitudinal_up_up_;
-  bool ph_longitudinal_up_down_;
-  bool pp_up_down_;
-
+  std::vector<FourPointType> channels_;
   std::vector<double> four_point_momentum_transfer_input_;
   int four_point_frequency_transfer_;
   bool compute_all_transfers_;
@@ -180,13 +118,7 @@ template <typename Concurrency>
 int FourPointParameters<lattice_dimension>::getBufferSize(const Concurrency& concurrency) const {
   int buffer_size = 0;
 
-  buffer_size += concurrency.get_buffer_size(four_point_type_);
-  buffer_size += concurrency.get_buffer_size(ph_transverse_);
-  buffer_size += concurrency.get_buffer_size(ph_magnetic_);
-  buffer_size += concurrency.get_buffer_size(ph_charge_);
-  buffer_size += concurrency.get_buffer_size(ph_longitudinal_up_up_);
-  buffer_size += concurrency.get_buffer_size(ph_longitudinal_up_down_);
-  buffer_size += concurrency.get_buffer_size(pp_up_down_);
+  buffer_size += concurrency.get_buffer_size(channels_);
   buffer_size += concurrency.get_buffer_size(four_point_momentum_transfer_input_);
   buffer_size += concurrency.get_buffer_size(four_point_frequency_transfer_);
   buffer_size += concurrency.get_buffer_size(compute_all_transfers_);
@@ -198,13 +130,7 @@ template <int lattice_dimension>
 template <typename Concurrency>
 void FourPointParameters<lattice_dimension>::pack(const Concurrency& concurrency, char* buffer,
                                                   int buffer_size, int& position) const {
-  concurrency.pack(buffer, buffer_size, position, four_point_type_);
-  concurrency.pack(buffer, buffer_size, position, ph_transverse_);
-  concurrency.pack(buffer, buffer_size, position, ph_magnetic_);
-  concurrency.pack(buffer, buffer_size, position, ph_charge_);
-  concurrency.pack(buffer, buffer_size, position, ph_longitudinal_up_up_);
-  concurrency.pack(buffer, buffer_size, position, ph_longitudinal_up_down_);
-  concurrency.pack(buffer, buffer_size, position, pp_up_down_);
+  concurrency.pack(buffer, buffer_size, position, channels_);
   concurrency.pack(buffer, buffer_size, position, four_point_momentum_transfer_input_);
   concurrency.pack(buffer, buffer_size, position, four_point_frequency_transfer_);
   concurrency.pack(buffer, buffer_size, position, compute_all_transfers_);
@@ -214,13 +140,7 @@ template <int lattice_dimension>
 template <typename Concurrency>
 void FourPointParameters<lattice_dimension>::unpack(const Concurrency& concurrency, char* buffer,
                                                     int buffer_size, int& position) {
-  concurrency.unpack(buffer, buffer_size, position, four_point_type_);
-  concurrency.unpack(buffer, buffer_size, position, ph_transverse_);
-  concurrency.unpack(buffer, buffer_size, position, ph_magnetic_);
-  concurrency.unpack(buffer, buffer_size, position, ph_charge_);
-  concurrency.unpack(buffer, buffer_size, position, ph_longitudinal_up_up_);
-  concurrency.unpack(buffer, buffer_size, position, ph_longitudinal_up_down_);
-  concurrency.unpack(buffer, buffer_size, position, pp_up_down_);
+  concurrency.unpack(buffer, buffer_size, position, channels_);
   concurrency.unpack(buffer, buffer_size, position, four_point_momentum_transfer_input_);
   concurrency.unpack(buffer, buffer_size, position, four_point_frequency_transfer_);
   concurrency.unpack(buffer, buffer_size, position, compute_all_transfers_);
@@ -229,61 +149,46 @@ void FourPointParameters<lattice_dimension>::unpack(const Concurrency& concurren
 template <int lattice_dimension>
 template <typename ReaderOrWriter>
 void FourPointParameters<lattice_dimension>::readWrite(ReaderOrWriter& reader_or_writer) {
+  auto try_to_execute = [&](const std::string& name, auto& obj) {
+    try {
+      reader_or_writer.execute(name, obj);
+    }
+    catch (const std::exception& r_e) {
+    }
+  };
+
   try {
     reader_or_writer.open_group("four-point");
 
-    std::string four_point_name = toString(four_point_type_);
-    try {
-      reader_or_writer.execute("type", four_point_name);
-      four_point_type_ = stringToFourPointType(four_point_name);
+    const std::string channel_par_name = "channels";
+
+    std::vector<std::string> channel_names;
+    if (reader_or_writer.is_reader()) {
+      // Support legacy input files specifying a single channel name.
+      std::string four_point_name = "NONE";
+      try_to_execute("type", four_point_name);
+      if (four_point_name != "NONE")
+        channels_.push_back(stringToFourPointType(four_point_name));
+
+      try_to_execute(channel_par_name, channel_names);
+      for (auto name : channel_names)
+        channels_.push_back(stringToFourPointType(name));
+
+      // Remove duplicates
+      std::sort(channels_.begin(), channels_.end());
+      channels_.erase(std::unique(channels_.begin(), channels_.end()), channels_.end());
     }
-    catch (const std::exception& r_e) {
+
+    else {  // is writer.
+      for (auto channel : channels_)
+        channel_names.push_back(toString(channel));
+
+      try_to_execute(channel_par_name, channel_names);
     }
-    try {
-      reader_or_writer.execute("particle-hole-transverse", ph_transverse_);
-    }
-    catch (const std::exception& r_e) {
-    }
-    try {
-      reader_or_writer.execute("particle-hole-magnetic", ph_magnetic_);
-    }
-    catch (const std::exception& r_e) {
-    }
-    try {
-      reader_or_writer.execute("particle-hole-charge", ph_charge_);
-    }
-    catch (const std::exception& r_e) {
-    }
-    try {
-      reader_or_writer.execute("particle-hole-longitudinal-up-up", ph_longitudinal_up_up_);
-    }
-    catch (const std::exception& r_e) {
-    }
-    try {
-      reader_or_writer.execute("particle-hole-longitudinal-up-down", ph_longitudinal_up_down_);
-    }
-    catch (const std::exception& r_e) {
-    }
-    try {
-      reader_or_writer.execute("particle-particle-up-down", pp_up_down_);
-    }
-    catch (const std::exception& r_e) {
-    }
-    try {
-      reader_or_writer.execute("momentum-transfer", four_point_momentum_transfer_input_);
-    }
-    catch (const std::exception& r_e) {
-    }
-    try {
-      reader_or_writer.execute("frequency-transfer", four_point_frequency_transfer_);
-    }
-    catch (const std::exception& r_e) {
-    }
-    try {
-      reader_or_writer.execute("compute-all-transfers", compute_all_transfers_);
-    }
-    catch (const std::exception& r_e) {
-    }
+
+    try_to_execute("momentum-transfer", four_point_momentum_transfer_input_);
+    try_to_execute("frequency-transfer", four_point_frequency_transfer_);
+    try_to_execute("compute-all-transfers", compute_all_transfers_);
 
     reader_or_writer.close_group();
   }

--- a/include/dca/phys/parameters/four_point_parameters.hpp
+++ b/include/dca/phys/parameters/four_point_parameters.hpp
@@ -53,21 +53,19 @@ public:
   template <typename ReaderOrWriter>
   void readWrite(ReaderOrWriter& reader_or_writer);
 
-  // Returns the number of channels of G4 to accumulate.
-  const auto& get_channels() const {
-    return channels_;
+  const auto& get_four_point_channels() const {
+    return four_point_channels_;
   }
 
-  // Returns true if at least one channel is accumulated.
-  bool accumulateG4() const {
-    return channels_.size();
+  bool isAccumulatingG4() const {
+    return four_point_channels_.size();
   }
 
-  void set_channel(FourPointType type) {
-    channels_ = std::vector<FourPointType>{type};
+  void set_four_point_channel(FourPointType type) {
+    four_point_channels_ = std::vector<FourPointType>{type};
   }
-  void set_channels(const std::vector<FourPointType>& channels) {
-    channels_ = channels;
+  void set_four_point_channels(const std::vector<FourPointType>& channels) {
+    four_point_channels_ = channels;
   }
 
   const std::vector<double>& get_four_point_momentum_transfer_input() const {
@@ -107,7 +105,7 @@ public:
   }
 
 private:
-  std::vector<FourPointType> channels_;
+  std::vector<FourPointType> four_point_channels_;
   std::vector<double> four_point_momentum_transfer_input_;
   int four_point_frequency_transfer_;
   bool compute_all_transfers_;
@@ -118,7 +116,7 @@ template <typename Concurrency>
 int FourPointParameters<lattice_dimension>::getBufferSize(const Concurrency& concurrency) const {
   int buffer_size = 0;
 
-  buffer_size += concurrency.get_buffer_size(channels_);
+  buffer_size += concurrency.get_buffer_size(four_point_channels_);
   buffer_size += concurrency.get_buffer_size(four_point_momentum_transfer_input_);
   buffer_size += concurrency.get_buffer_size(four_point_frequency_transfer_);
   buffer_size += concurrency.get_buffer_size(compute_all_transfers_);
@@ -130,7 +128,7 @@ template <int lattice_dimension>
 template <typename Concurrency>
 void FourPointParameters<lattice_dimension>::pack(const Concurrency& concurrency, char* buffer,
                                                   int buffer_size, int& position) const {
-  concurrency.pack(buffer, buffer_size, position, channels_);
+  concurrency.pack(buffer, buffer_size, position, four_point_channels_);
   concurrency.pack(buffer, buffer_size, position, four_point_momentum_transfer_input_);
   concurrency.pack(buffer, buffer_size, position, four_point_frequency_transfer_);
   concurrency.pack(buffer, buffer_size, position, compute_all_transfers_);
@@ -140,7 +138,7 @@ template <int lattice_dimension>
 template <typename Concurrency>
 void FourPointParameters<lattice_dimension>::unpack(const Concurrency& concurrency, char* buffer,
                                                     int buffer_size, int& position) {
-  concurrency.unpack(buffer, buffer_size, position, channels_);
+  concurrency.unpack(buffer, buffer_size, position, four_point_channels_);
   concurrency.unpack(buffer, buffer_size, position, four_point_momentum_transfer_input_);
   concurrency.unpack(buffer, buffer_size, position, four_point_frequency_transfer_);
   concurrency.unpack(buffer, buffer_size, position, compute_all_transfers_);
@@ -168,19 +166,19 @@ void FourPointParameters<lattice_dimension>::readWrite(ReaderOrWriter& reader_or
       std::string four_point_name = "NONE";
       try_to_execute("type", four_point_name);
       if (four_point_name != "NONE")
-        channels_.push_back(stringToFourPointType(four_point_name));
+        four_point_channels_.push_back(stringToFourPointType(four_point_name));
 
       try_to_execute(channel_par_name, channel_names);
       for (auto name : channel_names)
-        channels_.push_back(stringToFourPointType(name));
+        four_point_channels_.push_back(stringToFourPointType(name));
 
       // Remove duplicates
-      std::sort(channels_.begin(), channels_.end());
-      channels_.erase(std::unique(channels_.begin(), channels_.end()), channels_.end());
+      std::sort(four_point_channels_.begin(), four_point_channels_.end());
+      four_point_channels_.erase(std::unique(four_point_channels_.begin(), four_point_channels_.end()), four_point_channels_.end());
     }
 
     else {  // is writer.
-      for (auto channel : channels_)
+      for (auto channel : four_point_channels_)
         channel_names.push_back(toString(channel));
 
       try_to_execute(channel_par_name, channel_names);

--- a/include/dca/phys/parameters/parameters.hpp
+++ b/include/dca/phys/parameters/parameters.hpp
@@ -192,7 +192,7 @@ void Parameters<Concurrency, Threading, Profiler, Model, RandomNumberGenerator, 
 
   domains::DCA_iteration_domain::write(writer);
 
-  if (FourPointParameters<Model::DIMENSION>::accumulateG4()) {
+  if (FourPointParameters<Model::DIMENSION>::isAccumulatingG4()) {
     domains::vertex_time_domain<domains::SP_TIME_DOMAIN>::write(writer);
     domains::vertex_time_domain<domains::TP_TIME_DOMAIN>::write(writer);
     domains::vertex_time_domain<domains::SP_TIME_DOMAIN_POSITIVE>::write(writer);

--- a/misc/wiki/Parameters.md
+++ b/misc/wiki/Parameters.md
@@ -1,0 +1,650 @@
+All applications read simulation parameters, e.g. the DCA cluster, the temperature, or output filenames, from a JSON-formatted input file, in which parameters are thematically grouped and sub-grouped in JSON objects. This page provides descriptions of all input parameters including their type and default value using the format  
+
+`"name":` type (default value)  
+Description.  
+
+In addition, we provide a complete (including mutually exclusive groups) [sample input file](https://github.com/CompFUSE/DCA/blob/master/tools/complete_input.json).
+
+## Output parameters
+
+Defined in <tt>output_parameters.hpp</tt>.  
+
+**Group** `"output":`
+
+`"directory":` string ("./")  
+Directory to write the output to.
+
+`"output-format":` string ("HDF5")  
+File format of the output files. Options are: "HDF5" | "JSON".
+
+`"directory-config-read":` string ("")  
+If not empty, the Monte Carlo configuration will be initialized with the configurations stored in this directory.
+
+`"directory-config-write":` string ("")  
+If not empty, after the last Monte Carlo iteration, the configurations are written in this directory.
+
+
+`"filename-dca":` string ("dca.hdf5")  
+Filename for the output of the application <tt>main_dca</tt>.
+
+`"filename-analysis":` string ("analysis.hdf5")  
+Filename for the output of the application <tt>main_analysis</tt>.
+
+`"filename-ed":` string ("ed.hdf5")  
+Filename for the ED output in the application <tt>cluster_solver_check</tt>.
+
+`"filename-qmc":` string ("qmc.hdf5")  
+Filename for the QMC output in the application <tt>cluster_solver_check</tt>.
+
+`"filename-profiling":` string ("profiling.json")  
+Filename for the profiling output. The file format is always JSON.
+
+`"dump-lattice-self-energy":` boolean (false)  
+Write out the lattice self-energy in DCA<sup>+</sup>.
+
+`"dump-cluster-Greens-functions":` boolean (false)  
+Write out the cluster Green's functions.
+
+`"dump-Gamma-lattice":` boolean (false)  
+Write out the &Gamma; function of the BSE lattice solver.
+
+`"dump-chi-0-lattice":` boolean (false)  
+Write out the &chi;<sub>0</sub> function of the BSE lattice solver.
+
+#### Example
+
+    {
+        "output": {
+            "directory": "./T=0.5",
+            "output-format": "HDF5",
+            "filename-dca": "dca.hdf5",
+            "filename-analysis": "analysis.hdf5",
+            "filename-ed": "ed.hdf5",
+            "filename-qmc": "qmc.hdf5",
+            "filename-profiling": "profiling.json",
+            "dump-lattice-self-energy": false,
+            "dump-cluster-Greens-functions": true,
+            "dump-Gamma-lattice": false,
+            "dump-chi-0-lattice": false
+        }
+    }
+
+
+## Physics parameters
+
+Defined in <tt>physics_parameters.hpp</tt>.  
+
+**Group** `"physics":`
+
+`"beta":` double (1.)  
+Inverse temperature.
+
+`"density":` double (1.)  
+Target electron density.
+
+`"chemical-potential":` double (0.)  
+Initial value of the chemical potential.  
+Note that this value is overwritten, if an output file with an initial self-energy is given (see section DCA parameters).
+
+`"adjust-chemical-potential":` boolean (true)  
+Adjust chemical potential to obtain specified density.
+
+#### Example
+
+    {
+        "physics": {
+            "beta": 0.5,
+            "density": 0.9,
+            "chemical-potential": 0.,
+            "adjust-chemical-potential": true
+        }
+    }
+
+
+## Model parameters
+
+Defined in <tt>model_parameters.hpp</tt>.  
+The following groups are *mutually exclusive*.
+
+### Single-band Hubbard model
+
+**Group** `"single-band-Hubbard-model":`  
+Used if *square lattice* or *triangular lattice* are selected.
+
+`"t":` double (0.)  
+Nearest neighbor hopping parameter.
+
+`"t-prime":` double (0.)  
+Next nearest neighbor hopping parameter.
+
+`"U":` double (0.)  
+On-site Coulomb repulsion.
+
+`"V":` double (0.)  
+Nearest neighbor coulomb repulsion, opposite spins.
+
+`"V-prime":` double (0.)  
+Nearest neighbor coulomb repulsion, same spins.
+
+#### Example
+
+    {
+        "single-band-Hubbard-model": {
+            "t": 1.,
+            "t-prime": 0.5,
+            "U": 8.,
+            "V": 2.,
+            "V-prime": 2.
+        }
+    }
+
+
+### Bilayer Hubbard model
+
+**Group** `"bilayer-Hubbard-model":`  
+Used if *bilayer lattice* is selected.
+
+`"t":` double (0.)  
+Nearest neighbor hopping parameter.
+
+`"t-prime":` double (0.)  
+Next nearest neighbor hopping parameter.
+ 
+`"t-perp":` double (0.)  
+Hopping parameter between layers.
+
+`"U":` double (0.)  
+On-site Coulomb repulsion.
+
+`"V":` double (0.)  
+Coulomb repulsion between layers, opposite spins.
+
+`"V-prime":` double (0.)  
+Coulomb repulsion between layers, same spins.
+
+
+#### Example
+
+    {
+        "bilayer-Hubbard-model": {
+            "t": 1.,
+            "t-prime": 0.5,
+            "t-perp": 0.2,
+            "U": 8.,
+            "V": 2.,
+            "V-prime": 2.
+        }
+    }
+
+
+### Material model
+
+**Group** `"material-model":`  
+Used if a material lattice is selected.
+
+`"t_ij-filename":` string ("t_ij.txt")  
+Name of the CSV file containing hopping parameters *t<sub>ij</sub>*.
+
+`"U_ij-filename":` string ("U_ij.txt")  
+Name of the CSV file containing values of the Coulomb repulsion *U<sub>ij</sub>*.
+
+
+#### Example
+
+    {
+        "material-model": {
+            "t_ij-filename": "NiO_t_ij.txt",
+            "U_ij-filename": "NiO_U_ij.txt"
+        }
+    }
+
+
+## DCA parameters
+
+Defined in <tt>dca_parameters.hpp</tt>.  
+
+**Group** `"DCA":`
+
+`"initial-self-energy":` string ("zero")  
+Either the name of the file with the initial self-energy (usually the <tt>main_dca</tt> output file of the previous temperature) or "zero" indicating that the initial self-energy should be zero.
+
+`"iterations":` integer (1)  
+Number of DCA<sup>(+)</sup> iterations.
+
+`"accuracy"`: double (0.)  
+Stop the DCA<sup>(+)</sup> loop if this accuracy has been reached.
+
+`"self-energy-mixing-factor":` double (1.)  
+&Sigma;<sup>(n)</sup> = &alpha; &Sigma;<sup>(n)</sup><sub>QMC</sub> + (1-&alpha;)&Sigma;<sup>(n-1)</sup><sub>coarsegrained</sub>, where &alpha; is the self-energy mixing factor.  
+
+`"interacting-orbitals":` array of integers ([0])  
+Indices of orbitals that are treated interacting.  
+Note that this parameter must be consistent with the model that is used.
+
+`"do-finite-size-QMC":` boolean (false)  
+Do a finite-size QMC calculation (no mean-field).
+
+
+<br></br>
+**Subgroup** `"coarse-graining":`  
+`"k-mesh-recursion":` integer (0)  
+Number of recursion steps in the creation of the momentum space mesh.  
+See the appendix of [1] for details.
+
+`"periods":` integer (0)  
+Number of "periods" of the interlaced coarse-graining patches, i.e. degree of their interleaving.    
+Restricted by *k-mesh-recursion*. See the appendix of [1] for details.
+
+`"quadrature-rule":`  integer (1)  
+Determines the quadrature rule used in the coarse-graining.  
+quadrature-rule < 0: use a flat mesh.  
+quadrature-rule >= 0: use the Grundmann-Moeller rule of index = *quadrature-rule*. A rule of index *s* is exact for polynomials up to order 2*s*+1 [2].
+
+`"threads":` integer (1)  
+Number of threads used in the coarse-graining.
+
+`"tail-frequencies":` integer (0)  
+Number of tail frequencies used for updating the chemical potential.
+
+
+<br></br>
+**Subgroup** `"DCA+":`  
+`"do-DCA+"`: boolean (false)  
+Use the DCA<sup>+</sup> algorithm with a continuous lattice self-energy.
+
+`"deconvolution-iterations":` integer (16)  
+Maximum number of iterations in the deconvolution step.
+
+`"deconvolution-tolerance":` double (1.e-3)  
+Termination criteria for the deconvolution step.
+
+`"HTS-approximation":` boolean (false)  
+Use high-temperature series approximation for lattice mapping.
+
+`"HTS-threads": ` integer (1)  
+Number of threads used in the HTS-solver.
+
+#### Example
+
+    {
+        "DCA": {
+            "initial-self-energy": "./T=0.5/dca.hdf5",
+            "iterations": 3,
+            "accuracy": 1.e-3,
+            "self-energy-mixing-factor": 0.5,
+            "interacting-orbitals": [0],
+
+            "do-finite-size-QMC": false,
+
+            "coarse-graining": {
+                "k-mesh-recursion": 3,
+                "periods": 2,
+                "quadrature-rule": 1,
+                "threads": 8,
+                "tail-frequencies": 10
+            },
+
+            "DCA+": {
+                "do-DCA+": true,
+                "deconvolution-iterations": 16,
+                "deconvolution-tolerance": 1.e-3,
+                "HTS-approximation": true,
+                "HTS-threads": 8
+            }
+        }
+    }
+	
+
+## Domains parameters
+
+Defined in <tt>domains_parameters.hpp</tt>.
+
+**Group** `"domains":`
+
+<br></br>
+**Subgroup** `"real-space-grids":`  
+`"cluster":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])  
+Real space DCA cluster.  
+Given as coordinates with respect to the lattice basis.  
+To choose a cluster of a given size, consult this [exhaustive list](https://github.com/CompFUSE/DCA/blob/master/tools/cluster_definitions.txt) of 2D and 3D clusters.
+
+`"sp-host":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])  
+Real space host grid for single-particle functions, also called *(sp-)lattice*.  
+In addition, it is used in the coarse-graining step of **both DCA and DCA<sup>+</sup>** as the grid for the free dispersion relation &epsilon;<sub>**k**</sub>.  
+Given as coordinates with respect to the lattice basis.
+
+`"tp-host":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])  
+Real space host grid for two-particle functions, also called *tp-lattice*. Only used in **DCA<sup>+</sup>**.  
+Given as coordinates with respect to the lattice basis.
+
+
+<br></br>
+**Subgroup** `"imaginary-time":`  
+`"sp-time-intervals":` integer (128)  
+Used to initialize <tt>time_domain</tt>, whose elements are  
+&nbsp;&nbsp;&nbsp;&nbsp; -&beta;+&epsilon;, -&beta;+&Delta;, ..., -&Delta;, -&epsilon;, &epsilon;, &Delta;, ..., &beta;-&Delta;, &beta;-&epsilon;,  
+where &Delta; = &beta;/*sp-time-intervals*.  
+More precisely, it determines the *G*<sub>0</sub>-interpolation domain in CT-AUX and the *F*-interpolation domain in SS-CT-HYB.  
+**TODO**: Make this clearer.
+
+`"time-intervals-for-time-measurements":` integer (1)  
+Used to initialize <tt>vertex_time_domain<TP_TIME_DOMAIN></tt> and <tt>vertex_time_domain<TP_TIME_DOMAIN_POSITIVE></tt>, where the latter is the domain for additional time measurements.
+
+
+<br></br>
+**Subgroup** `"imaginary-frequency"`  
+`"sp-fermionic-frequencies":` integer (256)  
+Number of positive and negative fermionic Matsubara frequencies, respectively.  
+Used to initialize <tt>frequency_domain</tt>, whose elements are (*n* = sp-fermionic-frequencies)  
+&nbsp;&nbsp;&nbsp;&nbsp; -(2*n*-1)&pi;/&beta;, ..., -3&pi;/&beta;, -&pi;/&beta;, &pi;/&beta;, 3&pi;/&beta;, ..., (2*n*-1)&pi;/&beta;.
+
+`"HTS-bosonic-frequencies":` integer (0)  
+Used to initialize <tt>vertex_frequency_domain<EXTENDED_BOSONIC></tt>, which is the bosonic Matsubara frequency mesh employed in the HTS-solver.
+The elements of the domain are (*n* = HTS-bosonic-frequencies):  
+&nbsp;&nbsp;&nbsp;&nbsp; -2*n*&pi;/&beta;, ..., -2&pi;/&beta;, 0, &pi;/&beta;, ..., 2*n*&pi;/&beta;
+
+`"four-point-fermionic-frequencies":`  integer (1)  
+Used to initialize <tt>vertex_frequency_domain<COMPACT/COMPACT_POSITIVE/EXTENDED/EXTENDED_POSITIVE></tt>, that is the fermionic Matsubara frequency mesh for measuring four-point quantities.
+
+<br></br>
+**Subgroup** `"real-frequency":`  
+`"min":` double (-10.)  
+`"max":` double (10.)  
+`"frequencies":` integer (3)  
+Parameters for the initialization of <tt>frequency_domain_real_axis</tt>:  
+&nbsp;&nbsp;&nbsp;&nbsp; *min*,  *min*+&Delta;, *min* + 2&Delta;, ..., *max*-&Delta;, *max*, &nbsp;&nbsp; &Delta; = (*max*-*min*)/(*frequencies*-1).
+
+`"imaginary-damping":` double (0.01)  
+Small *positive* shift, used to shift the real frequencies &omega; away from the real axis, &omega; -> &omega;+i&eta;.
+
+#### Example
+
+    {	
+        "domains": {
+            "real-space-grids": {
+                "cluster": [[2, 0],
+                            [0, 2]],
+                "sp-host": [[20, 20],
+                            [20,-20]],
+                "tp-host": [[8, 8],
+                            [8,-8]]
+            },
+
+            "imaginary-time": {
+                "sp-time-intervals": 128,
+                "time-intervals-for-time-measurements": 128
+            },
+
+            "imaginary-frequency": {
+                "sp-fermionic-frequencies": 256,
+                "HTS-bosonic-frequencies": 32,
+                "four-point-fermionic-frequencies": 16
+            },
+
+            "real-frequency": {
+                "min": -10,
+                "max": 10,
+                "frequencies": 128,
+                "imaginary-damping": 0.01
+            }
+        }
+    }
+
+
+## Monte Carlo integration parameters
+
+Defined in <tt>mci_parameters.hpp</tt>.
+
+**Group** `"Monte-Carlo-integration":`
+
+`"seed":` integer | string (985456376)  
+Seed for the random number generator(s) used in the Monte Carlo integration.  
+Instead of an integer, the string `"random"` can be passed to generate a random seed.
+
+`"warm-up-sweeps":` integer (20)  
+Number of warm-up sweeps.
+
+`"sweeps-per-measurement":` double (1.)  
+Number of sweeps per measurement.
+
+`"measurements":` integer (100)  
+Number of independent measurements in each Monte Carlo iteration.
+
+`"error-computation-type:"`  string("NONE")\
+Determines the type of error computation that will be performed during the last Monte Carlo iteration. Possible options are:
+- "NONE"
+- "STANDARD_DEVIATION"
+- "JACK_KNIFE"
+
+`"store-configuration"` : boolean (false)
+If true, the vertex configuration is stored between DCA iterations to initialize the walkers of the following iteration.
+
+<br></br>
+**subgroup** `"threaded-solver":`  
+Additional parameters for threaded Monte Carlo solvers.  
+`"walkers":` integer (1)  
+Number of Monte Carlo walkers.  
+`"accumulators":` integer (1)  
+Number of Monte Carlo accumulators.  
+`"shared-walk-and-accumulation-thread":` boolean (false)\
+When this mode is activated, each thread will run an instance of a walker and an accumulator. This parameter is ignored if the numbers of walkers and accumulators are different.\
+`"fix-meas-per-walker":` boolean(false)\
+The number of sweeps performed by each walker is fixed a priori, avoiding possible bias in the sampling of faster walkers.
+
+#### Example
+	
+    {
+        "Monte-Carlo-integration": {
+            "seed": 42,
+            "warm-up-sweeps": 40,
+            "sweeps-per-measurement": 4.,
+            "measurements": 1000000,
+            "error-computation-type": "JACK_KNIFE",
+
+            "threaded-solver": {
+                "walkers": 3,
+                "accumulators": 5,
+                "shared-walk-and-accumulation-thread": false
+            }
+        }
+    }
+	
+	
+## Monte Carlo solver parameters
+
+Defined in <tt>mc_solver_parameters.hpp</tt>.  
+The following parameter groups are *mutually exclusive*.
+
+### CT-AUX
+
+**Group** `"CT-AUX":`  
+Used if *CT-AUX* is selected as the cluster solver.
+
+`"expansion-parameter-K":` double (1.)  
+The perturbation order in the CT-AUX algorithm increases linearly with the expansion parameter *K*.  
+While *K* is only subject to the restriction of being positive, values of the order of 1 have proven to be a good choice [3].
+
+`"initial-configuration-size":` integer (10)  
+The CT-AUX solver is initialized with `"initial-configuration-size"` random **interacting** vertices.
+
+`"initial-matrix-size":` integer (128)  
+Initial size of the CT-AUX matrices.
+
+`"max-submatrix-size":` integer (128)  
+Maximum number of single spin updates per submatrix update (see [4]).
+
+`"neglect-Bennett-updates":` boolean (false)  
+Neglect the two types of Bennett updates:
+1. removal of an *interacting* spin that has already been proposed for removal,  
+2. removal of a *non-interacting* spin that has been proposed for insertion.  
+
+Turning on this option leads to a larger number of delayed spins (~`"max-submatrix-size"`) at the cost of a systematic error due to the violation of detailed balance.
+
+
+`"additional-time-measurements":` boolean (false)  
+Do additional time measurements.
+
+#### Example
+
+    {
+        "CT-AUX": {
+            "expansion-parameter-K": 1.,
+            "initial-configuration-size": 100,
+            "initial-matrix-size": 128,
+
+            "max-submatrix-size": 64,
+            "neglect-Bennett-updates": true,
+
+            "additional-time-measurements": true
+        }
+    }
+
+### CT-HYB
+
+**Group** `"SS-CT-HYB":`  
+Used if *SS-CT-HYB* is selected as the cluster solver.
+
+`"self-energy-tail-cutoff":` integer (0)  
+Cut-off parameter for imaginary frequency tail of self-energy.
+
+`"steps-per-sweep":` double (0.5)  
+`"shifts-per-sweep":` double (0.5)  
+The fraction of insert/removal steps is given by  
+&nbsp;&nbsp;&nbsp;&nbsp; *steps-per-sweep/(steps-per-sweep + shifts-per-sweep)*,  
+while the fraction of segments shifts is  
+&nbsp;&nbsp;&nbsp;&nbsp; *shifts-per-sweep/(steps-per-sweep + shifts-per-sweep)*.
+
+#### Example
+
+    {
+        "SS-CT-HYB": {
+            "self-energy-tail-cutoff": 10,
+            "steps-per-sweep": 0.6,
+            "shifts-per-sweep": 0.4
+        }
+    }
+
+
+## Four-point parameters
+ 
+Defined in <tt>four_point_parameters.hpp</tt>.
+
+**Group** `"four-point":`
+
+`"type":` string ("NONE")  
+Four-point type, options are:  
+* "NONE"
+* "PARTICLE_PARTICLE_UP_DOWN"
+* "PARTICLE_HOLE_CHARGE"
+* "PARTICLE_HOLE_MAGNETIC"
+* "PARTICLE_HOLE_LONGITUDINAL_UP_UP"
+* "PARTICLE_HOLE_LONGITUDINAL_UP_DOWN"
+* "PARTICLE_HOLE_TRANSVERSE"
+
+`"momentum-transfer":` array of doubles (null vector with the dimension of the lattice, e.g. for a 2D lattice: [0., 0.])  
+Transferred momentum **q**.  
+Must be an element of the reciprocal lattice of the DCA cluster (|| **q** - **K**<sub>DCA</sub> ||<sub>2</sub> < 10<sup>-3</sup>).  
+
+`"frequency-transfer":` integer (0)  
+Transferred frequency &omega;.   
+Given as the index *n* of the bosonic Matsubara frequency &omega;<sub>*n*</sub> = 2*n*&pi;/&beta;.
+
+`"compute-all-transfers":` boolean (false)\
+When this mode is activated all possible positive frequency transfers, up to and including the transfer with index "frequency-transfer". All possible momentum transfers will be computed as well, ignoring the parameter "momentum-transfer".
+
+#### Example
+	
+    {
+        "four-point": {
+            "type": "PARTICLE_PARTICLE_UP_DOWN",
+            "momentum-transfer": [0., 0.],
+            "frequency-transfer": 0,
+            "compute-all-transfers": false
+        }
+    }
+		
+		
+## Analysis parameters
+
+Defined in <tt>analysis_parameters.hpp</tt>.
+
+**Group** `"analysis":`
+
+`"symmetrize-Gamma":` boolean (true)  
+Symmetrize &Gamma;<sub>cluster</sub> and &Gamma;<sub>lattice</sub> according to the symmetry group and diagrammatic symmetries.
+
+`"Gamma-deconvolution-cut-off":` double (0.5)  
+Cut-off parameter for the deconvolution of the vertex &Gamma;(**K**<sub>1</sub>, **K**<sub>2</sub>).  
+The deconvolution is done by Fourier transforming to real space, dividing by the coarse-graining patch functions in real space &phi;(**r**) and then transforming back to reciprocal space. The real space patch functions are only inverted down to the value of this parameter,  
+&nbsp;&nbsp;&nbsp;&nbsp; &phi;<sup>-1</sup><sub>cut-off</sub>(**r**) = &phi;<sup>-1</sup>(**r**),&nbsp;&nbsp; if &phi;(**r**) > *Gamma-deconvolution-cut-off*,  
+&nbsp;&nbsp;&nbsp;&nbsp; &phi;<sup>-1</sup><sub>cut-off</sub>(**r**) = 0,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; else.
+
+`"project-onto-chrystal-harmonics":` boolean (false)  
+Project &Gamma; &chi;<sub>0</sub> onto the crystal harmonic functions and diagonalize in this subspace.
+
+`"projection-cut-off-radius":` double (1.5)  
+For the projection use crystal-harmonic functions of lattice vectors **r** with ||**r**||<sub>2</sub> < *projection-cut-off-radius*.
+
+
+#### Example
+
+    {
+        "analysis": {
+            "symmetrize-Gamma": true,
+            "Gamma-deconvolution-cut-off": 0.5,
+            "project-onto-crystal-harmonics": true,
+            "projection-cut-off-radius": 1.5
+        }
+    }
+
+
+## ED-solver parameters
+Defined in <tt>ed_solver_parameters.hpp</tt>.  
+Only required if the exact diagonalization solver is used, e.g. in the application <tt>cluster_solver_check</tt>.
+
+**Group** `"ED":`
+
+`"eigenvalue-cut-off":` double (1.e-6)  
+Only keep energy eigenvalues *E* for which e<sup>-*&beta;E*</sup> > *eigenvalue-cut-off*.
+
+#### Example
+
+    {
+        "ED": {
+            "eigenvalue-cut-off": 1.e-6
+        }
+    }
+
+
+## Double-counting parameters
+
+Defined in <tt>double_counting_parameters.hpp</tt>.  
+Only required for LDA+DMFT.
+
+**Group** `"double-couting":`
+
+`"method":` string ("none")  
+The double-counting method to use, options are:
+
+* "none": no double-counting correction
+* "constant-correction-without-U-correction"
+* "constant-correction-with-U-correction"
+
+`"correction"`: double (0.)  
+The value of the double-counting correction.
+
+#### Example
+
+    {
+        "double-counting": {
+            "method" : "constant-correction-without-U-correction",
+            "correction" : 4.2
+        }
+    }
+
+			
+### References
+[1]	P. Staar, M. Jiang, U. R. Hähner, T. C. Schulthess, and T. A. Maier, Physical Review B 93, 165144 (2016).  
+[2] https://people.sc.fsu.edu/~jburkardt/cpp_src/simplex_gm_rule/simplex_gm_rule.html  
+[3] E. Gull, P. Werner, O. Parcollet, and M. Troyer, Europhys. Lett. 82, 57003 (2008).  
+[4] E. Gull, P. Staar, S. Fuchs, P. Nukala, M. S. Summers, T. Pruschke, T. C. Schulthess, and T. Maier, Physical Review B 83, 075122 (2011).

--- a/misc/wiki/Parameters.md
+++ b/misc/wiki/Parameters.md
@@ -1,54 +1,54 @@
-All applications read simulation parameters, e.g. the DCA cluster, the temperature, or output filenames, from a JSON-formatted input file, in which parameters are thematically grouped and sub-grouped in JSON objects. This page provides descriptions of all input parameters including their type and default value using the format  
+All applications read simulation parameters, e.g. the DCA cluster, the temperature, or output filenames, from a JSON-formatted input file, in which parameters are thematically grouped and sub-grouped in JSON objects. This page provides descriptions of all input parameters including their type and default value using the format
 
-`"name":` type (default value)  
-Description.  
+`"name":` type (default value)
+Description.
 
 In addition, we provide a complete (including mutually exclusive groups) [sample input file](https://github.com/CompFUSE/DCA/blob/master/tools/complete_input.json).
 
 ## Output parameters
 
-Defined in <tt>output_parameters.hpp</tt>.  
+Defined in <tt>output_parameters.hpp</tt>.
 
 **Group** `"output":`
 
-`"directory":` string ("./")  
+`"directory":` string ("./")
 Directory to write the output to.
 
-`"output-format":` string ("HDF5")  
+`"output-format":` string ("HDF5")
 File format of the output files. Options are: "HDF5" | "JSON".
 
-`"directory-config-read":` string ("")  
+`"directory-config-read":` string ("")
 If not empty, the Monte Carlo configuration will be initialized with the configurations stored in this directory.
 
-`"directory-config-write":` string ("")  
+`"directory-config-write":` string ("")
 If not empty, after the last Monte Carlo iteration, the configurations are written in this directory.
 
 
-`"filename-dca":` string ("dca.hdf5")  
+`"filename-dca":` string ("dca.hdf5")
 Filename for the output of the application <tt>main_dca</tt>.
 
-`"filename-analysis":` string ("analysis.hdf5")  
+`"filename-analysis":` string ("analysis.hdf5")
 Filename for the output of the application <tt>main_analysis</tt>.
 
-`"filename-ed":` string ("ed.hdf5")  
+`"filename-ed":` string ("ed.hdf5")
 Filename for the ED output in the application <tt>cluster_solver_check</tt>.
 
-`"filename-qmc":` string ("qmc.hdf5")  
+`"filename-qmc":` string ("qmc.hdf5")
 Filename for the QMC output in the application <tt>cluster_solver_check</tt>.
 
-`"filename-profiling":` string ("profiling.json")  
+`"filename-profiling":` string ("profiling.json")
 Filename for the profiling output. The file format is always JSON.
 
-`"dump-lattice-self-energy":` boolean (false)  
+`"dump-lattice-self-energy":` boolean (false)
 Write out the lattice self-energy in DCA<sup>+</sup>.
 
-`"dump-cluster-Greens-functions":` boolean (false)  
+`"dump-cluster-Greens-functions":` boolean (false)
 Write out the cluster Green's functions.
 
-`"dump-Gamma-lattice":` boolean (false)  
+`"dump-Gamma-lattice":` boolean (false)
 Write out the &Gamma; function of the BSE lattice solver.
 
-`"dump-chi-0-lattice":` boolean (false)  
+`"dump-chi-0-lattice":` boolean (false)
 Write out the &chi;<sub>0</sub> function of the BSE lattice solver.
 
 #### Example
@@ -72,21 +72,21 @@ Write out the &chi;<sub>0</sub> function of the BSE lattice solver.
 
 ## Physics parameters
 
-Defined in <tt>physics_parameters.hpp</tt>.  
+Defined in <tt>physics_parameters.hpp</tt>.
 
 **Group** `"physics":`
 
-`"beta":` double (1.)  
+`"beta":` double (1.)
 Inverse temperature.
 
-`"density":` double (1.)  
+`"density":` double (1.)
 Target electron density.
 
-`"chemical-potential":` double (0.)  
-Initial value of the chemical potential.  
+`"chemical-potential":` double (0.)
+Initial value of the chemical potential.
 Note that this value is overwritten, if an output file with an initial self-energy is given (see section DCA parameters).
 
-`"adjust-chemical-potential":` boolean (true)  
+`"adjust-chemical-potential":` boolean (true)
 Adjust chemical potential to obtain specified density.
 
 #### Example
@@ -103,27 +103,27 @@ Adjust chemical potential to obtain specified density.
 
 ## Model parameters
 
-Defined in <tt>model_parameters.hpp</tt>.  
+Defined in <tt>model_parameters.hpp</tt>.
 The following groups are *mutually exclusive*.
 
 ### Single-band Hubbard model
 
-**Group** `"single-band-Hubbard-model":`  
+**Group** `"single-band-Hubbard-model":`
 Used if *square lattice* or *triangular lattice* are selected.
 
-`"t":` double (0.)  
+`"t":` double (0.)
 Nearest neighbor hopping parameter.
 
-`"t-prime":` double (0.)  
+`"t-prime":` double (0.)
 Next nearest neighbor hopping parameter.
 
-`"U":` double (0.)  
+`"U":` double (0.)
 On-site Coulomb repulsion.
 
-`"V":` double (0.)  
+`"V":` double (0.)
 Nearest neighbor coulomb repulsion, opposite spins.
 
-`"V-prime":` double (0.)  
+`"V-prime":` double (0.)
 Nearest neighbor coulomb repulsion, same spins.
 
 #### Example
@@ -141,25 +141,25 @@ Nearest neighbor coulomb repulsion, same spins.
 
 ### Bilayer Hubbard model
 
-**Group** `"bilayer-Hubbard-model":`  
+**Group** `"bilayer-Hubbard-model":`
 Used if *bilayer lattice* is selected.
 
-`"t":` double (0.)  
+`"t":` double (0.)
 Nearest neighbor hopping parameter.
 
-`"t-prime":` double (0.)  
+`"t-prime":` double (0.)
 Next nearest neighbor hopping parameter.
- 
-`"t-perp":` double (0.)  
+
+`"t-perp":` double (0.)
 Hopping parameter between layers.
 
-`"U":` double (0.)  
+`"U":` double (0.)
 On-site Coulomb repulsion.
 
-`"V":` double (0.)  
+`"V":` double (0.)
 Coulomb repulsion between layers, opposite spins.
 
-`"V-prime":` double (0.)  
+`"V-prime":` double (0.)
 Coulomb repulsion between layers, same spins.
 
 
@@ -179,13 +179,13 @@ Coulomb repulsion between layers, same spins.
 
 ### Material model
 
-**Group** `"material-model":`  
+**Group** `"material-model":`
 Used if a material lattice is selected.
 
-`"t_ij-filename":` string ("t_ij.txt")  
+`"t_ij-filename":` string ("t_ij.txt")
 Name of the CSV file containing hopping parameters *t<sub>ij</sub>*.
 
-`"U_ij-filename":` string ("U_ij.txt")  
+`"U_ij-filename":` string ("U_ij.txt")
 Name of the CSV file containing values of the Coulomb repulsion *U<sub>ij</sub>*.
 
 
@@ -201,67 +201,67 @@ Name of the CSV file containing values of the Coulomb repulsion *U<sub>ij</sub>*
 
 ## DCA parameters
 
-Defined in <tt>dca_parameters.hpp</tt>.  
+Defined in <tt>dca_parameters.hpp</tt>.
 
 **Group** `"DCA":`
 
-`"initial-self-energy":` string ("zero")  
+`"initial-self-energy":` string ("zero")
 Either the name of the file with the initial self-energy (usually the <tt>main_dca</tt> output file of the previous temperature) or "zero" indicating that the initial self-energy should be zero.
 
-`"iterations":` integer (1)  
+`"iterations":` integer (1)
 Number of DCA<sup>(+)</sup> iterations.
 
-`"accuracy"`: double (0.)  
+`"accuracy"`: double (0.)
 Stop the DCA<sup>(+)</sup> loop if this accuracy has been reached.
 
-`"self-energy-mixing-factor":` double (1.)  
-&Sigma;<sup>(n)</sup> = &alpha; &Sigma;<sup>(n)</sup><sub>QMC</sub> + (1-&alpha;)&Sigma;<sup>(n-1)</sup><sub>coarsegrained</sub>, where &alpha; is the self-energy mixing factor.  
+`"self-energy-mixing-factor":` double (1.)
+&Sigma;<sup>(n)</sup> = &alpha; &Sigma;<sup>(n)</sup><sub>QMC</sub> + (1-&alpha;)&Sigma;<sup>(n-1)</sup><sub>coarsegrained</sub>, where &alpha; is the self-energy mixing factor.
 
-`"interacting-orbitals":` array of integers ([0])  
-Indices of orbitals that are treated interacting.  
+`"interacting-orbitals":` array of integers ([0])
+Indices of orbitals that are treated interacting.
 Note that this parameter must be consistent with the model that is used.
 
-`"do-finite-size-QMC":` boolean (false)  
+`"do-finite-size-QMC":` boolean (false)
 Do a finite-size QMC calculation (no mean-field).
 
 
 <br></br>
-**Subgroup** `"coarse-graining":`  
-`"k-mesh-recursion":` integer (0)  
-Number of recursion steps in the creation of the momentum space mesh.  
+**Subgroup** `"coarse-graining":`
+`"k-mesh-recursion":` integer (0)
+Number of recursion steps in the creation of the momentum space mesh.
 See the appendix of [1] for details.
 
-`"periods":` integer (0)  
-Number of "periods" of the interlaced coarse-graining patches, i.e. degree of their interleaving.    
+`"periods":` integer (0)
+Number of "periods" of the interlaced coarse-graining patches, i.e. degree of their interleaving.
 Restricted by *k-mesh-recursion*. See the appendix of [1] for details.
 
-`"quadrature-rule":`  integer (1)  
-Determines the quadrature rule used in the coarse-graining.  
-quadrature-rule < 0: use a flat mesh.  
+`"quadrature-rule":`  integer (1)
+Determines the quadrature rule used in the coarse-graining.
+quadrature-rule < 0: use a flat mesh.
 quadrature-rule >= 0: use the Grundmann-Moeller rule of index = *quadrature-rule*. A rule of index *s* is exact for polynomials up to order 2*s*+1 [2].
 
-`"threads":` integer (1)  
+`"threads":` integer (1)
 Number of threads used in the coarse-graining.
 
-`"tail-frequencies":` integer (0)  
+`"tail-frequencies":` integer (0)
 Number of tail frequencies used for updating the chemical potential.
 
 
 <br></br>
-**Subgroup** `"DCA+":`  
-`"do-DCA+"`: boolean (false)  
+**Subgroup** `"DCA+":`
+`"do-DCA+"`: boolean (false)
 Use the DCA<sup>+</sup> algorithm with a continuous lattice self-energy.
 
-`"deconvolution-iterations":` integer (16)  
+`"deconvolution-iterations":` integer (16)
 Maximum number of iterations in the deconvolution step.
 
-`"deconvolution-tolerance":` double (1.e-3)  
+`"deconvolution-tolerance":` double (1.e-3)
 Termination criteria for the deconvolution step.
 
-`"HTS-approximation":` boolean (false)  
+`"HTS-approximation":` boolean (false)
 Use high-temperature series approximation for lattice mapping.
 
-`"HTS-threads": ` integer (1)  
+`"HTS-threads": ` integer (1)
 Number of threads used in the HTS-solver.
 
 #### Example
@@ -293,7 +293,7 @@ Number of threads used in the HTS-solver.
             }
         }
     }
-	
+
 
 ## Domains parameters
 
@@ -302,64 +302,64 @@ Defined in <tt>domains_parameters.hpp</tt>.
 **Group** `"domains":`
 
 <br></br>
-**Subgroup** `"real-space-grids":`  
-`"cluster":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])  
-Real space DCA cluster.  
-Given as coordinates with respect to the lattice basis.  
+**Subgroup** `"real-space-grids":`
+`"cluster":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])
+Real space DCA cluster.
+Given as coordinates with respect to the lattice basis.
 To choose a cluster of a given size, consult this [exhaustive list](https://github.com/CompFUSE/DCA/blob/master/tools/cluster_definitions.txt) of 2D and 3D clusters.
 
-`"sp-host":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])  
-Real space host grid for single-particle functions, also called *(sp-)lattice*.  
-In addition, it is used in the coarse-graining step of **both DCA and DCA<sup>+</sup>** as the grid for the free dispersion relation &epsilon;<sub>**k**</sub>.  
+`"sp-host":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])
+Real space host grid for single-particle functions, also called *(sp-)lattice*.
+In addition, it is used in the coarse-graining step of **both DCA and DCA<sup>+</sup>** as the grid for the free dispersion relation &epsilon;<sub>**k**</sub>.
 Given as coordinates with respect to the lattice basis.
 
-`"tp-host":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])  
-Real space host grid for two-particle functions, also called *tp-lattice*. Only used in **DCA<sup>+</sup>**.  
+`"tp-host":` array of arrays of integers (lattice basis, e.g. in 2D: [ [1, 0], [0, 1] ])
+Real space host grid for two-particle functions, also called *tp-lattice*. Only used in **DCA<sup>+</sup>**.
 Given as coordinates with respect to the lattice basis.
 
 
 <br></br>
-**Subgroup** `"imaginary-time":`  
-`"sp-time-intervals":` integer (128)  
-Used to initialize <tt>time_domain</tt>, whose elements are  
-&nbsp;&nbsp;&nbsp;&nbsp; -&beta;+&epsilon;, -&beta;+&Delta;, ..., -&Delta;, -&epsilon;, &epsilon;, &Delta;, ..., &beta;-&Delta;, &beta;-&epsilon;,  
-where &Delta; = &beta;/*sp-time-intervals*.  
-More precisely, it determines the *G*<sub>0</sub>-interpolation domain in CT-AUX and the *F*-interpolation domain in SS-CT-HYB.  
+**Subgroup** `"imaginary-time":`
+`"sp-time-intervals":` integer (128)
+Used to initialize <tt>time_domain</tt>, whose elements are
+&nbsp;&nbsp;&nbsp;&nbsp; -&beta;+&epsilon;, -&beta;+&Delta;, ..., -&Delta;, -&epsilon;, &epsilon;, &Delta;, ..., &beta;-&Delta;, &beta;-&epsilon;,
+where &Delta; = &beta;/*sp-time-intervals*.
+More precisely, it determines the *G*<sub>0</sub>-interpolation domain in CT-AUX and the *F*-interpolation domain in SS-CT-HYB.
 **TODO**: Make this clearer.
 
-`"time-intervals-for-time-measurements":` integer (1)  
+`"time-intervals-for-time-measurements":` integer (1)
 Used to initialize <tt>vertex_time_domain<TP_TIME_DOMAIN></tt> and <tt>vertex_time_domain<TP_TIME_DOMAIN_POSITIVE></tt>, where the latter is the domain for additional time measurements.
 
 
 <br></br>
-**Subgroup** `"imaginary-frequency"`  
-`"sp-fermionic-frequencies":` integer (256)  
-Number of positive and negative fermionic Matsubara frequencies, respectively.  
-Used to initialize <tt>frequency_domain</tt>, whose elements are (*n* = sp-fermionic-frequencies)  
+**Subgroup** `"imaginary-frequency"`
+`"sp-fermionic-frequencies":` integer (256)
+Number of positive and negative fermionic Matsubara frequencies, respectively.
+Used to initialize <tt>frequency_domain</tt>, whose elements are (*n* = sp-fermionic-frequencies)
 &nbsp;&nbsp;&nbsp;&nbsp; -(2*n*-1)&pi;/&beta;, ..., -3&pi;/&beta;, -&pi;/&beta;, &pi;/&beta;, 3&pi;/&beta;, ..., (2*n*-1)&pi;/&beta;.
 
-`"HTS-bosonic-frequencies":` integer (0)  
+`"HTS-bosonic-frequencies":` integer (0)
 Used to initialize <tt>vertex_frequency_domain<EXTENDED_BOSONIC></tt>, which is the bosonic Matsubara frequency mesh employed in the HTS-solver.
-The elements of the domain are (*n* = HTS-bosonic-frequencies):  
+The elements of the domain are (*n* = HTS-bosonic-frequencies):
 &nbsp;&nbsp;&nbsp;&nbsp; -2*n*&pi;/&beta;, ..., -2&pi;/&beta;, 0, &pi;/&beta;, ..., 2*n*&pi;/&beta;
 
-`"four-point-fermionic-frequencies":`  integer (1)  
+`"four-point-fermionic-frequencies":`  integer (1)
 Used to initialize <tt>vertex_frequency_domain<COMPACT/COMPACT_POSITIVE/EXTENDED/EXTENDED_POSITIVE></tt>, that is the fermionic Matsubara frequency mesh for measuring four-point quantities.
 
 <br></br>
-**Subgroup** `"real-frequency":`  
-`"min":` double (-10.)  
-`"max":` double (10.)  
-`"frequencies":` integer (3)  
-Parameters for the initialization of <tt>frequency_domain_real_axis</tt>:  
+**Subgroup** `"real-frequency":`
+`"min":` double (-10.)
+`"max":` double (10.)
+`"frequencies":` integer (3)
+Parameters for the initialization of <tt>frequency_domain_real_axis</tt>:
 &nbsp;&nbsp;&nbsp;&nbsp; *min*,  *min*+&Delta;, *min* + 2&Delta;, ..., *max*-&Delta;, *max*, &nbsp;&nbsp; &Delta; = (*max*-*min*)/(*frequencies*-1).
 
-`"imaginary-damping":` double (0.01)  
+`"imaginary-damping":` double (0.01)
 Small *positive* shift, used to shift the real frequencies &omega; away from the real axis, &omega; -> &omega;+i&eta;.
 
 #### Example
 
-    {	
+    {
         "domains": {
             "real-space-grids": {
                 "cluster": [[2, 0],
@@ -397,17 +397,17 @@ Defined in <tt>mci_parameters.hpp</tt>.
 
 **Group** `"Monte-Carlo-integration":`
 
-`"seed":` integer | string (985456376)  
-Seed for the random number generator(s) used in the Monte Carlo integration.  
+`"seed":` integer | string (985456376)
+Seed for the random number generator(s) used in the Monte Carlo integration.
 Instead of an integer, the string `"random"` can be passed to generate a random seed.
 
-`"warm-up-sweeps":` integer (20)  
+`"warm-up-sweeps":` integer (20)
 Number of warm-up sweeps.
 
-`"sweeps-per-measurement":` double (1.)  
+`"sweeps-per-measurement":` double (1.)
 Number of sweeps per measurement.
 
-`"measurements":` integer (100)  
+`"measurements":` integer (100)
 Number of independent measurements in each Monte Carlo iteration.
 
 `"error-computation-type:"`  string("NONE")\
@@ -420,19 +420,19 @@ Determines the type of error computation that will be performed during the last 
 If true, the vertex configuration is stored between DCA iterations to initialize the walkers of the following iteration.
 
 <br></br>
-**subgroup** `"threaded-solver":`  
-Additional parameters for threaded Monte Carlo solvers.  
-`"walkers":` integer (1)  
-Number of Monte Carlo walkers.  
-`"accumulators":` integer (1)  
-Number of Monte Carlo accumulators.  
+**subgroup** `"threaded-solver":`
+Additional parameters for threaded Monte Carlo solvers.
+`"walkers":` integer (1)
+Number of Monte Carlo walkers.
+`"accumulators":` integer (1)
+Number of Monte Carlo accumulators.
 `"shared-walk-and-accumulation-thread":` boolean (false)\
 When this mode is activated, each thread will run an instance of a walker and an accumulator. This parameter is ignored if the numbers of walkers and accumulators are different.\
 `"fix-meas-per-walker":` boolean(false)\
 The number of sweeps performed by each walker is fixed a priori, avoiding possible bias in the sampling of faster walkers.
 
 #### Example
-	
+
     {
         "Monte-Carlo-integration": {
             "seed": 42,
@@ -448,40 +448,40 @@ The number of sweeps performed by each walker is fixed a priori, avoiding possib
             }
         }
     }
-	
-	
+
+
 ## Monte Carlo solver parameters
 
-Defined in <tt>mc_solver_parameters.hpp</tt>.  
+Defined in <tt>mc_solver_parameters.hpp</tt>.
 The following parameter groups are *mutually exclusive*.
 
 ### CT-AUX
 
-**Group** `"CT-AUX":`  
+**Group** `"CT-AUX":`
 Used if *CT-AUX* is selected as the cluster solver.
 
-`"expansion-parameter-K":` double (1.)  
-The perturbation order in the CT-AUX algorithm increases linearly with the expansion parameter *K*.  
+`"expansion-parameter-K":` double (1.)
+The perturbation order in the CT-AUX algorithm increases linearly with the expansion parameter *K*.
 While *K* is only subject to the restriction of being positive, values of the order of 1 have proven to be a good choice [3].
 
-`"initial-configuration-size":` integer (10)  
+`"initial-configuration-size":` integer (10)
 The CT-AUX solver is initialized with `"initial-configuration-size"` random **interacting** vertices.
 
-`"initial-matrix-size":` integer (128)  
+`"initial-matrix-size":` integer (128)
 Initial size of the CT-AUX matrices.
 
-`"max-submatrix-size":` integer (128)  
+`"max-submatrix-size":` integer (128)
 Maximum number of single spin updates per submatrix update (see [4]).
 
-`"neglect-Bennett-updates":` boolean (false)  
+`"neglect-Bennett-updates":` boolean (false)
 Neglect the two types of Bennett updates:
-1. removal of an *interacting* spin that has already been proposed for removal,  
-2. removal of a *non-interacting* spin that has been proposed for insertion.  
+1. removal of an *interacting* spin that has already been proposed for removal,
+2. removal of a *non-interacting* spin that has been proposed for insertion.
 
 Turning on this option leads to a larger number of delayed spins (~`"max-submatrix-size"`) at the cost of a systematic error due to the violation of detailed balance.
 
 
-`"additional-time-measurements":` boolean (false)  
+`"additional-time-measurements":` boolean (false)
 Do additional time measurements.
 
 #### Example
@@ -501,17 +501,17 @@ Do additional time measurements.
 
 ### CT-HYB
 
-**Group** `"SS-CT-HYB":`  
+**Group** `"SS-CT-HYB":`
 Used if *SS-CT-HYB* is selected as the cluster solver.
 
-`"self-energy-tail-cutoff":` integer (0)  
+`"self-energy-tail-cutoff":` integer (0)
 Cut-off parameter for imaginary frequency tail of self-energy.
 
-`"steps-per-sweep":` double (0.5)  
-`"shifts-per-sweep":` double (0.5)  
-The fraction of insert/removal steps is given by  
-&nbsp;&nbsp;&nbsp;&nbsp; *steps-per-sweep/(steps-per-sweep + shifts-per-sweep)*,  
-while the fraction of segments shifts is  
+`"steps-per-sweep":` double (0.5)
+`"shifts-per-sweep":` double (0.5)
+The fraction of insert/removal steps is given by
+&nbsp;&nbsp;&nbsp;&nbsp; *steps-per-sweep/(steps-per-sweep + shifts-per-sweep)*,
+while the fraction of segments shifts is
 &nbsp;&nbsp;&nbsp;&nbsp; *shifts-per-sweep/(steps-per-sweep + shifts-per-sweep)*.
 
 #### Example
@@ -526,13 +526,13 @@ while the fraction of segments shifts is
 
 
 ## Four-point parameters
- 
+
 Defined in <tt>four_point_parameters.hpp</tt>.
 
 **Group** `"four-point":`
 
-`"type":` string ("NONE")  
-Four-point type, options are:  
+`"type":` string ("NONE")
+Deprecated option for selecting a single four-point channel type, options are:
 * "NONE"
 * "PARTICLE_PARTICLE_UP_DOWN"
 * "PARTICLE_HOLE_CHARGE"
@@ -541,19 +541,23 @@ Four-point type, options are:
 * "PARTICLE_HOLE_LONGITUDINAL_UP_DOWN"
 * "PARTICLE_HOLE_TRANSVERSE"
 
-`"momentum-transfer":` array of doubles (null vector with the dimension of the lattice, e.g. for a 2D lattice: [0., 0.])  
-Transferred momentum **q**.  
-Must be an element of the reciprocal lattice of the DCA cluster (|| **q** - **K**<sub>DCA</sub> ||<sub>2</sub> < 10<sup>-3</sup>).  
+`"channels":` array of strings ([])
+List of four point channels to be accumulated in the main dca application.
+Select only one for the analysis application.
 
-`"frequency-transfer":` integer (0)  
-Transferred frequency &omega;.   
+`"momentum-transfer":` array of doubles (null vector with the dimension of the lattice, e.g. for a 2D lattice: [0., 0.])
+Transferred momentum **q**.
+Must be an element of the reciprocal lattice of the DCA cluster (|| **q** - **K**<sub>DCA</sub> ||<sub>2</sub> < 10<sup>-3</sup>).
+
+`"frequency-transfer":` integer (0)
+Transferred frequency &omega;.
 Given as the index *n* of the bosonic Matsubara frequency &omega;<sub>*n*</sub> = 2*n*&pi;/&beta;.
 
 `"compute-all-transfers":` boolean (false)\
 When this mode is activated all possible positive frequency transfers, up to and including the transfer with index "frequency-transfer". All possible momentum transfers will be computed as well, ignoring the parameter "momentum-transfer".
 
 #### Example
-	
+
     {
         "four-point": {
             "type": "PARTICLE_PARTICLE_UP_DOWN",
@@ -562,27 +566,27 @@ When this mode is activated all possible positive frequency transfers, up to and
             "compute-all-transfers": false
         }
     }
-		
-		
+
+
 ## Analysis parameters
 
 Defined in <tt>analysis_parameters.hpp</tt>.
 
 **Group** `"analysis":`
 
-`"symmetrize-Gamma":` boolean (true)  
+`"symmetrize-Gamma":` boolean (true)
 Symmetrize &Gamma;<sub>cluster</sub> and &Gamma;<sub>lattice</sub> according to the symmetry group and diagrammatic symmetries.
 
-`"Gamma-deconvolution-cut-off":` double (0.5)  
-Cut-off parameter for the deconvolution of the vertex &Gamma;(**K**<sub>1</sub>, **K**<sub>2</sub>).  
-The deconvolution is done by Fourier transforming to real space, dividing by the coarse-graining patch functions in real space &phi;(**r**) and then transforming back to reciprocal space. The real space patch functions are only inverted down to the value of this parameter,  
-&nbsp;&nbsp;&nbsp;&nbsp; &phi;<sup>-1</sup><sub>cut-off</sub>(**r**) = &phi;<sup>-1</sup>(**r**),&nbsp;&nbsp; if &phi;(**r**) > *Gamma-deconvolution-cut-off*,  
+`"Gamma-deconvolution-cut-off":` double (0.5)
+Cut-off parameter for the deconvolution of the vertex &Gamma;(**K**<sub>1</sub>, **K**<sub>2</sub>).
+The deconvolution is done by Fourier transforming to real space, dividing by the coarse-graining patch functions in real space &phi;(**r**) and then transforming back to reciprocal space. The real space patch functions are only inverted down to the value of this parameter,
+&nbsp;&nbsp;&nbsp;&nbsp; &phi;<sup>-1</sup><sub>cut-off</sub>(**r**) = &phi;<sup>-1</sup>(**r**),&nbsp;&nbsp; if &phi;(**r**) > *Gamma-deconvolution-cut-off*,
 &nbsp;&nbsp;&nbsp;&nbsp; &phi;<sup>-1</sup><sub>cut-off</sub>(**r**) = 0,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; else.
 
-`"project-onto-chrystal-harmonics":` boolean (false)  
+`"project-onto-chrystal-harmonics":` boolean (false)
 Project &Gamma; &chi;<sub>0</sub> onto the crystal harmonic functions and diagonalize in this subspace.
 
-`"projection-cut-off-radius":` double (1.5)  
+`"projection-cut-off-radius":` double (1.5)
 For the projection use crystal-harmonic functions of lattice vectors **r** with ||**r**||<sub>2</sub> < *projection-cut-off-radius*.
 
 
@@ -599,12 +603,12 @@ For the projection use crystal-harmonic functions of lattice vectors **r** with 
 
 
 ## ED-solver parameters
-Defined in <tt>ed_solver_parameters.hpp</tt>.  
+Defined in <tt>ed_solver_parameters.hpp</tt>.
 Only required if the exact diagonalization solver is used, e.g. in the application <tt>cluster_solver_check</tt>.
 
 **Group** `"ED":`
 
-`"eigenvalue-cut-off":` double (1.e-6)  
+`"eigenvalue-cut-off":` double (1.e-6)
 Only keep energy eigenvalues *E* for which e<sup>-*&beta;E*</sup> > *eigenvalue-cut-off*.
 
 #### Example
@@ -618,19 +622,19 @@ Only keep energy eigenvalues *E* for which e<sup>-*&beta;E*</sup> > *eigenvalue-
 
 ## Double-counting parameters
 
-Defined in <tt>double_counting_parameters.hpp</tt>.  
+Defined in <tt>double_counting_parameters.hpp</tt>.
 Only required for LDA+DMFT.
 
 **Group** `"double-couting":`
 
-`"method":` string ("none")  
+`"method":` string ("none")
 The double-counting method to use, options are:
 
 * "none": no double-counting correction
 * "constant-correction-without-U-correction"
 * "constant-correction-with-U-correction"
 
-`"correction"`: double (0.)  
+`"correction"`: double (0.)
 The value of the double-counting correction.
 
 #### Example
@@ -642,9 +646,9 @@ The value of the double-counting correction.
         }
     }
 
-			
+
 ### References
-[1]	P. Staar, M. Jiang, U. R. Hähner, T. C. Schulthess, and T. A. Maier, Physical Review B 93, 165144 (2016).  
-[2] https://people.sc.fsu.edu/~jburkardt/cpp_src/simplex_gm_rule/simplex_gm_rule.html  
-[3] E. Gull, P. Werner, O. Parcollet, and M. Troyer, Europhys. Lett. 82, 57003 (2008).  
+[1]	P. Staar, M. Jiang, U. R. Hähner, T. C. Schulthess, and T. A. Maier, Physical Review B 93, 165144 (2016).
+[2] https://people.sc.fsu.edu/~jburkardt/cpp_src/simplex_gm_rule/simplex_gm_rule.html
+[3] E. Gull, P. Werner, O. Parcollet, and M. Troyer, Europhys. Lett. 82, 57003 (2008).
 [4] E. Gull, P. Staar, S. Fuchs, P. Nukala, M. S. Summers, T. Pruschke, T. C. Schulthess, and T. Maier, Physical Review B 83, 075122 (2011).

--- a/src/phys/four_point_type.cpp
+++ b/src/phys/four_point_type.cpp
@@ -18,9 +18,7 @@ namespace phys {
 // dca::phys::
 
 FourPointType stringToFourPointType(const std::string& name) {
-  if (name == "NONE")
-    return NONE;
-  else if (name == "PARTICLE_PARTICLE_UP_DOWN")
+  if (name == "PARTICLE_PARTICLE_UP_DOWN")
     return PARTICLE_PARTICLE_UP_DOWN;
   else if (name == "PARTICLE_HOLE_TRANSVERSE")
     return PARTICLE_HOLE_TRANSVERSE;
@@ -38,8 +36,6 @@ FourPointType stringToFourPointType(const std::string& name) {
 
 std::string toString(const FourPointType type) {
   switch (type) {
-    case NONE:
-      return "NONE";
     case PARTICLE_PARTICLE_UP_DOWN:
       return "PARTICLE_PARTICLE_UP_DOWN";
     case PARTICLE_HOLE_TRANSVERSE:
@@ -57,5 +53,5 @@ std::string toString(const FourPointType type) {
   }
 }
 
-}  // phys
-}  // dca
+}  // namespace phys
+}  // namespace dca

--- a/test/integration/cluster_solver/stdthread_qmci/stdthread_ctaux_tp_test.cpp
+++ b/test/integration/cluster_solver/stdthread_qmci/stdthread_ctaux_tp_test.cpp
@@ -91,7 +91,7 @@ void performTest(const std::string& input, const std::string& baseline) {
     // Read and confront with previous run.
     if (concurrency.id() == 0) {
       Data::SpGreensFunction G_k_w_check(data.G_k_w.get_name());
-      Data::TpGreensFunction G4_check(data.get_G4()[0].get_name());
+      Data::TpGreensFunction G4_check("G4");
       G_k_w_check.set_name(data.G_k_w.get_name());
       dca::io::HDF5Reader reader;
       reader.open_file(input_dir + baseline);

--- a/test/performance/phys/accumulation/tp_accumulation_performance_test.cpp
+++ b/test/performance/phys/accumulation/tp_accumulation_performance_test.cpp
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
     std::cout << "\nN positive frequencies:\t" << parameters.get_four_point_fermionic_frequencies();
     std::cout << "\nN bands:\t" << BDmn::dmn_size();
     std::cout << "\nN cluster sites:\t" << RDmn::dmn_size();
-    std::cout << "\nType:\t" << parameters.get_four_point_type();
+    std::cout << "\nType:\t" << dca::phys::toString(parameters.get_channels().at(0));
     std::cout << "\n\nTpAccumulation CPU time [sec]:\t " << time << "\n";
   }
 

--- a/test/performance/phys/accumulation/tp_accumulation_performance_test.cpp
+++ b/test/performance/phys/accumulation/tp_accumulation_performance_test.cpp
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
     std::cout << "\nN positive frequencies:\t" << parameters.get_four_point_fermionic_frequencies();
     std::cout << "\nN bands:\t" << BDmn::dmn_size();
     std::cout << "\nN cluster sites:\t" << RDmn::dmn_size();
-    std::cout << "\nType:\t" << dca::phys::toString(parameters.get_channels().at(0));
+    std::cout << "\nType:\t" << dca::phys::toString(parameters.get_four_point_channels().at(0));
     std::cout << "\n\nTpAccumulation CPU time [sec]:\t " << time << "\n";
   }
 

--- a/test/unit/function/function_library_test.cpp
+++ b/test/unit/function/function_library_test.cpp
@@ -415,15 +415,19 @@ TEST(FunctionTest, CopyConstructor) {
   for (int linind = 0; linind < f2.size(); ++linind)
     EXPECT_EQ(f1(linind), f2(linind));
 
-  // Custom name
-  FunctionType f3(f1, "copied");
+  // Same name
+  FunctionType f3(f1);
 
-  EXPECT_EQ("copied", f3.get_name());
+  EXPECT_EQ(f1.get_name(), f3.get_name());
   EXPECT_EQ(f1.signature(), f3.signature());
   EXPECT_EQ(f1.size(), f3.size());
 
   for (int linind = 0; linind < f3.size(); ++linind)
     EXPECT_EQ(f1(linind), f3(linind));
+
+  // Different name
+  FunctionType f4(f3, "another name");
+  EXPECT_EQ("another name", f4.get_name());
 }
 
 TEST(FunctionTest, MoveConstructor) {
@@ -443,16 +447,20 @@ TEST(FunctionTest, MoveConstructor) {
   for (int linind = 0; linind < f2.size(); ++linind)
     EXPECT_EQ(f1(linind), f2(linind));
 
-  // Custom name
+  // Copy name
   FunctionType f1_copy_2(f1);
-  FunctionType f3(std::move(f1_copy_2), "moved");
+  FunctionType f3(std::move(f1_copy_2));
 
-  EXPECT_EQ("moved", f3.get_name());
+  EXPECT_EQ(f1.get_name(), f3.get_name());
   EXPECT_EQ(f1.signature(), f3.signature());
   EXPECT_EQ(f1.size(), f3.size());
 
   for (int linind = 0; linind < f3.size(); ++linind)
     EXPECT_EQ(f1(linind), f3(linind));
+
+  // Different name
+  FunctionType f4(std::move(f3), "another name");
+  EXPECT_EQ("another name", f4.get_name());
 }
 
 TEST(FunctionTest, CopyAssignment) {

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu_test.cpp
@@ -48,17 +48,16 @@ TEST_F(TpAccumulatorGpuTest, Accumulate) {
                                         TpAccumulatorGpuTest::RDmn::dmn_size(),
                                         parameters_.get_beta(), n);
 
-  parameters_.accumulateG4ParticleHoleTransverse(true);
-  parameters_.accumulateG4ParticleHoleMagnetic(true);
-  parameters_.accumulateG4ParticleHoleCharge(true);
-  parameters_.accumulateG4ParticleHoleLongitudinalUpUp(true);
-  parameters_.accumulateG4ParticleHoleLongitudinalUpDown(true);
-  parameters_.accumulateG4ParticleParticleUpDown(true);
+  using namespace dca::phys;
+  parameters_.set_channels(
+      std::vector<FourPointType>{PARTICLE_HOLE_TRANSVERSE, PARTICLE_HOLE_MAGNETIC,
+                                 PARTICLE_HOLE_CHARGE, PARTICLE_HOLE_LONGITUDINAL_UP_UP,
+                                 PARTICLE_HOLE_LONGITUDINAL_UP_DOWN, PARTICLE_PARTICLE_UP_DOWN});
 
   dca::phys::solver::accumulator::TpAccumulator<Parameters, dca::linalg::CPU> accumulatorHost(
-    data_->G0_k_w_cluster_excluded, parameters_);
+      data_->G0_k_w_cluster_excluded, parameters_);
   dca::phys::solver::accumulator::TpAccumulator<Parameters, dca::linalg::GPU> accumulatorDevice(
-    data_->G0_k_w_cluster_excluded, parameters_);
+      data_->G0_k_w_cluster_excluded, parameters_);
   const int sign = 1;
 
   accumulatorDevice.resetAccumulation(loop_counter);

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu_test.cpp
@@ -49,7 +49,7 @@ TEST_F(TpAccumulatorGpuTest, Accumulate) {
                                         parameters_.get_beta(), n);
 
   using namespace dca::phys;
-  parameters_.set_channels(
+  parameters_.set_four_point_channels(
       std::vector<FourPointType>{PARTICLE_HOLE_TRANSVERSE, PARTICLE_HOLE_MAGNETIC,
                                  PARTICLE_HOLE_CHARGE, PARTICLE_HOLE_LONGITUDINAL_UP_UP,
                                  PARTICLE_HOLE_LONGITUDINAL_UP_DOWN, PARTICLE_PARTICLE_UP_DOWN});
@@ -80,7 +80,7 @@ TEST_F(TpAccumulatorGpuTest, Accumulate) {
 TEST_F(TpAccumulatorGpuTest, SumToAndFinalize) {
   dca::linalg::util::initializeMagma();
 
-  parameters_.set_channel(dca::phys::PARTICLE_HOLE_TRANSVERSE);
+  parameters_.set_four_point_channel(dca::phys::PARTICLE_HOLE_TRANSVERSE);
 
   using Accumulator =
       dca::phys::solver::accumulator::TpAccumulator<G0Setup::Parameters, dca::linalg::GPU>;

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_gpu_test.cpp
@@ -80,7 +80,7 @@ TEST_F(TpAccumulatorGpuTest, Accumulate) {
 TEST_F(TpAccumulatorGpuTest, SumToAndFinalize) {
   dca::linalg::util::initializeMagma();
 
-  parameters_.set_four_point_type(dca::phys::PARTICLE_HOLE_TRANSVERSE);
+  parameters_.set_channel(dca::phys::PARTICLE_HOLE_TRANSVERSE);
 
   using Accumulator =
       dca::phys::solver::accumulator::TpAccumulator<G0Setup::Parameters, dca::linalg::GPU>;

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_particle_hole_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_particle_hole_test.cpp
@@ -6,6 +6,7 @@
 // See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Urs R. Haehner (haehneru@itp.phys.ethz.ch)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This file tests the accumulation of the two-particle Green's function G4 in the particle-hole
 // channels based on the relation between the particle-hole longitudinal up-up and up-down channels,
@@ -43,10 +44,9 @@ TEST_F(TpAccumulatorTest, ParticleHoleChannels) {
                                         TpAccumulatorTest::RDmn::dmn_size(), parameters_.get_beta(),
                                         n);
 
-  parameters_.accumulateG4ParticleHoleLongitudinalUpUp(true);
-  parameters_.accumulateG4ParticleHoleLongitudinalUpDown(true);
-  parameters_.accumulateG4ParticleHoleMagnetic(true);
-  parameters_.accumulateG4ParticleHoleCharge(true);
+  parameters_.set_channels(std::vector<dca::phys::FourPointType>{
+      dca::phys::PARTICLE_HOLE_LONGITUDINAL_UP_UP, dca::phys::PARTICLE_HOLE_LONGITUDINAL_UP_DOWN,
+      dca::phys::PARTICLE_HOLE_MAGNETIC, dca::phys::PARTICLE_HOLE_CHARGE});
 
   using TpAccumulatorType = dca::phys::solver::accumulator::TpAccumulator<Parameters>;
   TpAccumulatorType accumulator_ph(data_->G0_k_w_cluster_excluded, parameters_);

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_particle_hole_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_particle_hole_test.cpp
@@ -44,7 +44,7 @@ TEST_F(TpAccumulatorTest, ParticleHoleChannels) {
                                         TpAccumulatorTest::RDmn::dmn_size(), parameters_.get_beta(),
                                         n);
 
-  parameters_.set_channels(std::vector<dca::phys::FourPointType>{
+  parameters_.set_four_point_channels(std::vector<dca::phys::FourPointType>{
       dca::phys::PARTICLE_HOLE_LONGITUDINAL_UP_UP, dca::phys::PARTICLE_HOLE_LONGITUDINAL_UP_DOWN,
       dca::phys::PARTICLE_HOLE_MAGNETIC, dca::phys::PARTICLE_HOLE_CHARGE});
 

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_singleband_gpu_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_singleband_gpu_test.cpp
@@ -49,7 +49,7 @@ TEST_F(TpAccumulatorGpuSinglebandTest, Accumulate) {
                                         parameters_.get_beta(), n);
 
   using namespace dca::phys;
-  parameters_.set_channels(
+  parameters_.set_four_point_channels(
       std::vector<FourPointType>{PARTICLE_HOLE_TRANSVERSE, PARTICLE_HOLE_MAGNETIC,
                                  PARTICLE_HOLE_CHARGE, PARTICLE_HOLE_LONGITUDINAL_UP_UP,
                                  PARTICLE_HOLE_LONGITUDINAL_UP_DOWN, PARTICLE_PARTICLE_UP_DOWN});

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_singleband_gpu_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_singleband_gpu_test.cpp
@@ -48,17 +48,16 @@ TEST_F(TpAccumulatorGpuSinglebandTest, Accumulate) {
                                         TpAccumulatorGpuSinglebandTest::RDmn::dmn_size(),
                                         parameters_.get_beta(), n);
 
-  parameters_.accumulateG4ParticleHoleTransverse(true);
-  parameters_.accumulateG4ParticleHoleMagnetic(true);
-  parameters_.accumulateG4ParticleHoleCharge(true);
-  parameters_.accumulateG4ParticleHoleLongitudinalUpUp(true);
-  parameters_.accumulateG4ParticleHoleLongitudinalUpDown(true);
-  parameters_.accumulateG4ParticleParticleUpDown(true);
+  using namespace dca::phys;
+  parameters_.set_channels(
+      std::vector<FourPointType>{PARTICLE_HOLE_TRANSVERSE, PARTICLE_HOLE_MAGNETIC,
+                                 PARTICLE_HOLE_CHARGE, PARTICLE_HOLE_LONGITUDINAL_UP_UP,
+                                 PARTICLE_HOLE_LONGITUDINAL_UP_DOWN, PARTICLE_PARTICLE_UP_DOWN});
 
   dca::phys::solver::accumulator::TpAccumulator<Parameters, dca::linalg::CPU> accumulatorHost(
-    data_->G0_k_w_cluster_excluded, parameters_);
+      data_->G0_k_w_cluster_excluded, parameters_);
   dca::phys::solver::accumulator::TpAccumulator<Parameters, dca::linalg::GPU> accumulatorDevice(
-    data_->G0_k_w_cluster_excluded, parameters_);
+      data_->G0_k_w_cluster_excluded, parameters_);
   const int sign = 1;
 
   accumulatorDevice.resetAccumulation(0);

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_singleband_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_singleband_test.cpp
@@ -67,7 +67,7 @@ TEST_F(TpAccumulatorSinglebandTest, Accumulate) {
   for (const dca::phys::FourPointType type :
        {dca::phys::PARTICLE_HOLE_TRANSVERSE, dca::phys::PARTICLE_HOLE_MAGNETIC,
         dca::phys::PARTICLE_HOLE_CHARGE, dca::phys::PARTICLE_PARTICLE_UP_DOWN}) {
-    parameters_.set_four_point_type(type);
+    parameters_.set_channel(type);
 
     dca::phys::solver::accumulator::TpAccumulator<Parameters> accumulator(
         data_->G0_k_w_cluster_excluded, parameters_);

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_singleband_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_singleband_test.cpp
@@ -67,7 +67,7 @@ TEST_F(TpAccumulatorSinglebandTest, Accumulate) {
   for (const dca::phys::FourPointType type :
        {dca::phys::PARTICLE_HOLE_TRANSVERSE, dca::phys::PARTICLE_HOLE_MAGNETIC,
         dca::phys::PARTICLE_HOLE_CHARGE, dca::phys::PARTICLE_PARTICLE_UP_DOWN}) {
-    parameters_.set_channel(type);
+    parameters_.set_four_point_channel(type);
 
     dca::phys::solver::accumulator::TpAccumulator<Parameters> accumulator(
         data_->G0_k_w_cluster_excluded, parameters_);

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_test.cpp
@@ -67,7 +67,7 @@ TEST_F(TpAccumulatorTest, Accumulate) {
   for (const dca::phys::FourPointType type :
        {dca::phys::PARTICLE_HOLE_TRANSVERSE, dca::phys::PARTICLE_HOLE_MAGNETIC,
         dca::phys::PARTICLE_HOLE_CHARGE, dca::phys::PARTICLE_PARTICLE_UP_DOWN}) {
-    parameters_.set_channel(type);
+    parameters_.set_four_point_channel(type);
 
     dca::phys::solver::accumulator::TpAccumulator<Parameters> accumulator(
         data_->G0_k_w_cluster_excluded, parameters_);

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/tp_accumulator_test.cpp
@@ -67,7 +67,7 @@ TEST_F(TpAccumulatorTest, Accumulate) {
   for (const dca::phys::FourPointType type :
        {dca::phys::PARTICLE_HOLE_TRANSVERSE, dca::phys::PARTICLE_HOLE_MAGNETIC,
         dca::phys::PARTICLE_HOLE_CHARGE, dca::phys::PARTICLE_PARTICLE_UP_DOWN}) {
-    parameters_.set_four_point_type(type);
+    parameters_.set_channel(type);
 
     dca::phys::solver::accumulator::TpAccumulator<Parameters> accumulator(
         data_->G0_k_w_cluster_excluded, parameters_);

--- a/test/unit/phys/parameters/four_point_parameters/four_point_parameters_test.cpp
+++ b/test/unit/phys/parameters/four_point_parameters/four_point_parameters_test.cpp
@@ -6,6 +6,7 @@
 // See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Urs R. Haehner (haehneru@itp.phys.ethz.ch)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This file tests four_point_parameters.hpp
 //
@@ -21,19 +22,20 @@ TEST(FourPointParametersTest, DefaultValues) {
 
   std::vector<double> momentum_transfer_input_check{0., 0.};
 
-  EXPECT_EQ(dca::phys::NONE, pars.get_four_point_type());
-
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleTransverse());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleMagnetic());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleCharge());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleLongitudinalUpUp());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleLongitudinalUpDown());
-  EXPECT_EQ(false, pars.accumulateG4ParticleParticleUpDown());
+  EXPECT_EQ(0, pars.get_channels().size());
 
   EXPECT_EQ(momentum_transfer_input_check, pars.get_four_point_momentum_transfer_input());
   EXPECT_EQ(0, pars.get_four_point_frequency_transfer());
   EXPECT_EQ(false, pars.compute_all_transfers());
 }
+
+using namespace dca::phys;
+const std::vector<FourPointType> all_channels{PARTICLE_HOLE_TRANSVERSE,
+                                              PARTICLE_HOLE_MAGNETIC,
+                                              PARTICLE_HOLE_CHARGE,
+                                              PARTICLE_HOLE_LONGITUDINAL_UP_UP,
+                                              PARTICLE_HOLE_LONGITUDINAL_UP_DOWN,
+                                              PARTICLE_PARTICLE_UP_DOWN};
 
 TEST(FourPointParametersTest, ReadAll) {
   dca::io::JSONReader reader;
@@ -46,14 +48,7 @@ TEST(FourPointParametersTest, ReadAll) {
 
   std::vector<double> momentum_transfer_input_check{3.14, -1.57};
 
-  EXPECT_EQ(dca::phys::PARTICLE_PARTICLE_UP_DOWN, pars.get_four_point_type());
-
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleTransverse());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleMagnetic());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleCharge());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleLongitudinalUpUp());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleLongitudinalUpDown());
-  EXPECT_EQ(true, pars.accumulateG4ParticleParticleUpDown());
+  EXPECT_EQ(all_channels, pars.get_channels());
 
   EXPECT_EQ(momentum_transfer_input_check, pars.get_four_point_momentum_transfer_input());
   EXPECT_EQ(1, pars.get_four_point_frequency_transfer());
@@ -63,29 +58,11 @@ TEST(FourPointParametersTest, ReadAll) {
 TEST(FourPointParametersTest, Setters) {
   dca::phys::params::FourPointParameters<2> pars;
 
-  EXPECT_EQ(dca::phys::NONE, pars.get_four_point_type());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleTransverse());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleMagnetic());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleCharge());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleLongitudinalUpUp());
-  EXPECT_EQ(false, pars.accumulateG4ParticleHoleLongitudinalUpDown());
-  EXPECT_EQ(false, pars.accumulateG4ParticleParticleUpDown());
+  EXPECT_EQ(0, pars.get_channels().size());
 
-  pars.set_four_point_type(dca::phys::PARTICLE_HOLE_MAGNETIC);
-  pars.accumulateG4ParticleHoleTransverse(true);
-  pars.accumulateG4ParticleHoleMagnetic(true);
-  pars.accumulateG4ParticleHoleCharge(true);
-  pars.accumulateG4ParticleHoleLongitudinalUpUp(true);
-  pars.accumulateG4ParticleHoleLongitudinalUpDown(true);
-  pars.accumulateG4ParticleParticleUpDown(true);
+  pars.set_channels(all_channels);
 
-  EXPECT_EQ(dca::phys::PARTICLE_HOLE_MAGNETIC, pars.get_four_point_type());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleTransverse());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleMagnetic());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleCharge());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleLongitudinalUpUp());
-  EXPECT_EQ(true, pars.accumulateG4ParticleHoleLongitudinalUpDown());
-  EXPECT_EQ(true, pars.accumulateG4ParticleParticleUpDown());
+  EXPECT_EQ(all_channels, pars.get_channels());
 }
 
 TEST(FourPointParametersTest, AccumulateG4) {
@@ -93,78 +70,19 @@ TEST(FourPointParametersTest, AccumulateG4) {
 
   EXPECT_EQ(false, pars.accumulateG4());
 
-  pars.set_four_point_type(dca::phys::PARTICLE_HOLE_MAGNETIC);
+  pars.set_channel(PARTICLE_HOLE_MAGNETIC);
+
   EXPECT_EQ(true, pars.accumulateG4());
-
-  pars.set_four_point_type(dca::phys::NONE);
-  EXPECT_EQ(false, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleTransverse(true);
-  EXPECT_EQ(true, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleTransverse(false);
-  EXPECT_EQ(false, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleCharge(true);
-  EXPECT_EQ(true, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleCharge(false);
-  EXPECT_EQ(false, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleMagnetic(true);
-  EXPECT_EQ(true, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleMagnetic(false);
-  EXPECT_EQ(false, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleLongitudinalUpUp(true);
-  EXPECT_EQ(true, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleLongitudinalUpUp(false);
-  EXPECT_EQ(false, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleLongitudinalUpDown(true);
-  EXPECT_EQ(true, pars.accumulateG4());
-
-  pars.accumulateG4ParticleHoleLongitudinalUpDown(false);
-  EXPECT_EQ(false, pars.accumulateG4());
-
-  pars.accumulateG4ParticleParticleUpDown(true);
-  EXPECT_EQ(true, pars.accumulateG4());
-
-  pars.accumulateG4ParticleParticleUpDown(false);
-  EXPECT_EQ(false, pars.accumulateG4());
 }
 
-TEST(FourPointParametersTest, NumG4Channels) {
-  dca::phys::params::FourPointParameters<2> pars;
+TEST(FourPointParametersTest, ReadLegacy) {
+    dca::io::JSONReader reader;
+    dca::phys::params::FourPointParameters<2> pars;
 
-  EXPECT_EQ(0, pars.numG4Channels());
+    reader.open_file(DCA_SOURCE_DIR
+                     "/test/unit/phys/parameters/four_point_parameters/input_read_legacy.json");
+    pars.readWrite(reader);
+    reader.close_file();
 
-  pars.set_four_point_type(dca::phys::PARTICLE_HOLE_MAGNETIC);
-  EXPECT_EQ(1, pars.numG4Channels());
-
-  pars.set_four_point_type(dca::phys::NONE);
-  EXPECT_EQ(0, pars.numG4Channels());
-
-  pars.accumulateG4ParticleHoleTransverse(true);
-  EXPECT_EQ(1, pars.numG4Channels());
-
-  pars.accumulateG4ParticleHoleCharge(true);
-  EXPECT_EQ(2, pars.numG4Channels());
-
-  pars.accumulateG4ParticleHoleMagnetic(true);
-  EXPECT_EQ(3, pars.numG4Channels());
-
-  pars.accumulateG4ParticleHoleLongitudinalUpUp(true);
-  EXPECT_EQ(4, pars.numG4Channels());
-
-  pars.accumulateG4ParticleHoleLongitudinalUpDown(true);
-  EXPECT_EQ(5, pars.numG4Channels());
-
-  pars.accumulateG4ParticleParticleUpDown(true);
-  EXPECT_EQ(6, pars.numG4Channels());
-
-  pars.set_four_point_type(dca::phys::PARTICLE_HOLE_MAGNETIC);
-  EXPECT_EQ(1, pars.numG4Channels());
+    EXPECT_EQ(std::vector<FourPointType>{PARTICLE_HOLE_MAGNETIC}, pars.get_channels());
 }

--- a/test/unit/phys/parameters/four_point_parameters/four_point_parameters_test.cpp
+++ b/test/unit/phys/parameters/four_point_parameters/four_point_parameters_test.cpp
@@ -22,7 +22,7 @@ TEST(FourPointParametersTest, DefaultValues) {
 
   std::vector<double> momentum_transfer_input_check{0., 0.};
 
-  EXPECT_EQ(0, pars.get_channels().size());
+  EXPECT_EQ(0, pars.get_four_point_channels().size());
 
   EXPECT_EQ(momentum_transfer_input_check, pars.get_four_point_momentum_transfer_input());
   EXPECT_EQ(0, pars.get_four_point_frequency_transfer());
@@ -48,7 +48,7 @@ TEST(FourPointParametersTest, ReadAll) {
 
   std::vector<double> momentum_transfer_input_check{3.14, -1.57};
 
-  EXPECT_EQ(all_channels, pars.get_channels());
+  EXPECT_EQ(all_channels, pars.get_four_point_channels());
 
   EXPECT_EQ(momentum_transfer_input_check, pars.get_four_point_momentum_transfer_input());
   EXPECT_EQ(1, pars.get_four_point_frequency_transfer());
@@ -58,21 +58,21 @@ TEST(FourPointParametersTest, ReadAll) {
 TEST(FourPointParametersTest, Setters) {
   dca::phys::params::FourPointParameters<2> pars;
 
-  EXPECT_EQ(0, pars.get_channels().size());
+  EXPECT_EQ(0, pars.get_four_point_channels().size());
 
-  pars.set_channels(all_channels);
+  pars.set_four_point_channels(all_channels);
 
-  EXPECT_EQ(all_channels, pars.get_channels());
+  EXPECT_EQ(all_channels, pars.get_four_point_channels());
 }
 
 TEST(FourPointParametersTest, AccumulateG4) {
   dca::phys::params::FourPointParameters<2> pars;
 
-  EXPECT_EQ(false, pars.accumulateG4());
+  EXPECT_EQ(false, pars.isAccumulatingG4());
 
-  pars.set_channel(PARTICLE_HOLE_MAGNETIC);
+  pars.set_four_point_channel(PARTICLE_HOLE_MAGNETIC);
 
-  EXPECT_EQ(true, pars.accumulateG4());
+  EXPECT_EQ(true, pars.isAccumulatingG4());
 }
 
 TEST(FourPointParametersTest, ReadLegacy) {
@@ -84,5 +84,5 @@ TEST(FourPointParametersTest, ReadLegacy) {
     pars.readWrite(reader);
     reader.close_file();
 
-    EXPECT_EQ(std::vector<FourPointType>{PARTICLE_HOLE_MAGNETIC}, pars.get_channels());
+    EXPECT_EQ(std::vector<FourPointType>{PARTICLE_HOLE_MAGNETIC}, pars.get_four_point_channels());
 }

--- a/test/unit/phys/parameters/four_point_parameters/input_read_all.json
+++ b/test/unit/phys/parameters/four_point_parameters/input_read_all.json
@@ -2,12 +2,12 @@
     "four-point": {
         "type": "PARTICLE_PARTICLE_UP_DOWN",
 
-        "particle-hole-transverse": true,
-        "particle-hole-magnetic": true,
-        "particle-hole-charge": true,
-        "particle-hole-longitudinal-up-up": true,
-        "particle-hole-longitudinal-up-down": true,
-        "particle-particle-up-down": true,
+        "channels" : ["PARTICLE_HOLE_TRANSVERSE",
+            "PARTICLE_HOLE_MAGNETIC",
+            "PARTICLE_HOLE_CHARGE",
+            "PARTICLE_HOLE_LONGITUDINAL_UP_UP",
+            "PARTICLE_HOLE_LONGITUDINAL_UP_DOWN",
+            "PARTICLE_PARTICLE_UP_DOWN"],
 
         "momentum-transfer": [3.14, -1.57],
         "frequency-transfer": 1,

--- a/test/unit/phys/parameters/four_point_parameters/input_read_legacy.json
+++ b/test/unit/phys/parameters/four_point_parameters/input_read_legacy.json
@@ -1,0 +1,5 @@
+{
+    "four-point": {
+        "type": "PARTICLE_HOLE_MAGNETIC"
+    }
+}

--- a/tools/complete_input.json
+++ b/tools/complete_input.json
@@ -131,7 +131,7 @@
     },
 
     "four-point": {
-        "type": "NONE",
+        "channel": [],
         "momentum-transfer": [0., 0.],
         "frequency-transfer": 0,
         "compute-all-transfers" : false


### PR DESCRIPTION
Depends on #138.

- Fixes issue 137 from DCA-develop by removing the duplicated parameter.
- Allow the code to be more maintainable with respect to the addition of new G4 channels.

- The function class now copies the name during construction. This violates the rule that copy/move constructors should behave identically to the assignment operator, but this allows the names a vector of functions to not break upon reallocation, which is particularly important if the code or tests rely on the name. The rationale would be that we do not want to erase a pre-existing name upon copying the values, but we are free to utilize another name while constructing a new function.

The wiki needs to be updated upon approval.