### PR TITLE
Fix MPI datatype using FORTRAN complex types instead of CXX types

### DIFF
--- a/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
@@ -92,14 +92,14 @@ struct MPITypeMap<double> {
 template <>
 struct MPITypeMap<std::complex<float>> {
   static MPI_Datatype value() {
-    return MPI_COMPLEX;
+    return MPI_CXX_FLOAT_COMPLEX;
   }
 };
 
 template <>
 struct MPITypeMap<std::complex<double>> {
   static MPI_Datatype value() {
-    return MPI_DOUBLE_COMPLEX;
+    return MPI_CXX_DOUBLE_COMPLEX;
   }
 };
 

--- a/test/unit/parallel/mpi_concurrency/mpi_type_map_test.cpp
+++ b/test/unit/parallel/mpi_concurrency/mpi_type_map_test.cpp
@@ -31,9 +31,9 @@ TEST(MPITypeMapTest, All) {
 
   EXPECT_EQ(MPI_DOUBLE, MPITypeMap<double>::value());
 
-  EXPECT_EQ(MPI_COMPLEX, MPITypeMap<std::complex<float>>::value());
+  EXPECT_EQ(MPI_CXX_FLOAT_COMPLEX, MPITypeMap<std::complex<float>>::value());
 
-  EXPECT_EQ(MPI_DOUBLE_COMPLEX, MPITypeMap<std::complex<double>>::value());
+  EXPECT_EQ(MPI_CXX_DOUBLE_COMPLEX, MPITypeMap<std::complex<double>>::value());
 }
 
 TEST(MPITypeMapTest, Enums) {


### PR DESCRIPTION
This fixes some tests that failed on my laptop (mpich 3.3.1)