### PR TITLE
Don't run multi GPU test if enough GPU's aren't present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,11 @@ set(DCA_LIBS
   cuda_utils
 )
 
+set(SYSTEM_GPU_COUNT 0)
+
 if (DCA_HAVE_CUDA)
+  EXECUTE_PROCESS(COMMAND bash -c "nvidia-smi -L | awk 'BEGIN { num_gpu=0;} /GPU/ { num_gpu++;} END { printf(\"%d\", num_gpu) }'"
+                  OUTPUT_VARIABLE SYSTEM_GPU_COUNT)
   list(APPEND DCA_LIBS
     blas_kernels
     dnfft_kernels
@@ -166,6 +170,8 @@ option(DCA_WITH_TESTS_FAST "Build DCA++'s fast tests." OFF)
 option(DCA_WITH_TESTS_EXTENSIVE "Build DCA++'s extensive tests." OFF)
 option(DCA_WITH_TESTS_PERFORMANCE "Build DCA++'s performance tests. (Only in Release mode.)" OFF)
 option(DCA_WITH_TESTS_STOCHASTIC  "Build DCA++'s stochastic tests." OFF)
+
+set(DCA_TEST_GPU_COUNT "${SYSTEM_GPU_COUNT}" CACHE INTEGER "Number of GPUs available on one node for one test.")
 
 set(TEST_RUNNER "" CACHE STRING "Command for executing (MPI) programs.")
 set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "Flag used by TEST_RUNNER to specify the number of processes.")

--- a/cmake/dca_testing.cmake
+++ b/cmake/dca_testing.cmake
@@ -82,7 +82,11 @@ function(dca_add_gtest name)
     return()
   endif()
 
-  if (DCA_ADD_GTEST_CUDA_CVD AND NOT DCA_HAVE_CUDA)
+  if (DCA_ADD_GTEST_CUDA_CVD AND NOT DCA_HAVE_CUDA )
+    return()
+  endif()
+
+  if (DCA_ADD_GTEST_CUDA_CVD AND (DCA_TEST_GPU_COUNT LESS 3) )
     return()
   endif()
 


### PR DESCRIPTION
this will prevent multi gpu tests from running if multiple GPU's are not present