### PR TITLE
Fix daint build

### DIFF
--- a/build-aux/daint_gpu.cmake
+++ b/build-aux/daint_gpu.cmake
@@ -17,5 +17,5 @@ option(DCA_WITH_CUDA "Enable GPU support." ON)
 
 # For the GPU support we also need MAGMA.
 # MAGMA has been installed with EasyBuild.
-set(MAGMA_DIR $ENV{EBROOTMAGMA} CACHE PATH
+set(MAGMA_DIR $ENV{MAGMAROOT} CACHE PATH
   "Path to the MAGMA installation directory. Hint for CMake to find MAGMA.")

--- a/build-aux/daint_gpu.cmake
+++ b/build-aux/daint_gpu.cmake
@@ -19,3 +19,8 @@ option(DCA_WITH_CUDA "Enable GPU support." ON)
 # MAGMA has been installed with EasyBuild.
 set(MAGMA_DIR $ENV{MAGMAROOT} CACHE PATH
   "Path to the MAGMA installation directory. Hint for CMake to find MAGMA.")
+
+
+# Intel MKL flags
+set(CMAKE_EXE_LINKER_FLAGS '-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_lp64
+    -lmkl_sequential -lmkl_core -lpthread -lm -ldl')

--- a/build-aux/daint_gpu.cmake
+++ b/build-aux/daint_gpu.cmake
@@ -22,5 +22,4 @@ set(MAGMA_DIR $ENV{MAGMAROOT} CACHE PATH
 
 
 # Intel MKL flags
-set(CMAKE_EXE_LINKER_FLAGS '-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_lp64
-    -lmkl_sequential -lmkl_core -lpthread -lm -ldl')
+set(CMAKE_EXE_LINKER_FLAGS '-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl' CACHE INTERNAL "" FORCE)

--- a/build-aux/daint_gpu_load_modules.sh
+++ b/build-aux/daint_gpu_load_modules.sh
@@ -1,0 +1,14 @@
+#echo "Clearing modules and loading DCA++ modules"
+#module purge
+
+module load daint-gpu
+module swich PrgEnv-cray PrgEnv-gnu
+
+module load cudatoolkit
+module load cray-mpich
+module load cray-hdf5
+module load cray-fftw
+module load papi-wrap
+
+export MAGMAROOT=/project/s299/easybuild/daint/haswell/software/magma/2.5.3-gcc-8.3-cuda-10.2
+export PATH=/project/s299/easybuild/daint/haswell/software/cmake/cmake-3.18.2/bin/:${PATH}

--- a/build-aux/daint_gpu_load_modules.sh
+++ b/build-aux/daint_gpu_load_modules.sh
@@ -8,7 +8,10 @@ module load cudatoolkit
 module load cray-mpich
 module load cray-hdf5
 module load cray-fftw
-module load papi-wrap
+
+# Use intel linear algebra libraries
+module unload cray-libsci/*
+module load intel
 
 export MAGMAROOT=/project/s299/easybuild/daint/haswell/software/magma/2.5.3-gcc-8.3-cuda-10.2
 export PATH=/project/s299/easybuild/daint/haswell/software/cmake/cmake-3.18.2/bin/:${PATH}

--- a/src/profiling/CMakeLists.txt
+++ b/src/profiling/CMakeLists.txt
@@ -3,7 +3,7 @@
 add_library(profiling STATIC events/time.cpp)
 
 find_library(PAPI_LIB papi)
-if(PAPI_LIB)
+if(PAPI_LIB AND DCA_PROFILER EQUAL "PAPI")
     add_library(papi_profiling STATIC events/papi_and_time_event.cpp)
     target_link_libraries(papi_profiling PUBLIC papi)
     target_link_libraries(profiling PUBLIC papi_profiling)

--- a/test/integration/cluster_solver/ss_ct_hyb/CMakeLists.txt
+++ b/test/integration/cluster_solver/ss_ct_hyb/CMakeLists.txt
@@ -1,8 +1,7 @@
 set(TEST_INCLUDES )
-set(TEST_LIBRARIES ${DCA_LIBS} ${DCA_CUDA_LIBS} statistical_testing)
+set(TEST_LIBRARIES ${DCA_LIBS} ${DCA_CUDA_LIBS})
 
 dca_add_gtest(NiO_no_change_test
-    GTEST_MAIN
     EXTENSIVE
     MPI MPI_NUMPROC 2
     INCLUDE_DIRS ${DCA_INCLUDE_DIRS};${PROJECT_SOURCE_DIR}

--- a/test/integration/cluster_solver/ss_ct_hyb/NiO_no_change_test.cpp
+++ b/test/integration/cluster_solver/ss_ct_hyb/NiO_no_change_test.cpp
@@ -23,15 +23,18 @@
 #include "dca/phys/parameters/parameters.hpp"
 #include "dca/profiling/null_profiler.hpp"
 #include "dca/util/git_version.hpp"
+#include "dca/testing/dca_mpi_test_environment.hpp"
+#include "dca/testing/minimalist_printer.hpp"
 
 constexpr int update_baseline = false;
 
 const std::string test_directory = DCA_SOURCE_DIR "/test/integration/cluster_solver/ss_ct_hyb/";
 
-TEST(Ni0NoChangeTest, GreensFunction) {
-  using Concurrency = dca::parallel::MPIConcurrency;
-  Concurrency concurrency(0, nullptr);
+using Concurrency = dca::parallel::MPIConcurrency;
+dca::testing::DcaMpiTestEnvironment* dca_test_env = nullptr;
 
+TEST(Ni0NoChangeTest, GreensFunction) {
+  auto& concurrency = dca_test_env->concurrency;
   const int id = concurrency.id();
 
   if (id == 0)
@@ -108,4 +111,24 @@ TEST(Ni0NoChangeTest, GreensFunction) {
       writer.close_file();
     }
   }
+}
+
+int main(int argc, char** argv) {
+  int result = 0;
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  dca_test_env = new dca::testing::DcaMpiTestEnvironment(argc, argv, "");
+  ::testing::AddGlobalTestEnvironment(dca_test_env);
+
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+
+  if (dca_test_env->concurrency.id() != 0) {
+    delete listeners.Release(listeners.default_result_printer());
+    listeners.Append(new dca::testing::MinimalistPrinter);
+  }
+
+  result = RUN_ALL_TESTS();
+
+  return result;
 }

--- a/test/integration/coarsegraining/CMakeLists.txt
+++ b/test/integration/coarsegraining/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 dca_add_gtest(coarsegraining_test
         EXTENSIVE
-        GTEST_MAIN
         MPI MPI_NUMPROC 2
         INCLUDE_DIRS ${DCA_INCLUDE_DIRS}
         LIBS         ${DCA_LIBS}

--- a/test/integration/coarsegraining/coarsegraining_test.cpp
+++ b/test/integration/coarsegraining/coarsegraining_test.cpp
@@ -28,7 +28,8 @@
 #include "gtest/gtest.h"
 
 #include "dca/function/function.hpp"
-#include "dca/function/util/difference.hpp"
+#include "dca/io/hdf5/hdf5_reader.hpp"
+#include "dca/io/hdf5/hdf5_writer.hpp"
 #include "dca/io/json/json_reader.hpp"
 #include "dca/phys/dca_data/dca_data.hpp"
 #include "dca/phys/domains/cluster/symmetries/point_groups/no_symmetry.hpp"
@@ -40,10 +41,8 @@
 #include "dca/phys/parameters/parameters.hpp"
 #include "dca/profiling/null_profiler.hpp"
 #include "dca/testing/minimalist_printer.hpp"
+#include "dca/testing/dca_mpi_test_environment.hpp"
 #include "dca/util/git_version.hpp"
-#include "dca/util/modules.hpp"
-#include "dca/io/hdf5/hdf5_reader.hpp"
-#include "dca/io/hdf5/hdf5_writer.hpp"
 
 // Set to true to dump the result in an hdf5 file.
 constexpr bool write_G_r_w = false;
@@ -76,8 +75,10 @@ using KDmn = Data::KClusterDmn;
 template <class SigmaType>
 void computeMockSigma(SigmaType& Sigma);
 
+dca::testing::DcaMpiTestEnvironment* dca_test_env;
+
 void performTest(const bool test_dca_plus) {
-  static Concurrency concurrency(0, nullptr);
+  auto& concurrency = dca_test_env->concurrency;
 
   Parameters parameters(dca::util::GitVersion::string(), concurrency);
   parameters.read_input_and_broadcast<dca::io::JSONReader>(input);
@@ -184,4 +185,24 @@ void computeMockSigma(SigmaType& Sigma) {
         for (int b = 0; b < BDmn::get_size(); ++b)
           Sigma(b, s, b, s, k, w) = sigma_val;
   }
+}
+
+int main(int argc, char** argv) {
+  int result = 0;
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  dca_test_env = new dca::testing::DcaMpiTestEnvironment(argc, argv, "");
+  ::testing::AddGlobalTestEnvironment(dca_test_env);
+
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+
+  if (dca_test_env->concurrency.id() != 0) {
+    delete listeners.Release(listeners.default_result_printer());
+    listeners.Append(new dca::testing::MinimalistPrinter);
+  }
+
+  result = RUN_ALL_TESTS();
+
+  return result;
 }

--- a/test/system-level/analysis/dca_pp_up_down_full/analysis_dca_pp_up_down_full_test.cpp
+++ b/test/system-level/analysis/dca_pp_up_down_full/analysis_dca_pp_up_down_full_test.cpp
@@ -103,9 +103,9 @@ TEST(AnalysisDCAParticleParticleUpDownFullTest, LeadingEigenvalues) {
   }
   for (int i = 0; i < leading_symmetry_decomposition.size(); ++i) {
     EXPECT_NEAR(std::abs(leading_symmetry_decomposition_check(i).real()),
-                std::abs(leading_symmetry_decomposition(i).real()), 1.e-10);
+                std::abs(leading_symmetry_decomposition(i).real()), 1.e-8);
     EXPECT_NEAR(std::abs(leading_symmetry_decomposition_check(i).imag()),
-                std::abs(leading_symmetry_decomposition(i).imag()), 1.e-10);
+                std::abs(leading_symmetry_decomposition(i).imag()), 1.e-8);
   }
 
   std::cout << "\nWriting data.\n" << std::endl;

--- a/test/system-level/analysis/dca_pp_up_down_sym/analysis_dca_pp_up_down_sym_test.cpp
+++ b/test/system-level/analysis/dca_pp_up_down_sym/analysis_dca_pp_up_down_sym_test.cpp
@@ -101,9 +101,9 @@ TEST(AnalysisDCAParticleParticleUpDownSymmetricTest, LeadingEigenvalues) {
   }
   for (int i = 0; i < leading_symmetry_decomposition.size(); ++i) {
     EXPECT_NEAR(std::abs(leading_symmetry_decomposition_check(i).real()),
-                std::abs(leading_symmetry_decomposition(i).real()), 1.e-10);
+                std::abs(leading_symmetry_decomposition(i).real()), 1.e-8);
     EXPECT_NEAR(std::abs(leading_symmetry_decomposition_check(i).imag()),
-                std::abs(leading_symmetry_decomposition(i).imag()), 1.e-10);
+                std::abs(leading_symmetry_decomposition(i).imag()), 1.e-8);
   }
 
   std::cout << "\nWriting data.\n" << std::endl;

--- a/test/unit/profiling/CMakeLists.txt
+++ b/test/unit/profiling/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 find_library(PAPI_LIB papi)
-if(PAPI_LIB)
+if(PAPI_LIB AND DCA_PROFILER EQUAL "PAPI")
     dca_add_gtest(papi_profiler_test GTEST_MAIN LIBS json profiling)
 endif()


### PR DESCRIPTION
The Daint build was broken after an update to cuda removed support for the spefic version we were using. I found that it is much easier to rely on system modules where possible rather than maintaining easy-build just for Daint, as it mixes system modules with very few self built tools. Lets see if this works from the jenkins environment.