### PR TITLE
DMatrixBuilder and G0 interpolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,10 +151,9 @@ if (DCA_HAVE_CUDA)
     cuda_utils)
   list(APPEND DCA_LIBS
     blas_kernels
-    ctaux_walker_kernels
     dnfft_kernels
     lapack_kernels
-    mc_tools_kernels
+    mc_kernels
     special_transform_kernels
     ${DCA_CUDA_LIBS})
 endif()

--- a/include/dca/linalg/matrixop.hpp
+++ b/include/dca/linalg/matrixop.hpp
@@ -7,6 +7,7 @@
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
 //         Raffaele Solca' (rasolca@itp.phys.ethz.ch)
+//         Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
 //
 // This file provides the matrix interface for the following matrix operations:
 // - copyCol, copyRow, copyCols, copyRows
@@ -58,8 +59,7 @@ inline void copyMatrixToArray(const Matrix<Scalar, CPU>& mat, Scalar* a, int lda
 // Copies the m by n matrix stored in a to the matrix mat.
 // Preconditions: lda >= m.
 template <typename Scalar>
-inline void copyArrayToMatrix(int m, int n, const Scalar* a, int lda,
-                              Matrix<Scalar, CPU>& mat) {
+inline void copyArrayToMatrix(int m, int n, const Scalar* a, int lda, Matrix<Scalar, CPU>& mat) {
   assert(lda >= m);
   mat.resizeNoCopy(std::make_pair(m, n));
   lapack::lacpy("A", mat.nrRows(), mat.nrCols(), a, lda, mat.ptr(), mat.leadingDimension());
@@ -71,8 +71,7 @@ inline void copyArrayToMatrix(int m, int n, const Scalar* a, int lda,
 //                0 <= jx < mat_x.nrCols(), 0 <= jy < mat_y.nrCols().
 template <typename Scalar, DeviceType device_name>
 inline void copyCol(const Matrix<Scalar, device_name>& mat_x, int jx,
-                    Matrix<Scalar, device_name>& mat_y, int jy, int thread_id = 0,
-                    int stream_id = 0) {
+                    Matrix<Scalar, device_name>& mat_y, int jy, int thread_id = 0, int stream_id = 0) {
   assert(jx >= 0 && jx < mat_x.nrCols());
   assert(jy >= 0 && jy < mat_y.nrCols());
   assert(mat_x.nrRows() == mat_y.nrRows());
@@ -88,8 +87,8 @@ inline void copyCol(const Matrix<Scalar, device_name>& mat_x, int jx,
 //                0 <= j_y[i] < mat_y.nrCols() for 0 <= i < j_x.size().
 template <typename Scalar>
 inline void copyCols(const Matrix<Scalar, CPU>& mat_x, const Vector<int, CPU>& j_x,
-                     Matrix<Scalar, CPU>& mat_y, const Vector<int, CPU>& j_y,
-                     int /*thread_id*/ = 0, int /*stream_id*/ = 0) {
+                     Matrix<Scalar, CPU>& mat_y, const Vector<int, CPU>& j_y, int /*thread_id*/ = 0,
+                     int /*stream_id*/ = 0) {
   assert(j_x.size() <= j_y.size());
 
   for (int ind_j = 0; ind_j < j_x.size(); ++ind_j)
@@ -114,8 +113,7 @@ inline void copyCols(const Matrix<Scalar, GPU>& mat_x, const Vector<int, GPU>& j
 //                0 <= ix < mat_x.nrRows(), 0 <= iy < mat_y.nrRows().
 template <typename Scalar, DeviceType device_name>
 inline void copyRow(const Matrix<Scalar, device_name>& mat_x, int ix,
-                    Matrix<Scalar, device_name>& mat_y, int iy, int thread_id = 0,
-                    int stream_id = 0) {
+                    Matrix<Scalar, device_name>& mat_y, int iy, int thread_id = 0, int stream_id = 0) {
   assert(ix >= 0 && ix < mat_x.nrRows());
   assert(iy >= 0 && iy < mat_y.nrRows());
   assert(mat_x.nrCols() == mat_y.nrCols());
@@ -132,8 +130,8 @@ inline void copyRow(const Matrix<Scalar, device_name>& mat_x, int ix,
 //                0 <= i_y[i] < mat_y.nrRows() for 0 <= i < i_x.size().
 template <typename Scalar>
 inline void copyRows(const Matrix<Scalar, CPU>& mat_x, const Vector<int, CPU>& i_x,
-                     Matrix<Scalar, CPU>& mat_y, const Vector<int, CPU>& i_y,
-                     int /*thread_id*/ = 0, int /*stream_id*/ = 0) {
+                     Matrix<Scalar, CPU>& mat_y, const Vector<int, CPU>& i_y, int /*thread_id*/ = 0,
+                     int /*stream_id*/ = 0) {
   assert(i_x.size() <= i_y.size());
   assert(mat_x.nrCols() == mat_y.nrCols());
 
@@ -199,8 +197,8 @@ auto difference(const Matrix<Scalar, device_name>& a, const Matrix<Scalar, CPU>&
   return difference(cp_a, b, diff_threshold);
 }
 template <typename Scalar, DeviceType device_name_a, DeviceType device_name_b>
-auto difference(const Matrix<Scalar, device_name_a>& a,
-                const Matrix<Scalar, device_name_b>& b, double diff_threshold = 1e-3) {
+auto difference(const Matrix<Scalar, device_name_a>& a, const Matrix<Scalar, device_name_b>& b,
+                double diff_threshold = 1e-3) {
   Matrix<Scalar, CPU> cp_b(b);
   return difference(a, cp_b, diff_threshold);
 }
@@ -282,8 +280,7 @@ void inverse(MatrixType<Scalar, device_name>& mat) {
 }
 
 template <typename Scalar>
-void smallInverse(Matrix<Scalar, CPU>& m_inv, Vector<int, CPU>& ipiv,
-                  Vector<Scalar, CPU>& work) {
+void smallInverse(Matrix<Scalar, CPU>& m_inv, Vector<int, CPU>& ipiv, Vector<Scalar, CPU>& work) {
   assert(m_inv.is_square());
   switch (m_inv.nrCols()) {
     case 1:
@@ -303,8 +300,8 @@ void smallInverse(Matrix<Scalar, CPU>& m_inv, Vector<int, CPU>& ipiv,
     case 3: {
       const Matrix<Scalar, CPU> m(m_inv);
       const Scalar det = m(0, 0) * (m(1, 1) * m(2, 2) - m(2, 1) * m(1, 2)) -
-                             m(1, 0) * (m(0, 1) * m(2, 2) - m(0, 2) * m(2, 1)) +
-                             m(2, 0) * (m(0, 1) * m(1, 2) - m(0, 2) * m(1, 1));
+                         m(1, 0) * (m(0, 1) * m(2, 2) - m(0, 2) * m(2, 1)) +
+                         m(2, 0) * (m(0, 1) * m(1, 2) - m(0, 2) * m(1, 1));
       m_inv(0, 0) = (m(1, 1) * m(2, 2) - m(2, 1) * m(1, 2)) / det;
       m_inv(0, 1) = -(m(0, 1) * m(2, 2) - m(0, 2) * m(2, 1)) / det;
       m_inv(0, 2) = (m(0, 1) * m(1, 2) - m(0, 2) * m(1, 1)) / det;
@@ -466,8 +463,7 @@ inline void scaleRow(Matrix<Scalar, device_name>& mat, int i, Scalar val, int th
 // Preconditions: i.size() == val.size(), 0 <= i[k] < mat.nrRow() for 0 <= k < i.size().
 template <typename Scalar>
 inline void scaleRows(Matrix<Scalar, CPU>& mat, const Vector<int, CPU>& i,
-                      const Vector<Scalar, CPU>& val, int /*thread_id*/ = 0,
-                      int /*stream_id*/ = 0) {
+                      const Vector<Scalar, CPU>& val, int /*thread_id*/ = 0, int /*stream_id*/ = 0) {
   assert(i.size() == val.size());
 
   for (int j = 0; j < mat.nrCols(); ++j)
@@ -562,8 +558,8 @@ inline void swapRowAndCol(Matrix<Scalar, device_name>& mat, int i1, int i2, int 
 //                a.nrRows() == y.size() if transa == 'N', a.nrCols() == y.size() otherwise,
 //                a.nrCols() == x.size() if transa == 'N', a.nrRows() == x.size() otherwise.
 template <typename Scalar>
-void gemv(char transa, Scalar alpha, const Matrix<Scalar, CPU>& a,
-          const Vector<Scalar, CPU>& x, Scalar beta, Vector<Scalar, CPU>& y) {
+void gemv(char transa, Scalar alpha, const Matrix<Scalar, CPU>& a, const Vector<Scalar, CPU>& x,
+          Scalar beta, Vector<Scalar, CPU>& y) {
   if (transa == 'N') {
     assert(a.nrRows() == y.size());
     assert(a.nrCols() == x.size());
@@ -603,8 +599,8 @@ void gemv(char transa, const Matrix<Scalar, CPU>& a, const Vector<Scalar, CPU>& 
 template <typename Scalar, DeviceType device_name, template <typename, DeviceType> class MatrixA,
           template <typename, DeviceType> class MatrixB, template <typename, DeviceType> class MatrixC>
 void gemm(char transa, char transb, Scalar alpha, const MatrixA<Scalar, device_name>& a,
-          const MatrixB<Scalar, device_name>& b, Scalar beta,
-          MatrixC<Scalar, device_name>& c, int thread_id = 0, int stream_id = 0) {
+          const MatrixB<Scalar, device_name>& b, Scalar beta, MatrixC<Scalar, device_name>& c,
+          int thread_id = 0, int stream_id = 0) {
   int m = c.nrRows();
   int n = c.nrCols();
   int k;
@@ -705,8 +701,8 @@ void trsm(char uplo, char diag, const Matrix<Scalar, device_name>& a,
 //                ka == kb, where ka = a.nrCols() if transa == 'N', ka = a.nrRows() otherwise and
 //                          kb = b.nrRows() if transb == 'N', kb = b.nrCols() otherwise.
 template <typename Scalar>
-void gemm(char transa, char transb, Matrix<Scalar, CPU>& a,
-          Matrix<std::complex<Scalar>, CPU>& b, Matrix<std::complex<Scalar>, CPU>& c) {
+void gemm(char transa, char transb, Matrix<Scalar, CPU>& a, Matrix<std::complex<Scalar>, CPU>& b,
+          Matrix<std::complex<Scalar>, CPU>& c) {
   Matrix<Scalar, CPU> b_part(b.size());
   Matrix<Scalar, CPU> c_re(c.size());
   Matrix<Scalar, CPU> c_im(c.size());
@@ -789,8 +785,7 @@ static void gemm(char transa, char transb, Matrix<std::complex<Scalar>, CPU>& a,
 //                and kb = b[0].nrRows() if transb == 'N', kb = b[0].nrCols() otherwise.
 template <typename Scalar>
 void multiply(char transa, char transb, const std::array<Matrix<Scalar, CPU>, 2>& a,
-              const std::array<Matrix<Scalar, CPU>, 2>& b,
-              std::array<Matrix<Scalar, CPU>, 2>& c,
+              const std::array<Matrix<Scalar, CPU>, 2>& b, std::array<Matrix<Scalar, CPU>, 2>& c,
               std::array<Matrix<Scalar, CPU>, 5>& work) {
   assert(a[0].size() == a[1].size());
   assert(b[0].size() == b[1].size());
@@ -827,8 +822,7 @@ void multiply(char transa, char transb, const std::array<Matrix<Scalar, CPU>, 2>
 
 template <typename Scalar>
 void multiply(const std::array<Matrix<Scalar, CPU>, 2>& a,
-              const std::array<Matrix<Scalar, CPU>, 2>& b,
-              std::array<Matrix<Scalar, CPU>, 2>& c,
+              const std::array<Matrix<Scalar, CPU>, 2>& b, std::array<Matrix<Scalar, CPU>, 2>& c,
               std::array<Matrix<Scalar, CPU>, 5>& work) {
   multiply('N', 'N', a, b, c, work);
 }
@@ -847,8 +841,7 @@ void multiply(const std::array<Matrix<Scalar, CPU>, 2>& a,
 //                and kb = b.nrRows() if transb == 'N', kb = b.nrCols() otherwise.
 template <typename Scalar, DeviceType device_name>
 void multiply(char transa, char transb, const std::array<Matrix<Scalar, device_name>, 2>& a,
-              const Matrix<Scalar, device_name>& b,
-              std::array<Matrix<Scalar, device_name>, 2>& c) {
+              const Matrix<Scalar, device_name>& b, std::array<Matrix<Scalar, device_name>, 2>& c) {
   assert(transa == 'N' || transa == 'T' || transa == 'C');
   assert(transb == 'N' || transb == 'T');
   assert(a[0].size() == a[1].size());
@@ -861,8 +854,7 @@ void multiply(char transa, char transb, const std::array<Matrix<Scalar, device_n
 
 template <typename Scalar, DeviceType device_name>
 void multiply(const std::array<Matrix<Scalar, device_name>, 2>& a,
-              const Matrix<Scalar, device_name>& b,
-              std::array<Matrix<Scalar, device_name>, 2>& c) {
+              const Matrix<Scalar, device_name>& b, std::array<Matrix<Scalar, device_name>, 2>& c) {
   multiply('N', 'N', a, b, c);
 }
 
@@ -953,9 +945,8 @@ inline void multiplyDiagonalRight(const Matrix<Scalar, GPU>& a, const Vector<Sca
 // Postcondition: lambda_re, lambda_i, are resized, vl if jobvl == 'V', vr if jobvr == 'V' are
 // resized.
 template <typename Scalar>
-void eigensolver(char jobvl, char jobvr, const Matrix<Scalar, CPU>& a,
-                 Vector<Scalar, CPU>& lambda_re, Vector<Scalar, CPU>& lambda_im,
-                 Matrix<Scalar, CPU>& vl, Matrix<Scalar, CPU>& vr) {
+void eigensolver(char jobvl, char jobvr, const Matrix<Scalar, CPU>& a, Vector<Scalar, CPU>& lambda_re,
+                 Vector<Scalar, CPU>& lambda_im, Matrix<Scalar, CPU>& vl, Matrix<Scalar, CPU>& vr) {
   assert(a.is_square());
 
   Matrix<Scalar, CPU> a_copy(a);
@@ -992,8 +983,7 @@ void eigensolver(char jobvl, char jobvr, const Matrix<Scalar, CPU>& a,
 // Postcondition: lambda, is resized, vl if jobvl == 'V', vr if jobvr == 'V' are resized.
 template <typename Scalar>
 void eigensolver(char jobvl, char jobvr, const Matrix<std::complex<Scalar>, CPU>& a,
-                 Vector<std::complex<Scalar>, CPU>& lambda,
-                 Matrix<std::complex<Scalar>, CPU>& vl,
+                 Vector<std::complex<Scalar>, CPU>& lambda, Matrix<std::complex<Scalar>, CPU>& vl,
                  Matrix<std::complex<Scalar>, CPU>& vr) {
   assert(a.is_square());
 
@@ -1082,8 +1072,7 @@ void eigensolverHermitian(char jobv, char uplo, const Matrix<std::complex<Scalar
 }
 
 template <typename Scalar>
-void eigensolverGreensFunctionMatrix(char jobv, char uplo,
-                                     const Matrix<std::complex<Scalar>, CPU>& a,
+void eigensolverGreensFunctionMatrix(char jobv, char uplo, const Matrix<std::complex<Scalar>, CPU>& a,
                                      Vector<Scalar, CPU>& lambda,
                                      Matrix<std::complex<Scalar>, CPU>& v) {
   assert(a.is_square());
@@ -1112,8 +1101,7 @@ void eigensolverGreensFunctionMatrix(char jobv, char uplo,
 // Out: a_inv
 // Postconditions: a_inv is resized to the needed dimension.
 template <typename Scalar>
-void pseudoInverse(const Matrix<Scalar, CPU>& a, Matrix<Scalar, CPU>& a_inv,
-                   double eps = 1.e-6) {
+void pseudoInverse(const Matrix<Scalar, CPU>& a, Matrix<Scalar, CPU>& a_inv, double eps = 1.e-6) {
   int m = a.nrRows();
   int n = a.nrCols();
   a_inv.resizeNoCopy(std::make_pair(n, m));
@@ -1171,6 +1159,20 @@ void pseudoInverse(const Matrix<Scalar, CPU>& a, Matrix<Scalar, CPU>& a_inv,
     gemm('N', 'C', at_a, a, a_inv);
   }
 }
+
+template <typename Scalar>
+bool areNear(const Matrix<Scalar, CPU>& A, const Matrix<Scalar, CPU>& B, const double err = 1e-16) {
+  if (A.size() != B.size())
+    return false;
+
+  for (int j = 0; j < A.size().second; j++)
+    for (int i = 0; i < A.size().first; i++)
+      if (std::abs(A(i, j) - B(i, j)) > err)
+        return false;
+
+  return true;
+}
+
 }  // namespace matrixop
 }  // namespace linalg
 }  // namespace dca

--- a/include/dca/phys/dca_step/cluster_solver/cluster_solver_name.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/cluster_solver_name.hpp
@@ -17,7 +17,7 @@ namespace phys {
 namespace solver {
 // dca::phys::solver::
 
-enum ClusterSolverName { CT_AUX, SS_CT_HYB, ED_ADVANCED, HIGH_TEMPERATURE_SERIES };
+enum ClusterSolverName { CT_AUX, SS_CT_HYB, CT_INT, ED_ADVANCED, HIGH_TEMPERATURE_SERIES };
 
 }  // solver
 }  // phys

--- a/include/dca/phys/dca_step/cluster_solver/ctint/details/shrink_G0.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/details/shrink_G0.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage./
+//  See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// Method for extracting a single G0 sector.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DETAILS_SHRINK_G0_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DETAILS_SHRINK_G0_HPP
+
+#include "dca/function/function.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/domains/common_domains.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+namespace details {
+// dca::phys::solver::ctint::details::
+
+template <class Rdmn>
+auto shrinkG0(const func::function<double, func::dmn_variadic<Nu, Nu, Rdmn, Tdmn>>& G0) {
+  func::function<double, func::dmn_variadic<Bdmn, Bdmn, Rdmn, Tdmn>> g0_trimmed;
+  const int s = 0;
+  for (int b1 = 0; b1 < Bdmn::dmn_size(); b1++)
+    for (int b2 = 0; b2 < Bdmn::dmn_size(); b2++)
+      for (int r = 0; r < Rdmn::dmn_size(); r++)
+        for (int t = 0; t < Tdmn::dmn_size(); t++)
+          g0_trimmed(b1, b2, r, t) = G0(b1, s, b2, s, r, t);
+  return g0_trimmed;
+}
+
+}  // namespace details
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DETAILS_SHRINK_G0_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cuh
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cuh
@@ -1,0 +1,51 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.txt for citation guidelines if you use this code for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// Helper class used by the interpolation and DMatrixBuilder classes.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DEVICE_HELPER_CTINT_HELPER_CUH
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DEVICE_HELPER_CTINT_HELPER_CUH
+
+#include <vector>
+
+#include <cuda.h>
+
+#include "dca/phys/dca_step/cluster_solver/shared_tools/cluster_helper.cuh"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+class CtintHelper {
+public:
+  static void set(const int* sum_r, int lda, const int* sub_r, int lds, int nb, int nc, int r0);
+
+  // Return the index of a single particle function of b1, b2, r1 - r2.
+  __device__ std::size_t index(int b1, int b2, int r1, int r2) const;
+
+private:
+  std::size_t subdm_step_[2];
+};
+
+// Global instance.
+extern __device__ __constant__ CtintHelper ctint_helper;
+
+__device__ inline std::size_t CtintHelper::index(int b1, int b2, int r1, int r2) const {
+  const int delta_r = solver::details::cluster_real_helper.subtract(r2, r1);
+  return b1 + b2 * subdm_step_[0] + delta_r * subdm_step_[1];
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DEVICE_HELPER_CTINT_HELPER_CUH

--- a/include/dca/phys/dca_step/cluster_solver/ctint/domains/common_domains.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/domains/common_domains.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage./
+//  See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+//
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DOMAINS_COMMON_DOMAINS_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DOMAINS_COMMON_DOMAINS_HPP
+
+#include "dca/function/domains/dmn_0.hpp"
+#include "dca/function/domains/dmn_variadic.hpp"
+#include "dca/phys/domains/cluster/cluster_domain.hpp"
+#include "dca/phys/domains/quantum/electron_band_domain.hpp"
+#include "dca/phys/domains/quantum/electron_spin_domain.hpp"
+#include "dca/phys/domains/time_and_frequency/frequency_domain.hpp"
+#include "dca/phys/domains/time_and_frequency/time_domain.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+using dca::func::dmn_0;
+using dca::func::dmn_variadic;
+using Tdmn = dmn_0<domains::time_domain>;
+using Wdmn = dmn_0<domains::frequency_domain>;
+using Sdmn = dmn_0<domains::electron_spin_domain>;
+using Bdmn = dmn_0<domains::electron_band_domain>;
+using Sdmn = dmn_0<domains::electron_spin_domain>;
+using Nu = dmn_variadic<Bdmn, Sdmn>;
+
+
+template<int DIMENSION>
+using Rdmn_ = dmn_0<domains::cluster_domain<double, DIMENSION, domains::CLUSTER, domains::REAL_SPACE,
+                                           domains::BRILLOUIN_ZONE>>;
+template<int DIMENSION>
+using Kdmn_ = dmn_0<domains::cluster_domain<double, DIMENSION, domains::CLUSTER,
+                                           domains::MOMENTUM_SPACE, domains::BRILLOUIN_ZONE>>;
+
+
+}  // ctint
+}  // solver
+}  // phys
+}  // dca
+
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DOMAINS_COMMON_DOMAINS_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/domains/ct_int_domains.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/domains/ct_int_domains.hpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage./
+//  See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file provides the POsitiveTimeDomains and ParametersDomain used by the g0 interpolator.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DOMAINS_POSITIVE_TIME_DOMAIN_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DOMAINS_POSITIVE_TIME_DOMAIN_HPP
+
+#include <stdexcept>
+
+#include "dca/phys/domains/time_and_frequency/time_domain.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+class PositiveTimeDomain {
+private:
+  using TimeDomain = dca::phys::domains::time_domain;
+
+public:
+  using ElementType = typename TimeDomain::element_type;
+  using element_type = ElementType;  // For putting PositiveTimeDomain in dmn_0.
+
+  // Creates a domain that contains the elements in the range [0, beta] of the base domain.
+  static void initialize();
+
+  static std::size_t get_size() {
+    return elements_.size();
+  }
+  static const std::string& get_name() {
+    return name_;
+  }
+  static std::vector<ElementType>& get_elements() {
+    assert(initialized_);
+    return elements_;
+  }
+
+  static bool is_initialized() {
+    return initialized_;
+  }
+
+private:
+  static void commonInit(const std::string& name);
+
+  static bool initialized_;
+  static std::string name_;
+  static std::vector<ElementType> elements_;
+};
+
+struct G0ParametersDomain {
+  void static initialize(int n) {
+    size_ = n;
+  }
+
+  void static reset() {
+    size_ = -1;
+  }
+
+  // Used by dmn_variadic to compute the size.
+  int static get_size() {
+    return size_;
+  }
+
+  using element_type = void;
+  using this_type = G0ParametersDomain;
+
+private:
+  static int size_;
+};
+
+
+
+}  // dca
+}  // phys
+}  // solver
+}  // ctint
+
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_DOMAINS_POSITIVE_TIME_DOMAIN_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.hpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//          Jérémie Bouquet (bouquetj@gmail.com)
+//
+// Class to compute matrices made by different combinations of G0 and auxiliary fields.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_D_MATRIX_BUILDER_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_D_MATRIX_BUILDER_HPP
+
+#include <array>
+#include <cassert>
+#include <type_traits>
+
+#include "dca/linalg/linalg.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/structs/solver_configuration.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/structs/ct_int_matrix_configuration.hpp"
+
+#ifdef DCA_HAVE_CUDA
+#include <cuda.h>
+#include "dca/phys/dca_step/cluster_solver/ctint/structs/device_configuration.hpp"
+#endif  // DCA_HAVE_CUDA
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+template <linalg::DeviceType device_t>
+class DMatrixBuilder;
+
+template <linalg::DeviceType device_t>
+using Matrix = linalg::Matrix<double, device_t>;
+
+template <>
+class DMatrixBuilder<linalg::CPU> {
+private:
+  using Matrix = linalg::Matrix<double, linalg::CPU>;
+  using MatrixPair = std::array<linalg::Matrix<double, linalg::CPU>, 2>;
+
+public:
+  template <class RDmn>
+  DMatrixBuilder(const G0Interpolation<linalg::CPU>& g0, int nb, const RDmn& /*r_dmn*/);
+
+  DMatrixBuilder(const G0Interpolation<linalg::CPU>& g0,
+                 const linalg::Matrix<int, linalg::CPU>& site_diff, int nb);
+
+  virtual ~DMatrixBuilder() {}
+
+  void setAlphas(const std::array<double, 3>& alphas_base, bool adjust_dd);
+
+  void buildSQR(MatrixPair& S, MatrixPair& Q, MatrixPair& R, const SolverConfiguration& config) const;
+
+  const G0Interpolation<linalg::CPU>& getG0() const {
+    return g0_ref_;
+  }
+
+  double computeD(const int i, const int j, const Sector& config) const;
+  double computeAlpha(const int aux_spin_type, const int b) const;
+  double computeF(const double alpha) const;
+  double computeF(const int aux_spin_type, int b) const;
+  double computeGamma(int aux_spin_type, int new_aux_spin_type, int b) const;
+  void computeG0(linalg::Matrix<double, linalg::CPU>& G0, const Sector& configuration,
+                 const int n_init, const int n_max, const int which_section) const;
+
+#ifdef DCA_HAVE_CUDA
+  virtual void computeG0(linalg::Matrix<double, linalg::GPU>& /*G0*/,
+                         const details::DeviceConfiguration& /*configuration*/, int /*n_init*/,
+                         bool /*right_section*/, cudaStream_t /*stream*/) const {
+    throw(std::runtime_error("Not implemented."));
+  }
+#endif  // DCA_HAVE_CUDA
+
+private:
+  int label(const int nu1, const int nu2, const int r) const;
+
+protected:
+  const G0Interpolation<linalg::CPU>& g0_ref_;
+  std::vector<double> alpha_dd_;
+  double alpha_dd_neg_ = 0;
+  double alpha_ndd_ = 0;
+  const int n_bands_ = -1;
+  std::array<int, 2> sbdm_step_;
+  // Note: site_diff is a matrix where site_diff(i,j) = r_j - r_i.
+  const linalg::Matrix<int, linalg::CPU>& site_diff_;
+};
+
+template <class RDmn>
+DMatrixBuilder<linalg::CPU>::DMatrixBuilder(const G0Interpolation<linalg::CPU>& g0, int nb,
+                                            const RDmn& /*r_dmn*/)
+    : DMatrixBuilder(g0, RDmn::parameter_type::get_subtract_matrix(), nb) {}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_D_MATRIX_BUILDER_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_gpu.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_gpu.hpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//          Jérémie Bouquet (bouquetj@gmail.com)
+//
+// Builds G0 matrices used by the GPU walker.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_D_MATRIX_BUILDER_GPU_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_D_MATRIX_BUILDER_GPU_HPP
+
+#ifndef DCA_HAVE_CUDA
+#error "This file needs GPU support."
+#endif
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.hpp"
+
+#include "dca/phys/dca_step/cluster_solver/ctint/structs/device_configuration.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation_gpu.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+template <>
+class DMatrixBuilder<linalg::GPU> final : public DMatrixBuilder<linalg::CPU> {
+private:
+  using Matrix = linalg::Matrix<double, linalg::GPU>;
+  using MatrixPair = std::array<linalg::Matrix<double, linalg::GPU>, 2>;
+  using BaseClass = DMatrixBuilder<linalg::CPU>;
+
+public:
+  template <class RDmn>
+  DMatrixBuilder(const G0Interpolation<linalg::GPU>& g0, int nb, const RDmn& /*rdmn*/);
+
+  DMatrixBuilder(const G0Interpolation<linalg::GPU>& g0,
+                 const linalg::Matrix<int, linalg::CPU>& site_diff,
+                 const linalg::Matrix<int, linalg::CPU>& site_add, int nb, int r0);
+
+
+  const G0Interpolation<linalg::GPU>& getG0() const {
+    return g0_ref_;
+  }
+
+  void computeG0(Matrix& G0, const details::DeviceConfiguration& configuration, int n_init,
+                 bool right_section, cudaStream_t stream) const override;
+
+private:
+  const G0Interpolation<linalg::GPU>& g0_ref_;
+};
+
+template <class RDmn>
+DMatrixBuilder<linalg::GPU>::DMatrixBuilder(const G0Interpolation<linalg::GPU>& g0, int nb,
+                                            const RDmn& /*rdmn*/)
+    : DMatrixBuilder(g0, RDmn::parameter_type::get_add_matrix(),
+                     RDmn::parameter_type::get_subtract_matrix(), nb,
+                     RDmn::parameter_type::origin_index()) {}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_D_MATRIX_BUILDER_GPU_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/device_interpolation_data.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/device_interpolation_data.hpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file provides a trivially copyable representation of the data needed by
+// g0_interpolation_gpu.hpp.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_DEVICE_INTERPOLATION_DATA_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_DEVICE_INTERPOLATION_DATA_HPP
+#ifdef DCA_HAVE_CUDA
+
+#include "dca/util/cuda_definitions.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+class DeviceInterpolationData {
+public:
+  DeviceInterpolationData(const DeviceInterpolationData& other) = default;
+
+  __DEVICE__ double operator()(double tau, int lindex) const;
+
+protected:
+  DeviceInterpolationData() = default;
+
+  constexpr static int coeff_size_ = 4;  // Same as G0Interpolation<linalg::CPU>.
+  unsigned stride_;
+  double beta_, n_div_beta_;
+  double *values_, *g0_minus_;
+};
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_HAVE_CUDA
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_DEVICE_INTERPOLATION_DATA_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/function_proxy.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/function_proxy.hpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage./
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// Lightweight class providing constant access to a function of different domain with
+// the same total size.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_FUNCTION_PROXY_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_FUNCTION_PROXY_HPP
+
+#include "dca/function/function.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::pyhs::solver::ctint::
+
+template<typename ScalarType, class Domain>
+class FunctionProxy {
+  public:
+  template<class OtherDmn>
+  FunctionProxy(const func::function<ScalarType, OtherDmn>& f):
+  fnc_values_(f.values()),
+  dmn_(){
+    if(dmn_.get_size() != f.get_domain().get_size())
+      throw(std::logic_error("Domain sizes are different.\n"));
+  }
+
+  template <typename... Ts>
+  ScalarType operator()(Ts... indices) const{
+    return fnc_values_[dmn_(indices...)];
+  }
+
+private:
+  const ScalarType* fnc_values_;
+  Domain dmn_;
+};
+
+}  // ctint
+}  // solver
+}  // phys
+}  // dca
+
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_FUNCTION_PROXY_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.hpp
@@ -1,0 +1,110 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This class organizes the interpolation G0(tau) for tau in [0, beta]
+// specialization for CPU.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_G0_INTERPOLATION_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_G0_INTERPOLATION_HPP
+
+#include <assert.h>
+#include <vector>
+
+#include "dca/function/domains/dmn.hpp"
+#include "dca/function/domains/dmn_0.hpp"
+#include "dca/function/domains/dmn_variadic.hpp"
+#include "dca/function/function.hpp"
+#include "dca/linalg/device_type.hpp"
+#include "dca/math/interpolation/akima_interpolation.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/domains/ct_int_domains.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/function_proxy.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+// void template
+template <linalg::DeviceType device_t>
+class G0Interpolation {};
+
+// ParametersDomain is a collection of discrete labels not involving the time.
+template <>
+class G0Interpolation<linalg::CPU> {
+private:
+  using Pdmn = G0ParametersDomain;
+  using Pdmn0 = func::dmn_0<G0ParametersDomain>;
+  using Tdmn = func::dmn_0<domains::time_domain>;
+  using PTdmn = func::dmn_variadic<Pdmn0, Tdmn>;
+
+public:
+  G0Interpolation() = default;
+  // See this->initialize(G0_pars_t).
+  template <class InputDmn>
+  G0Interpolation(const func::function<double, InputDmn>& G0_pars_t);
+
+  virtual ~G0Interpolation() {}
+
+  // In: G0_pars_t. Assumed to be a function of discrete labels and time (in this order) and to
+  //             be antiperiodic in time.
+  template <class InputDmn>
+  void initialize(const func::function<double, InputDmn>& G0_pars_t);
+  // Constructor. Reshape the G0Dmn and calls the first constructor.
+  // In: G0_r_t: function of dmn_variadic<D1, D2, ..., Tdmn>
+
+  // Returns cubic interpolation of G0(tau) in the spin-band-position defined by lindex.
+  double operator()(double tau, int lindex) const;
+
+  // Number of value if g0 stored per parameter value.
+  int getTimeSlices() const {
+    return G0_coeff_[1];
+  }
+  int getStride() const {
+    return getTimeSlices() * COEFF_SIZE;
+  }
+
+  friend class G0Interpolation<linalg::GPU>;
+
+  static constexpr int COEFF_SIZE = 4;
+
+private:
+  virtual void initialize(const FunctionProxy<double, PTdmn>& G0_pars_t);
+
+private:
+  using CoeffDmn = func::dmn_0<func::dmn<COEFF_SIZE>>;
+  using PTime0 = func::dmn_0<PositiveTimeDomain>;
+  using InterpolationDmn = func::dmn_variadic<CoeffDmn, PTime0, Pdmn0>;
+
+  func::function<double, InterpolationDmn> G0_coeff_;
+  double beta_ = 0;
+  // value at tau = 0
+  std::vector<double> g0_minus_;
+  // Spacing between time bins.
+  double n_div_beta_;
+};
+
+template <class InputDmn>
+G0Interpolation<linalg::CPU>::G0Interpolation(const func::function<double, InputDmn>& G0_pars_t) {
+  initialize(G0_pars_t);
+}
+
+template <class InputDmn>
+void G0Interpolation<linalg::CPU>::initialize(const func::function<double, InputDmn>& G0_pars_t) {
+  PositiveTimeDomain::initialize();
+  Pdmn::initialize(InputDmn::dmn_size() / Tdmn::dmn_size());
+  initialize(FunctionProxy<double, PTdmn>(G0_pars_t));
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_G0_INTERPOLATION_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation_gpu.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation_gpu.hpp
@@ -1,0 +1,109 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This class organizes the interpolation G0(tau) for tau in [0, beta]
+// specialization for CPU.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_G0_INTERPOLATION_GPU_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_G0_INTERPOLATION_GPU_HPP
+#ifdef DCA_HAVE_CUDA
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/device_interpolation_data.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.hpp"
+
+#include <stdexcept>
+
+#include "dca/linalg/device_type.hpp"
+#include "dca/linalg/vector.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cuh"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/kernels_interface.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+template <>
+class G0Interpolation<linalg::GPU> final : public DeviceInterpolationData,
+                                           public G0Interpolation<linalg::CPU> {
+private:
+  using PDmn = G0ParametersDomain;
+  using PDmn0 = func::dmn_0<G0ParametersDomain>;
+  using TDmn = func::dmn_0<domains::time_domain>;
+  using HostInterpolation = G0Interpolation<linalg::CPU>;
+
+public:
+  G0Interpolation() = default;
+  G0Interpolation(const G0Interpolation<linalg::GPU>& other) = delete;
+
+  // See this->initialize(G0_pars_t).
+  template <class InputDmn>
+  G0Interpolation(const func::function<double, InputDmn>& G0_pars_t);
+  // In: G0_pars_t. Assumed to be a function of discrete labels and time (in this order) and to
+  //             be antiperiodic in time.
+  template <class InputDmn>
+  void initialize(const func::function<double, InputDmn>& G0_pars_t);
+  // Constructor. Reshape the G0Dmn and calls the first constructor.
+  // In: G0_r_t: function of dmn_variadic<D1, D2, ..., TDmn>
+
+  // Returns cubic interpolation of G0(tau) in the spin-band-position defined by lindex.
+  // Call from the CPU only for testing purposes.
+  double operator()(double tau, int lindex) const;
+
+  //  int getStride() const {
+  //    if (time_slices_ == -1)
+  //      throw(std::logic_error("The interpolation was not initialized."));
+  //    return time_slices_ * COEFF_SIZE;
+  //  }
+
+  using HostInterpolation::COEFF_SIZE;
+
+private:
+  using HostInterpolation::CoeffDmn;
+  using HostInterpolation::PTime0;
+  using HostInterpolation::InterpolationDmn;
+
+  linalg::Vector<double, linalg::GPU> G0_coeff_;
+  linalg::Vector<double, linalg::GPU> g0_minus_dev_;
+  int time_slices_ = -1;
+};
+
+template <class InputDmn>
+void G0Interpolation<linalg::GPU>::initialize(const func::function<double, InputDmn>& G0_pars_t) {
+  HostInterpolation::initialize(G0_pars_t);
+  assert(HostInterpolation::beta_);
+
+  time_slices_ = getTimeSlices();
+  DeviceInterpolationData::beta_ = HostInterpolation::beta_;
+  DeviceInterpolationData::n_div_beta_ = HostInterpolation::n_div_beta_;
+  DeviceInterpolationData::stride_ = HostInterpolation::getStride();
+
+  g0_minus_dev_.set(HostInterpolation::g0_minus_, 0, 0);
+  G0_coeff_.resizeNoCopy(HostInterpolation::G0_coeff_.size());
+  cudaMemcpy(G0_coeff_.ptr(), HostInterpolation::G0_coeff_.values(),
+             G0_coeff_.size() * sizeof(decltype(G0_coeff_.ptr())), cudaMemcpyHostToDevice);
+  // Copy pointer to the data structure.
+  DeviceInterpolationData::values_ = G0_coeff_.ptr();
+  DeviceInterpolationData::g0_minus_ = g0_minus_dev_.ptr();
+}
+
+template <class InputDmn>
+G0Interpolation<linalg::GPU>::G0Interpolation(const func::function<double, InputDmn>& G0_pars_t) {
+  initialize(G0_pars_t);
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_HAVE_CUDA
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_G0_INTERPOLATION_GPU_HPP

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/kernels_interface.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/kernels_interface.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file provides access to the kernel building the G0 matrix on the GPU.
+
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_KERNELS_INTERFACE_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_KERNELS_INTERFACE_HPP
+#ifdef DCA_HAVE_CUDA
+
+#include <cuda.h>
+
+#include "dca/linalg/matrix_view.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/structs/device_configuration.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/device_interpolation_data.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+namespace details {
+// dca::phys::solver::ctint::details::
+
+void buildG0Matrix(linalg::MatrixView<double, linalg::GPU> G0, const int n_init,
+                   const bool right_section, DeviceConfiguration config,
+                   DeviceInterpolationData g0_interp, cudaStream_t stream);
+
+}  // namespace details
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_HAVE_CUDA
+#endif  // DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_TOOLS_KERNELS_INTERFACE_HPP

--- a/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/g4_helper.cuh
+++ b/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/g4_helper.cuh
@@ -16,6 +16,8 @@
 
 #include <cuda.h>
 
+#include "dca/phys/dca_step/cluster_solver/shared_tools/cluster_helper.cuh"
+
 namespace dca {
 namespace phys {
 namespace solver {
@@ -58,12 +60,9 @@ protected:
   int lds_;
   int nw_pos_;
   int ext_size_;
-  int k0_;
   unsigned sbdm_steps_[10];
-  int* add_matrix_;
-  int* sub_matrix_;
-  int* w_ex_indices_;
-  int* k_ex_indices_;
+  const int* w_ex_indices_;
+  const int* k_ex_indices_;
 };
 
 // Global instance to be used in the tp accumulation kernel.
@@ -80,16 +79,16 @@ inline __device__ int G4Helper::wexMinus(const int w_idx, const int w_ex_idx) co
 
 inline __device__ int G4Helper::addKex(const int k_idx, const int k_ex_idx) const {
   const int k_ex = k_ex_indices_[k_ex_idx];
-  return add_matrix_[k_idx + lda_ * k_ex];
+  return solver::details::cluster_momentum_helper.add(k_idx, k_ex);
 }
 
 inline __device__ int G4Helper::kexMinus(const int k_idx, const int k_ex_idx) const {
   const int k_ex = k_ex_indices_[k_ex_idx];
-  return sub_matrix_[k_idx + lds_ * k_ex];
+  return solver::details::cluster_momentum_helper.subtract(k_idx, k_ex);
 }
 
 inline __device__ int G4Helper::kMinus(const int k_idx) const {
-  return sub_matrix_[k_idx + lds_ * k0_];
+  return solver::details::cluster_momentum_helper.minus(k_idx);
 }
 
 inline __device__ bool G4Helper::extendGIndices(int& k1, int& k2, int& w1, int& w2) const {

--- a/include/dca/phys/dca_step/cluster_solver/shared_tools/cluster_helper.cuh
+++ b/include/dca/phys/dca_step/cluster_solver/shared_tools/cluster_helper.cuh
@@ -1,0 +1,65 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.txt for citation guidelines if you use this code for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// Helper class for adding and subtracting cluster elements on the device.
+
+#ifndef DCA_INCLUDE_DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_SHARED_TOOLS_CLUSTER_HELPER_CUH
+#define DCA_INCLUDE_DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_SHARED_TOOLS_CLUSTER_HELPER_CUH
+
+#include <vector>
+
+#include <cuda.h>
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace details {
+// dca::phys::solver::details::
+
+class ClusterHelper {
+public:
+  // Initialize real reciprocal cluster if mometnum == true.
+  static void set(int nc, const int* add, int lda, const int* sub, int lds, bool momentum);
+
+  // Returns the index of id_1 + id_2.
+  __device__ inline int add(int id_1, int id_2) const;
+  // Returns the index of id_2 - id_1.
+  __device__ inline int subtract(int id_1, int id_2) const;
+  // returns the index of -id
+  __device__ inline int minus(int id) const;
+
+private:
+  int nc_;
+  const int* add_matrix_;
+  const int* sub_matrix_;
+};
+
+// Global instance for real space and momentum clusters.
+extern __device__ __constant__ ClusterHelper cluster_real_helper;
+extern __device__ __constant__ ClusterHelper cluster_momentum_helper;
+
+inline __device__ int ClusterHelper::add(const int id_1, const int id_2) const {
+  return add_matrix_[id_1 + nc_ * id_2];
+}
+
+inline __device__ int ClusterHelper::subtract(int id_1, int id_2) const {
+  return sub_matrix_[id_1 + nc_ * id_2];
+}
+
+inline __device__ int ClusterHelper::minus(const int id) const {
+  const int id_0 = sub_matrix_[0];
+  return sub_matrix_[id + nc_ * id_0];
+}
+
+}  // namespace details
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif  // DCA_INCLUDE_DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_SHARED_TOOLS_CLUSTER_HELPER_CUH

--- a/include/dca/util/cuda_blocks.hpp
+++ b/include/dca/util/cuda_blocks.hpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage./
+//  See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// Provides an utility to select block and grid size for CUDA kernels.
+
+#ifndef DCA_UTIL_CUDA_BLOCKS_HPP
+#define DCA_UTIL_CUDA_BLOCKS_HPP
+
+#include <array>
+#include <cassert>
+
+#include <cuda.h>
+
+#include "dca/util/integer_division.hpp"
+
+namespace dca {
+namespace util {
+// dca::util::
+
+inline std::array<int, 2> get1DBlockSize(const int ni, const int block_size) {
+  const int n_threads = std::min(block_size, ni);
+  const int n_blocks = util::ceilDiv(ni, n_threads);
+  return std::array<int, 2>{n_blocks, n_threads};
+}
+
+inline std::array<dim3, 2> get2DBlockSize(const uint i, const uint j, const uint block_size = 32) {
+  assert(i > 0 && j > 0);
+  const uint n_threads_i = std::min(block_size, i);
+  const uint n_threads_j = std::min(block_size, j);
+  if (n_threads_i * n_threads_j > 32 * 32)
+    throw(std::logic_error("Block size is too big"));
+
+  const uint n_blocks_i = dca::util::ceilDiv(i, n_threads_i);
+  const uint n_blocks_j = dca::util::ceilDiv(j, n_threads_j);
+
+  return std::array<dim3, 2>{dim3(n_blocks_i, n_blocks_j), dim3(n_threads_i, n_threads_j)};
+}
+
+inline std::array<dim3, 2> getBlockSize3D(const uint i, const uint j, const uint k) {
+  const uint n_threads_k = std::min(uint(8), k);
+  const uint max_block_size_ij = n_threads_k > 1 ? 8 : 32;
+  const uint n_threads_i = std::min(max_block_size_ij, i);
+  const uint n_threads_j = std::min(max_block_size_ij, j);
+
+  const uint n_blocks_i = dca::util::ceilDiv(i, n_threads_i);
+  const uint n_blocks_j = dca::util::ceilDiv(j, n_threads_j);
+  const uint n_blocks_k = dca::util::ceilDiv(k, n_threads_k);
+
+  return std::array<dim3, 2>{dim3(n_blocks_i, n_blocks_j, n_blocks_k),
+                             dim3(n_threads_i, n_threads_j, n_blocks_k)};
+}
+
+inline auto getBlockSize(const uint i, const uint j, const uint block_size = 32) {
+  return get2DBlockSize(i, j, block_size);
+}
+
+}  // util
+}  // dca
+
+#endif  // DCA_UTIL_CUDA_BLOCKS_HPP

--- a/include/dca/util/cuda_definitions.hpp
+++ b/include/dca/util/cuda_definitions.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage./
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// Redefine keyword like __device__ and __host__
+// so that code can be compiled either by nvcc or the host compiler.
+
+#ifndef DCA_UTIL_CUDA_DEFINITIONS_HPP
+#define DCA_UTIL_CUDA_DEFINITIONS_HPP
+
+#ifdef __CUDACC__
+#define __HOST__ __host__
+#define __DEVICE__ __device__
+#define IS_CUDA_COMPILER
+
+#else // the compiler is not nvcc
+#define __HOST__
+#define __DEVICE__
+#endif
+
+
+#endif  // DCA_UTIL_CUDA_DEFINITIONS_HPP

--- a/src/phys/dca_step/cluster_solver/CMakeLists.txt
+++ b/src/phys/dca_step/cluster_solver/CMakeLists.txt
@@ -2,5 +2,30 @@
 
 add_subdirectory(ctaux)
 add_subdirectory(ctint)
-add_subdirectory(shared_tools)
 add_subdirectory(ss_ct_hyb)
+
+if (DCA_HAVE_CUDA)
+    # All the interdependent .cu files need to be compiled together due to limits of the nvcc linker.
+    set(MC_KERNEL_FILES
+            # CT-INT
+            ctint/walker/tools/d_matrix_kernels.cu
+            ctint/device_helper/ctint_helper.cu
+            ctint/walker/tools/g0_interpolation_gpu.cu
+
+            # CT-AUX
+            ctaux/walker/ct_aux_walker_tools_kernels.cu
+            ctaux/walker/tools/g0_interpolation/g0_interpolation_kernels.cu
+            ctaux/walker/tools/g_matrix_tools/g_matrix_tools_kernels.cu
+            ctaux/walker/tools/n_matrix_tools/n_matrix_tools_kernels.cu
+
+            # Shared Tools
+            shared_tools/accumulation/tp/ndft/ndft_kernels.cu
+            shared_tools/accumulation/tp/tp_accumulator_kernels.cu
+            shared_tools/accumulation/tp/g4_helper.cu
+            shared_tools/cluster_helper.cu
+            )
+
+
+    cuda_add_library(mc_kernels ${MC_KERNEL_FILES})
+    target_compile_definitions(mc_kernels PUBLIC  "-DDCA_HAVE_CUDA")
+endif()

--- a/src/phys/dca_step/cluster_solver/ctaux/CMakeLists.txt
+++ b/src/phys/dca_step/cluster_solver/ctaux/CMakeLists.txt
@@ -12,13 +12,3 @@ if (DCA_HAVE_CUDA)
   set_property(TARGET ctaux
                APPEND PROPERTY COMPILE_DEFINITIONS DCA_HAVE_CUDA)
 endif ()
-
-if (DCA_HAVE_CUDA)
-  CUDA_ADD_LIBRARY(ctaux_walker_kernels
-    walker/ct_aux_walker_tools_kernels.cu
-    walker/tools/g0_interpolation/g0_interpolation_kernels.cu
-    walker/tools/g_matrix_tools/g_matrix_tools_kernels.cu
-    walker/tools/n_matrix_tools/n_matrix_tools_kernels.cu)
-
-  target_compile_definitions(ctaux_walker_kernels PRIVATE -DDCA_HAVE_CUDA)
-endif()

--- a/src/phys/dca_step/cluster_solver/ctint/CMakeLists.txt
+++ b/src/phys/dca_step/cluster_solver/ctint/CMakeLists.txt
@@ -1,8 +1,16 @@
 # CT-INT
 
+if (DCA_HAVE_CUDA)
+  set(CTINT_CUDA_CPP_FILES walker/tools/d_matrix_builder_gpu.cpp)
+endif ()
+
 add_library(ctint
+    domains/ct_int_domains.cpp
     structs/interaction_vertices.cpp
     structs/read_write_configuration.cpp
+    walker/tools/g0_interpolation.cpp
+    walker/tools/d_matrix_builder.cpp
+    ${CTINT_CUDA_CPP_FILES}
     )
 
 if (DCA_HAVE_CUDA)

--- a/src/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cu
+++ b/src/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cu
@@ -1,0 +1,44 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.txt for citation guidelines if you use this code for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file implements the static methods of CtintHelper.
+
+#include "dca/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cuh"
+
+#include <stdexcept>
+#include <mutex>
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+// Global helper instance.
+__device__ __constant__ CtintHelper ctint_helper;
+
+void CtintHelper::set(const int* add_r, int lda, const int* sub_r, int lds, const int nb,
+                      const int nc, const int r0) {
+  static std::once_flag flag;
+  std::call_once(flag, [&] {
+    // Initialize real space cluster.
+    solver::details::ClusterHelper::set(nc, add_r, lda, sub_r, lds, 0);
+
+    CtintHelper host_helper;
+    host_helper.subdm_step_[0] = nb;
+    host_helper.subdm_step_[1] = nb * nb;
+
+    cudaMemcpyToSymbol(ctint_helper, &host_helper, sizeof(CtintHelper));
+  });
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca

--- a/src/phys/dca_step/cluster_solver/ctint/domains/ct_int_domains.cpp
+++ b/src/phys/dca_step/cluster_solver/ctint/domains/ct_int_domains.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage./
+//  See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+//
+
+#include <algorithm>
+
+#include "dca/phys/dca_step/cluster_solver/ctint/domains/ct_int_domains.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+
+void PositiveTimeDomain::initialize() {
+  if (not TimeDomain::is_initialized())
+    throw(std::logic_error("Time domain was not initialized."));
+  if (initialized_) {  // Nothing to do (assume time domain did not change)
+    assert(elements_.size() == TimeDomain::get_size() / 2);
+    return;
+  }
+
+  const std::size_t size = TimeDomain::get_size() / 2;
+  elements_.resize(size);
+  std::copy_n(&TimeDomain::get_elements()[size], size, elements_.begin());
+
+  // TODO consider if  you have to remove the epsilon shift
+  // Remove shift by epsilon
+  elements_[0] = 0.;
+  elements_.back() = TimeDomain::get_volume();  // = beta.
+  initialized_ = true;
+}
+
+bool PositiveTimeDomain::initialized_ = false;
+std::string PositiveTimeDomain::name_ = "positive time domain";
+std::vector<typename PositiveTimeDomain::ElementType> PositiveTimeDomain::elements_;
+
+int G0ParametersDomain::size_ = -1;
+
+}  // dca
+}  // phys
+}  // solver
+}  // ctint

--- a/src/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.cpp
+++ b/src/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.cpp
@@ -1,0 +1,158 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//          Jérémie Bouquet (bouquetj@gmail.com).
+//
+// CPU implementation of d_matrix_builder.hpp
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+using linalg::CPU;
+using linalg::GPU;
+
+DMatrixBuilder<CPU>::DMatrixBuilder(const G0Interpolation<CPU>& g0,
+                                    const linalg::Matrix<int, linalg::CPU>& site_diff, const int nb)
+    : g0_ref_(g0), n_bands_(nb), sbdm_step_{nb, nb * nb}, site_diff_(site_diff) {}
+
+void DMatrixBuilder<CPU>::setAlphas(const std::array<double, 3>& alphas_base, bool adjust_dd) {
+  alpha_dd_neg_ = alphas_base[1];
+  alpha_ndd_ = alphas_base[2];
+
+  const int r0 = site_diff_(0, 0);
+  alpha_dd_.resize(n_bands_);
+  for (int b = 0; b < n_bands_; ++b) {
+    alpha_dd_[b] = alphas_base[0];
+    // TODO: check if shifting by g0(0+) or g0(0-).
+    if (adjust_dd)  // shift by g0(0).
+      alpha_dd_[b] += std::abs(g0_ref_(0., label(b, b, r0)));
+  }
+}
+
+void DMatrixBuilder<CPU>::buildSQR(MatrixPair& S, MatrixPair& Q, MatrixPair& R,
+                                   const SolverConfiguration& config) const {
+  std::array<int, 2> size_increase = config.sizeIncrease();
+
+  for (int s = 0; s < 2; ++s) {
+    const int delta = size_increase[s];
+    const Sector& sector = config.getSector(s);
+    const int n = sector.size() - delta;
+
+    Q[s].resizeNoCopy(std::make_pair(n, delta));
+    R[s].resizeNoCopy(std::make_pair(delta, n));
+    S[s].resizeNoCopy(std::make_pair(delta, delta));
+
+    for (int j = 0; j < delta; j++)
+      for (int i = 0; i < n; i++)
+        Q[s](i, j) = computeD(i, n + j, sector);
+    for (int j = 0; j < n; j++)
+      for (int i = 0; i < delta; i++)
+        R[s](i, j) = computeD(i + n, j, sector);
+    for (int j = 0; j < delta; j++)
+      for (int i = 0; i < delta; i++)
+        S[s](i, j) = computeD(n + i, n + j, sector);
+  }
+}
+
+double DMatrixBuilder<CPU>::computeD(const int i, const int j, const Sector& configuration) const {
+  assert(configuration.size() > i and configuration.size() > j);
+
+  const int b1 = configuration.getLeftB(i);
+  const int b2 = configuration.getRightB(j);
+  const int delta_r = site_diff_(configuration.getRightR(j), configuration.getLeftR(i));
+  const int p_index = label(b1, b2, delta_r);
+  const double delta_tau = configuration.getTau(i) - configuration.getTau(j);
+  const double g0_val = g0_ref_(delta_tau, p_index);
+  if (i == j)
+    return g0_val - computeAlpha(configuration.getAuxFieldType(i), b1);
+  else
+    return g0_val;
+}
+
+int DMatrixBuilder<CPU>::label(const int b1, const int b2, const int r) const {
+  return b1 + b2 * sbdm_step_[0] + r * sbdm_step_[1];
+}
+
+double DMatrixBuilder<CPU>::computeAlpha(const int aux_spin_type, const int b) const {
+  assert(alpha_dd_.size());
+  switch (std::abs(aux_spin_type)) {
+    case 1:
+      return aux_spin_type < 0 ? (0.5 + alpha_dd_[b]) : (0.5 - alpha_dd_[b]);
+    case 2:
+      return aux_spin_type < 0 ? (0.5 + alpha_dd_neg_) : (0.5 - alpha_dd_neg_);
+    case 3:
+      return aux_spin_type < 0 ? alpha_ndd_ : -alpha_ndd_;
+    default:
+      throw(std::logic_error("type not recognized."));
+  }
+}
+
+double DMatrixBuilder<CPU>::computeF(const double alpha) const {
+  return alpha / (alpha - 1);
+}
+
+double DMatrixBuilder<CPU>::computeF(const int aux_spin_type, int b) const {
+  if (aux_spin_type == 0)
+    return 1;
+  else
+    return computeF(computeAlpha(aux_spin_type, b));
+}
+
+double DMatrixBuilder<CPU>::computeGamma(const int aux_spin_type, const int new_aux_spin_type,
+                                         int b) const {
+  return (computeF(new_aux_spin_type, b) - computeF(aux_spin_type, b)) / computeF(aux_spin_type, b);
+}
+
+// Compute only the parts of G0 required at a given moment. (Re)Computing every element is not needed in most situations.
+void DMatrixBuilder<CPU>::computeG0(Matrix& G0, const Sector& configuration, const int n_init,
+                                    const int n_max, const int which_section) const {
+  int b_i, b_j, r_i, r_j;
+  double tau_i, tau_j;
+
+  if (which_section == 0) {
+    for (int i = n_init; i < n_max; ++i) {
+      b_i = configuration.getLeftB(i);
+      tau_i = configuration.getTau(i);
+      r_i = configuration.getLeftR(i);
+
+      for (int j = 0; j < n_init; ++j) {
+        b_j = configuration.getRightB(j);
+        tau_j = configuration.getTau(j);
+        r_j = configuration.getRightR(j);
+
+        G0(i - n_init, j) = g0_ref_(tau_i - tau_j, label(b_i, b_j, site_diff_(r_j, r_i)));
+      }
+    }
+  }
+
+  else {
+    for (int i = 0; i < n_max; ++i) {
+      b_i = configuration.getLeftB(i);
+      tau_i = configuration.getTau(i);
+      r_i = configuration.getLeftR(i);
+
+      for (int j = n_init; j < n_max; ++j) {
+        b_j = configuration.getRightB(j);
+        tau_j = configuration.getTau(j);
+        r_j = configuration.getRightR(j);
+
+        G0(i, j - n_init) = g0_ref_(tau_i - tau_j, label(b_i, b_j, site_diff_(r_j, r_i)));
+      }
+    }
+  }
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca

--- a/src/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_gpu.cpp
+++ b/src/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_gpu.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//          Jérémie Bouquet (bouquetj@gmail.com).
+//
+// GPU implementation of d_matrix_builder.hpp
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_gpu.hpp"
+
+#include "dca/linalg/matrix_view.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/kernels_interface.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cuh"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+using linalg::CPU;
+using linalg::GPU;
+
+DMatrixBuilder<linalg::GPU>::DMatrixBuilder(const G0Interpolation<GPU>& g0,
+                                            const linalg::Matrix<int, linalg::CPU>& site_add,
+                                            const linalg::Matrix<int, linalg::CPU>& site_diff,
+                                            const int nb, const int r0)
+    : BaseClass(g0, site_diff, nb), g0_ref_(g0) {
+  assert(site_add.size() == site_diff.size());
+  CtintHelper::set(site_add.ptr(), site_add.leadingDimension(), site_diff.ptr(),
+                   site_diff.leadingDimension(), nb, site_add.nrRows(), r0);
+}
+
+void DMatrixBuilder<GPU>::computeG0(Matrix& G0, const details::DeviceConfiguration& configuration,
+                                    const int n_init, bool right_section, cudaStream_t stream) const {
+  if (G0.nrRows() * G0.nrCols() == 0)
+    return;
+  details::buildG0Matrix(linalg::MatrixView<double, linalg::GPU>(G0), n_init, right_section,
+                         configuration, g0_ref_, stream);
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca

--- a/src/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_kernels.cu
+++ b/src/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_kernels.cu
@@ -1,0 +1,68 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file implements the device methods of DMatrixBuilder.
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/kernels_interface.hpp"
+
+#include <cuda.h>
+
+#include "dca/linalg/util/error_cuda.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cuh"
+#include "dca/util/cuda_blocks.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+namespace details {
+// dca::phys::solver::ctint::details::
+
+__global__ void buildG0MatrixKernel(linalg::MatrixView<double, linalg::GPU> G0, const int n_init,
+                                    const bool right_section, DeviceConfiguration config,
+                                    DeviceInterpolationData g0_interp) {
+  const int id_i = blockIdx.x * blockDim.x + threadIdx.x;
+  const int id_j = blockIdx.y * blockDim.y + threadIdx.y;
+  if (id_i >= G0.nrRows() || id_j >= G0.nrCols())
+    return;
+  int i(id_i);
+  int j(id_j);
+
+  if (right_section)
+    j += n_init;
+  else
+    i += n_init;
+
+  const int b_i = config.getLeftB(i);
+  const double tau_i = config.getTau(i);
+
+  const int b_j = config.getRightB(j);
+  const double tau_j = config.getTau(j);
+
+  const int label = ctint_helper.index(b_i, b_j, config.getLeftR(i), config.getRightR(j));
+
+  G0(id_i, id_j) = g0_interp(tau_i - tau_j, label);
+}
+
+void buildG0Matrix(linalg::MatrixView<double, linalg::GPU> G0, const int n_init,
+                   const bool right_section, DeviceConfiguration config,
+                   DeviceInterpolationData g0_interp, cudaStream_t stream) {
+  // assert(CtintHelper::is_initialized());
+  const auto blocks = dca::util::getBlockSize(G0.nrRows(), G0.nrCols());
+
+  buildG0MatrixKernel<<<blocks[0], blocks[1], 0, stream>>>(G0, n_init, right_section, config,
+                                                           g0_interp);
+  checkErrorsCudaDebug();
+}
+
+}  // namespace details
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca

--- a/src/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.cpp
+++ b/src/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.cpp
@@ -1,0 +1,80 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+//  See LICENSE.txt for terms of usage.
+//  See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// CPU implementation of g0_interpolation.hpp.
+
+#include <dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.hpp>
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+void G0Interpolation<linalg::CPU>::initialize(const FunctionProxy<double, PTdmn>& G0_pars_t) {
+  beta_ = PositiveTimeDomain::get_elements().back();
+  n_div_beta_ = double(PositiveTimeDomain::get_size() - 1) / beta_;
+
+  const int t_pos_size = PositiveTimeDomain::get_size();
+  dca::math::interpolation::akima_interpolation<double> akima_obj(t_pos_size);
+  G0_coeff_.reset();
+  g0_minus_.resize(Pdmn::get_size());
+
+  std::vector<double> y(t_pos_size), x(t_pos_size);
+  // The abscissa is scaled to integer steps
+  for (int i = 0; i < x.size(); i++)
+    x[i] = i;
+
+  // Loop over each cluster-orbital label.
+  for (int p = 0; p < Pdmn::get_size(); p++) {
+    // set G0(0-)
+    g0_minus_[p] = G0_pars_t(p, t_pos_size - 1);
+    // Compute interpolation coefficients:
+    for (int t = 0; t < t_pos_size; t++)
+      y[t] = G0_pars_t(p, t + t_pos_size);
+    akima_obj.initialize(x.data(), y.data());
+    // Store coefficients:
+    for (int t = 0; t < t_pos_size - 1; t++) {
+      for (int l = 0; l < 4; l++)
+        G0_coeff_(l, t, p) = akima_obj.get_alpha(l, t);
+      assert(G0_coeff_(0, t, p) == G0_pars_t(p, t + t_pos_size));
+    }
+  }
+}
+
+double G0Interpolation<linalg::CPU>::operator()(double tau, int lindex) const {
+  assert(beta_ != 0);
+  if (tau == 0)  // returns G0(tau = 0+)
+    return g0_minus_[lindex];
+
+  short int factor = 1;
+  if (tau < 0) {
+    tau += beta_;
+    factor = -1;
+  }
+  assert(tau >= 0 and tau <= beta_);
+  assert(lindex >= 0 and lindex < Pdmn::get_size());
+
+  // Scale tau in [0, n_time_slices). Assume even spacing in time.
+  const double scaled_tau = tau * n_div_beta_;
+  const int tau_index(scaled_tau);
+  const double delta_tau = scaled_tau - tau_index;
+
+  // Get the pointer to the first akima coeff.
+  const double* const coeff_ptr = &G0_coeff_(0, tau_index, lindex);
+  // Return akima interpolation.
+  return factor *
+         (coeff_ptr[0] +
+          delta_tau * (coeff_ptr[1] + delta_tau * (coeff_ptr[2] + delta_tau * coeff_ptr[3])));
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca

--- a/src/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation_gpu.cu
+++ b/src/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation_gpu.cu
@@ -1,0 +1,72 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Authors: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file implements the device methods of G0Interpolation<GPU>.
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation_gpu.hpp"
+
+#include <cuda_runtime.h>
+
+#include "dca/linalg/util/error_cuda.hpp"
+#include "dca/util/cuda_blocks.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+// dca::phys::solver::ctint::
+
+__device__ double DeviceInterpolationData::operator()(double tau, int lindex) const {
+  assert(tau >= -beta_ && tau <= beta_);
+
+  if (tau == 0)  // returns G0(tau = 0+)
+    return g0_minus_[lindex];
+
+  short int factor = 1;
+  if (tau < 0) {
+    tau += beta_;
+    factor = -1;
+  }
+
+  // Scale tau in [0, n_time_slices). Assume even spacing in time.
+  const double scaled_tau = tau * n_div_beta_;
+  const int tau_index(scaled_tau);
+  const double delta_tau = scaled_tau - tau_index;
+
+  // Get the pointer to the first akima coeff.
+  const double* coeff_ptr = &values_[tau_index * coeff_size_ + lindex * stride_];
+
+  // Return akima interpolation.
+  return factor *
+         (coeff_ptr[0] +
+          delta_tau * (coeff_ptr[1] + delta_tau * (coeff_ptr[2] + delta_tau * coeff_ptr[3])));
+}
+
+__global__ void g0InterpolationTestKernel(double tau, const int lindex,
+                                          DeviceInterpolationData g0, double* result) {
+  *result = g0(tau, lindex);
+}
+
+double G0Interpolation<linalg::GPU>::operator()(double tau, int lindex) const {
+  double* d_result;
+  double result;
+  cudaMalloc((void**)&d_result, sizeof(double));
+
+  g0InterpolationTestKernel<<<1, 1>>>(tau, lindex, *this, d_result);
+
+  assert(cudaSuccess == cudaPeekAtLastError());
+  cudaMemcpy(&result, d_result, sizeof(double), cudaMemcpyDeviceToHost);
+  cudaFree(d_result);
+  return result;
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca

--- a/src/phys/dca_step/cluster_solver/shared_tools/cluster_helper.cu
+++ b/src/phys/dca_step/cluster_solver/shared_tools/cluster_helper.cu
@@ -1,0 +1,59 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+// See CITATION.txt for citation guidelines if you use this code for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file implements ClusterHelper::set.
+
+#include "dca/phys/dca_step/cluster_solver/shared_tools/cluster_helper.cuh"
+
+#include <mutex>
+
+#include "dca/linalg/util/allocators/vectors_typedefs.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace details {
+// dca::phys::solver::details::
+
+__device__ __constant__ ClusterHelper cluster_real_helper;
+__device__ __constant__ ClusterHelper cluster_momentum_helper;
+
+void ClusterHelper::set(int nc, const int* add, int lda, const int* sub, int lds, bool momentum) {
+  static std::array<std::once_flag, 2> flags;
+
+  std::call_once(flags[momentum], [=]() {
+    ClusterHelper host_helper;
+    host_helper.nc_ = nc;
+
+    auto compact_transfer = [=](const int* matrix, int ldm, int** dest) {
+      linalg::util::HostVector<int> compact(nc * nc);
+      for (int j = 0; j < nc; ++j)
+        for (int i = 0; i < nc; ++i)
+          compact[i + nc * j] = matrix[i + ldm * j];
+
+      cudaMalloc(dest, sizeof(int) * lds * nc);
+      cudaMemcpy(*dest, compact.data(), sizeof(int) * nc * nc, cudaMemcpyHostToDevice);
+    };
+
+    compact_transfer(add, lda, const_cast<int**>(&host_helper.add_matrix_));
+    compact_transfer(sub, lds, const_cast<int**>(&host_helper.sub_matrix_));
+
+    if (momentum) {
+      cudaMemcpyToSymbol(cluster_momentum_helper, &host_helper, sizeof(ClusterHelper));
+    }
+    else {
+      cudaMemcpyToSymbol(cluster_real_helper, &host_helper, sizeof(ClusterHelper));
+    }
+  });
+}
+
+}  // namespace details
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca

--- a/test/unit/linalg/matrix_view_test.cpp
+++ b/test/unit/linalg/matrix_view_test.cpp
@@ -66,6 +66,24 @@ TEST(MatrixViewTest, ReadWrite) {
   EXPECT_DEBUG_DEATH(view(0, 4), "Assertion.");
 }
 
+TEST(MatrixViewTest, Assignment) {
+  dca::linalg::Matrix<int, dca::linalg::CPU> mat(4);
+  auto init_func = [](int i, int j) { return i >= 2 ? 1 : 0; };
+  testing::setMatrixElements(mat, init_func);
+
+  dca::linalg::MatrixView<int, dca::linalg::CPU> upper_left(mat, 0, 0, 2, 2);
+  dca::linalg::MatrixView<int, dca::linalg::CPU> lower_right(mat, 2, 2, 2, 2);
+
+  upper_left = lower_right;  // Assign ones to upper left submatrix.
+  for (int j = 0; j < 2; ++j)
+    for (int i = 0; i < 2; ++i)
+      EXPECT_EQ(1, mat(i, j));
+
+  dca::linalg::MatrixView<int, dca::linalg::CPU> another_size(mat, 0, 0, 3, 3);
+  // Invalid assignment:
+  EXPECT_THROW(upper_left = another_size       , std::invalid_argument);
+}
+
 TEST(MatrixViewTest, MakeConstantView) {
   dca::linalg::Matrix<double, dca::linalg::CPU> mat(std::make_pair(4, 2));
   auto init_func = [](int i, int j) { return j + 10. * i; };

--- a/test/unit/phys/dca_step/cluster_solver/ctint/CMakeLists.txt
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_subdirectory(structs)
-
+add_subdirectory(walker)

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/CMakeLists.txt
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(tools)

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/mock_parameters.hpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/mock_parameters.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE.txt for terms of usage.
+//  See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+// Giovanni Balduzzi(gbalduzz@ethz.phys.ch)
+//
+// This file provides the minimum parameters for initializing the time domain.
+
+#ifndef TEST_UNIT_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_MOCK_PARAMETERS_HPP
+#define TEST_UNIT_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_MOCK_PARAMETERS_HPP
+
+namespace dca {
+namespace ctint {
+namespace testing {
+// dca::testing::
+
+class MockParameters {
+private:
+  double beta_;
+  int time_intervals_;
+
+public:
+  MockParameters(double b, int i) : beta_(b), time_intervals_(i) {}
+
+  double get_beta() const {
+    return beta_;
+  }
+
+  int get_sp_time_intervals() const {
+    return time_intervals_;
+  }
+};
+
+}  // testing
+}  // ctint
+}  // dca
+
+#endif  //  TEST_UNIT_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_MOCK_PARAMETERS_HPP

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/tools/CMakeLists.txt
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/tools/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(TEST_INCLUDES ${DCA_INCLUDE_DIRS};${PROJECT_SOURCE_DIR})
+set(TEST_LIBS     ${DCA_LIBS})
+
+dca_add_gtest(ct_int_interpolation_test
+    FAST
+    GTEST_MAIN
+    INCLUDE_DIRS ${TEST_INCLUDES}
+    LIBS     ${TEST_LIBS}
+    )
+
+dca_add_gtest(ct_int_interpolation_test_gpu
+    FAST
+    CUDA
+    GTEST_MAIN
+    INCLUDE_DIRS ${TEST_INCLUDES}
+    LIBS     ${TEST_LIBS};mc_kernels
+    )
+
+dca_add_gtest(d_matrix_builder_test_gpu
+    FAST
+    CUDA
+    GTEST_MAIN
+    INCLUDE_DIRS ${TEST_INCLUDES}
+    LIBS     ${TEST_LIBS};mc_kernels;ctint
+    )

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/tools/ct_int_interpolation_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/tools/ct_int_interpolation_test.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file tests interpolation of G0 on the CPU.
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation.hpp"
+
+#include "gtest/gtest.h"
+#include <iostream>
+#include <cmath>
+
+#include "test/unit/phys/dca_step/cluster_solver/ctint/walker/mock_parameters.hpp"
+
+using std::cout;
+using std::endl;
+
+TEST(G0Interpolation, G0Interpolation) {
+  using dca::phys::domains::time_domain;
+  using dca::func::dmn_0;
+  using dca::func::dmn_variadic;
+  using LabelDmn = dmn_0<dca::func::dmn<2>>;
+
+  dca::ctint::testing::MockParameters pars(M_PI, 20);
+
+  // Initialize the domains.
+  time_domain::initialize(pars);
+  // dca::phys::solver::ctint::PositiveTimeDomain::initialize();
+
+  using TestDomain = dmn_variadic<LabelDmn, dmn_0<time_domain>>;
+  dca::func::function<double, TestDomain> f;
+
+  // Write function values.
+  for (int i = 0; i < time_domain::get_size(); i++) {
+    const double t = time_domain::get_elements()[i];
+    f(0, i) = std::sin(t);
+    f(1, i) = std::sin(2 * t);
+  }
+  dca::phys::solver::ctint::G0Interpolation<dca::linalg::CPU> g0(f);
+
+  for (double x : {0., 0.5, 3., M_PI - 1e-3}) {
+    EXPECT_NEAR(std::sin(x), g0(x, 0), 1e-3);
+    EXPECT_NEAR(std::sin(2 * x), g0(x, 1), 1e-3);
+
+    EXPECT_NEAR(-std::sin(x), g0(-x, 0), 1e-3);
+    EXPECT_NEAR(-std::sin(2 * x), -g0(x, 1), 1e-3);
+  }
+}

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/tools/ct_int_interpolation_test_gpu.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/tools/ct_int_interpolation_test_gpu.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file tests the interpolation of G0 on the GPU.
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/g0_interpolation_gpu.hpp"
+
+#include <iostream>
+#include <cmath>
+#include "gtest/gtest.h"
+
+#include "dca/phys/dca_step/cluster_solver/ctint/device_helper/ctint_helper.cuh"
+#include "test/unit/phys/dca_step/cluster_solver/ctint/walker/mock_parameters.hpp"
+
+using std::cout;
+using std::endl;
+
+TEST(G0Interpolation, G0Interpolation) {
+  using dca::phys::domains::time_domain;
+  using dca::func::dmn_0;
+  using dca::func::dmn_variadic;
+  using LabelDmn = dmn_0<dca::func::dmn<2>>;
+
+  dca::ctint::testing::MockParameters pars(M_PI, 20);
+
+  // Initialize the domains.
+  time_domain::initialize(pars);
+  // dca::phys::solver::ctint::PositiveTimeDomain::initialize();
+
+  using TestDomain = dmn_variadic<LabelDmn, dmn_0<time_domain>>;
+  dca::func::function<double, TestDomain> f;
+
+  // Write function values.
+  for (int i = 0; i < time_domain::get_size(); i++) {
+    const double t = time_domain::get_elements()[i];
+    f(0, i) = std::exp(t);
+    f(1, i) = std::sin(t);
+  }
+  dca::phys::solver::ctint::G0Interpolation<dca::linalg::CPU> g0_cpu(f);
+
+  dca::phys::solver::ctint::G0Interpolation<dca::linalg::GPU> g0_gpu(f);
+
+  for (double x : {0., 0.5, 3., M_PI - 1e-3}) {
+    EXPECT_NEAR(g0_cpu(x, 0), g0_gpu(x, 0), 1e-12);
+    EXPECT_NEAR(g0_cpu(x, 1), g0_gpu(x, 1), 1e-12);
+  }
+}

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_test_gpu.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_test_gpu.cpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2018 ETH Zurich
+// Copyright (C) 2018 UT-Battelle, LLC
+// All rights reserved.
+// See LICENSE.txt for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Giovanni Balduzzi (gbalduzz@itp.phys.ethz.ch)
+//
+// This file compares the CPU and GBU implementations of the DMatrixBuilder class.
+
+
+#include <dca/phys/dca_step/cluster_solver/ctint/structs/device_configuration_manager.hpp>
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_gpu.hpp"
+
+#include "gtest/gtest.h"
+
+#include "dca/linalg/matrixop.hpp"
+#include "dca/linalg/util/cuda_stream.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/details/shrink_G0.hpp"
+#include "test/unit/phys/dca_step/cluster_solver/test_setup.hpp"
+
+using G0Setup = dca::testing::G0Setup<dca::testing::LatticeSquare, dca::phys::solver::CT_INT>;
+using namespace dca::phys::solver;
+using HostMatrix = dca::linalg::Matrix<double, dca::linalg::CPU>;
+using DeviceMatrix = dca::linalg::Matrix<double, dca::linalg::GPU>;
+
+TEST_F(G0Setup, RemoveAndInstertVertex) {
+  // Setup rng values
+  std::vector<double> rng_values(100);
+  for (double& x : rng_values)
+    x = double(std::rand()) / RAND_MAX;
+  G0Setup::RngType rng(rng_values);
+
+  using namespace dca::testing;
+  dca::func::dmn_variadic<BDmn, BDmn, RDmn> label_dmn;
+
+  // Setup interpolation and matrix builder class.
+  ctint::G0Interpolation<dca::linalg::GPU> g0(
+      dca::phys::solver::ctint::details::shrinkG0(data_->G0_r_t));
+
+  const int nb = BDmn::dmn_size();
+
+  ctint::DMatrixBuilder<dca::linalg::GPU> builder(g0, nb, RDmn());
+  builder.setAlphas(parameters_.getAlphas(), false);
+
+  ctint::DMatrixBuilder<dca::linalg::CPU> builder_cpu(g0, nb, RDmn());
+  builder_cpu.setAlphas(parameters_.getAlphas(), false);
+
+  ctint::InteractionVertices interaction_vertices;
+    interaction_vertices.initializeFromHamiltonian(data_->H_interactions);
+
+  HostMatrix G0;
+  DeviceMatrix G0_dev;
+  dca::linalg::util::CudaStream stream;
+
+  const std::vector<int> sizes{1, 3, 8};
+  const std::vector<int> deltas{1, 2, 3};
+  int s(0);
+  bool right_sector = true;
+  for (int size : sizes) {
+    right_sector = !right_sector;
+
+    // Setup the configuration.
+    ctint::SolverConfiguration configuration(parameters_.get_beta(), BDmn::dmn_size(),
+                                             interaction_vertices);
+    ctint::DeviceConfigurationManager device_config;
+    for (int i = 0; i < size; i++)
+      configuration.insertRandom(rng);
+    device_config.upload(configuration, 0);
+
+    for (int delta : deltas) {
+      s = !s;
+      if (delta > size)
+        continue;
+
+      const int n_init = size - delta;
+      const std::pair<int, int> matrix_size =
+          right_sector ? std::make_pair(size, delta) : std::make_pair(delta, n_init);
+      G0.resizeNoCopy(matrix_size);
+      G0_dev.resizeNoCopy(matrix_size);
+
+      builder_cpu.computeG0(G0, configuration.getSector(s), n_init, size, right_sector);
+      builder.computeG0(G0_dev, device_config.getDeviceData(s), n_init, right_sector, stream);
+      cudaStreamSynchronize(stream);
+
+      HostMatrix G0_dev_copy(G0_dev);
+      EXPECT_TRUE(dca::linalg::matrixop::areNear(G0, G0_dev_copy, 1e-10));
+    }
+  }
+}

--- a/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/ndft/CMakeLists.txt
+++ b/test/unit/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/ndft/CMakeLists.txt
@@ -11,4 +11,4 @@ dca_add_gtest(cached_ndft_gpu_test
   CUDA
   FAST
   INCLUDE_DIRS ${DCA_INCLUDE_DIRS};${PROJECT_SOURCE_DIR}
-  LIBS ${DCA_CUDA_LIBS} time_and_frequency_domains random function mc_tools_kernels)
+  LIBS ${DCA_CUDA_LIBS} time_and_frequency_domains random function mc_kernels)


### PR DESCRIPTION
This PR includes the methods for computing the G0 and D matrix on CPU and GPU, plus all the changes necessary to accommodate them in the codebase.
All the solver .cu files are compiled in the same library to avoid issues at linkage time with nvcc.