### PR TITLE
default store-config is true.

### DIFF
--- a/include/dca/phys/parameters/mci_parameters.hpp
+++ b/include/dca/phys/parameters/mci_parameters.hpp
@@ -40,7 +40,7 @@ public:
         fix_meas_per_walker_(false),
         adjust_self_energy_for_double_counting_(false),
         error_computation_type_(ErrorComputationType::NONE),
-        store_configuration_(false) {}
+        store_configuration_(true) {}
 
   template <typename Concurrency>
   int getBufferSize(const Concurrency& concurrency) const;

--- a/misc/wiki/Parameters.md
+++ b/misc/wiki/Parameters.md
@@ -421,7 +421,7 @@ Determines the type of error computation that will be performed during the last 
 - "STANDARD_DEVIATION"
 - "JACK_KNIFE"
 
-`"store-configuration"` : boolean (false)
+`"store-configuration"` : boolean (true)
 If true, the vertex configuration is stored between DCA iterations to initialize the walkers of the following iteration.
 
 <br></br>

--- a/test/unit/phys/parameters/mci_parameters/input_read_all.json
+++ b/test/unit/phys/parameters/mci_parameters/input_read_all.json
@@ -5,7 +5,7 @@
         "sweeps-per-measurement": 4.,
         "measurements": 200,
         "error-computation-type" : "JACK_KNIFE",
-        "store-configuration" : true,
+        "store-configuration" : false,
 
         "threaded-solver": {
             "walkers": 3,

--- a/test/unit/phys/parameters/mci_parameters/mci_parameters_test.cpp
+++ b/test/unit/phys/parameters/mci_parameters/mci_parameters_test.cpp
@@ -34,8 +34,8 @@ TEST(MciParametersTest, DefaultValues) {
   EXPECT_EQ(1, pars.get_walkers());
   EXPECT_EQ(1, pars.get_accumulators());
   EXPECT_EQ(false, pars.shared_walk_and_accumulation_thread());
-  EXPECT_FALSE(pars.adjust_self_energy_for_double_counting());
-  EXPECT_FALSE(pars.store_configuration());
+  EXPECT_EQ(false, pars.adjust_self_energy_for_double_counting());
+  EXPECT_EQ(true, pars.store_configuration());
 }
 
 TEST(MciParametersTest, ReadAll) {
@@ -54,7 +54,7 @@ TEST(MciParametersTest, ReadAll) {
   EXPECT_EQ(3, pars.get_walkers());
   EXPECT_EQ(5, pars.get_accumulators());
   EXPECT_EQ(true, pars.shared_walk_and_accumulation_thread());
-  EXPECT_TRUE(pars.store_configuration());
+  EXPECT_EQ(false, pars.store_configuration());
 }
 
 TEST(MciParametersTest, ReadPositiveIntegerSeed) {


### PR DESCRIPTION
As discussed in the call, keep configurations between iterations by default.