### PR TITLE
Fix #141

### DIFF
--- a/include/dca/parallel/stdthread/thread_pool/affinity.hpp
+++ b/include/dca/parallel/stdthread/thread_pool/affinity.hpp
@@ -19,11 +19,15 @@ namespace parallel {
 // dca::parallel::
 
 // Returns a list of cores id for which the calling thread has affinity.
+// If the macro __linux__ is not defined, returns an empty vector.
 std::vector<int> get_affinity();
 
+// Sets the affinity list of the current thread.
+// If the macro __linux__ is not defined, performs a no-op.
 void set_affinity(const std::vector<int>& cores);
 
-// Number of cores used by this process.
+// Returns the number of visible hardware cores.
+// If the macro __linux__ is not defined, returns std::hardware_concurrency().
 int get_core_count();
 
 }  // namespace parallel

--- a/test/unit/parallel/stdthread/thread_pool/affinity_test.cpp
+++ b/test/unit/parallel/stdthread/thread_pool/affinity_test.cpp
@@ -13,7 +13,6 @@
 
 #include <iostream>
 #include <future>
-#include <thread>
 
 #include "gtest/gtest.h"
 
@@ -40,12 +39,12 @@ TEST(AffinityTest, All) {
     dca::parallel::set_affinity(new_set);
 
     auto b = dca::parallel::get_affinity();
+#if defined(__linux__)
     EXPECT_TRUE(equal(new_set, b));
+#else
+    EXPECT_TRUE(equal(std::vector<int>{}, b));
+#endif
   });
 
   f.get();
-}
-
- TEST(AffinityTest, Count) {
-  EXPECT_EQ(std::thread::hardware_concurrency(), dca::parallel::get_core_count());
 }


### PR DESCRIPTION
The set affinity operations is now a no-op on a non-linux system. The test is pretty minimalistic, but this feature does not affect results, and the selected affinity is just what happens to work best on Summit.

@ubulling, can you test this on a mac and merge it?