### PR TITLE
De obfuscate move and shrink

### DIFF
--- a/include/dca/linalg/util/allocators/pinned_allocator.hpp
+++ b/include/dca/linalg/util/allocators/pinned_allocator.hpp
@@ -57,13 +57,16 @@ public:
     ptr = nullptr;
   }
 
-  constexpr bool operator==(const PinnedAllocator<T>& /*other*/) {
-    return true;
-  }
-  constexpr bool operator!=(const PinnedAllocator<T>& /*other*/) {
-    return false;
-  }
 };
+
+// These are part of the requirements for a C++ Allocator however these are insufficient
+// and they do not appear to be relevant to our codebase yet.
+// They are part of what's needed to do a std::move on a PinnedAllocator backed object
+// and avoid deallocation and reallocation.
+template <class T, class U>
+bool operator==(const PinnedAllocator<T>&, const PinnedAllocator<U>&) { return true; }
+template <class T, class U>
+bool operator!=(const PinnedAllocator<T>&, const PinnedAllocator<U>&) { return false; }
 
 }  // util
 }  // linalg

--- a/include/dca/testing/type_testing.hpp
+++ b/include/dca/testing/type_testing.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 ETH Zurich
+// Copyright (C) 2019 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Peter Doak (doakpw@ornl.gov)
+//
+// This class provides an alternative output mode which produces minimal amount of information about
+// tests. Only failed assertions are disclosed.
+
+#ifndef DCA_TESTING_TYPE_TESTING_HPP
+#define DCA_TESTING_TYPE_TESTING_HPP
+
+#include <type_traits>
+
+namespace dca {
+namespace testing {
+
+template<typename...>
+using void_t = void;
+
+template<typename, typename, typename = void>
+struct can_compare : std::false_type {};
+
+template<typename A, typename B>
+struct can_compare<A, B,
+    void_t<decltype(std::declval<A>() == std::declval<B>())>
+                   > : std::true_type {};
+
+}
+}
+#endif

--- a/test/unit/linalg/util/CMakeLists.txt
+++ b/test/unit/linalg/util/CMakeLists.txt
@@ -14,3 +14,8 @@ dca_add_gtest(stream_handle_test
               GTEST_MAIN
               CUDA
               LIBS ${DCA_LIBS})
+
+dca_add_gtest(pinned_allocator_test
+              GTEST_MAIN
+              CUDA
+              LIBS ${DCA_LIBS} ${DCA_CUDA_LIBS})

--- a/test/unit/linalg/util/pinned_allocator_test.cpp
+++ b/test/unit/linalg/util/pinned_allocator_test.cpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 ETH Zurich
+// Copyright (C) 2019 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Peter Doak (doakpw@ornl.gov)
+//
+// This file tests the pinned allocator
+
+#include "dca/linalg/util/allocators/pinned_allocator.hpp"
+#include "dca/testing/type_testing.hpp"
+#include <stdexcept>
+#include <cuda_runtime.h>
+#include "gtest/gtest.h"
+
+TEST(PinnedAllocatorTest, Allocator) {
+  using dca::linalg::util::PinnedAllocator;
+  std::vector<int, PinnedAllocator<int>> pinned_array1(20,1.0);
+  std::vector<int, PinnedAllocator<int>> pinned_array2;
+  pinned_array2 = std::move(pinned_array1);
+
+  PinnedAllocator<double> dalloc;
+  PinnedAllocator<double> d2alloc;
+  PinnedAllocator<int> ialloc;
+  double* mymem = dalloc.allocate(64);
+  std::allocator<double> sdalloc;
+  EXPECT_TRUE( dalloc == d2alloc );
+  EXPECT_TRUE( dalloc == ialloc );
+
+  if(dalloc == d2alloc)
+    dalloc.deallocate(mymem);
+
+  // Test that compile time logic works as expected
+  static_assert(! dca::testing::can_compare<decltype(dalloc), decltype(sdalloc)>::value, "PinnedAllocator and std::allocator should not be comparable");
+  static_assert( dca::testing::can_compare<decltype(dalloc), decltype(d2alloc)>::value, "PinnedAllocator's should be comparable");
+  static_assert( dca::testing::can_compare<decltype(dalloc), decltype(ialloc)>::value, "PinnedAllocator's should be comparable");
+  
+}


### PR DESCRIPTION
I found the implementation very confusing. I think this is simpler, equivalent and it passes the unit test.