### PR TITLE
fix pure virtual function calls involving MPIConcurrency and gtest

### DIFF
--- a/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
@@ -35,6 +35,10 @@ namespace dca {
 namespace parallel {
 // dca::parallel::
 
+/** Extremely overengineered
+ *
+ *  \todo simplify
+ */
 class MPIConcurrency final : public virtual MPIInitializer,
                              public virtual MPIProcessorGrouping,
                              public MPIPacking,

--- a/include/dca/testing/dca_mpi_test_environment.hpp
+++ b/include/dca/testing/dca_mpi_test_environment.hpp
@@ -23,10 +23,10 @@ namespace testing {
 struct DcaMpiTestEnvironment : public ::testing::Environment {
   using ConcurrencyType = dca::parallel::MPIConcurrency;
 
-  DcaMpiTestEnvironment(int argc, char* argv[], std::string file_name)
-      : concurrency(argc, argv), input_file_name(file_name) {}
+  DcaMpiTestEnvironment(ConcurrencyType& con, std::string file_name)
+      : concurrency(con), input_file_name(file_name) {}
 
-  ConcurrencyType concurrency;
+  ConcurrencyType& concurrency;
   std::string input_file_name;
 };
 

--- a/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_interband/bilayer_lattice_Nc1_interband.cpp
+++ b/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_interband/bilayer_lattice_Nc1_interband.cpp
@@ -159,8 +159,9 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
   dca_test_env = new dca::testing::DcaMpiTestEnvironment(
-      argc, argv, DCA_SOURCE_DIR
+      concurrency, DCA_SOURCE_DIR
       "/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_interband/"
       "input.bilayer_lattice_Nc1_interband.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);

--- a/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_intra_plus_interband/bilayer_lattice_Nc1_intra_plus_interband.cpp
+++ b/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_intra_plus_interband/bilayer_lattice_Nc1_intra_plus_interband.cpp
@@ -154,8 +154,9 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
   dca_test_env = new dca::testing::DcaMpiTestEnvironment(
-      argc, argv, DCA_SOURCE_DIR
+      concurrency, DCA_SOURCE_DIR
       "/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_intra_plus_interband/"
       "input.bilayer_lattice_Nc1_intra_plus_interband.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);

--- a/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_intraband/bilayer_lattice_Nc1_intraband.cpp
+++ b/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_intraband/bilayer_lattice_Nc1_intraband.cpp
@@ -153,8 +153,9 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
   dca_test_env = new dca::testing::DcaMpiTestEnvironment(
-      argc, argv, DCA_SOURCE_DIR
+      concurrency, DCA_SOURCE_DIR
       "/test/integration/cluster_solver/ctaux/bilayer_lattice/Nc1_intraband/"
       "input.bilayer_lattice_Nc1_intraband.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);

--- a/test/integration/cluster_solver/ctaux/square_lattice/Nc4_nn/square_lattice_Nc4_nn.cpp
+++ b/test/integration/cluster_solver/ctaux/square_lattice/Nc4_nn/square_lattice_Nc4_nn.cpp
@@ -139,9 +139,8 @@ int main(int argc, char** argv) {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  dca_test_env = new dca::testing::DcaMpiTestEnvironment(argc, argv,
-                                                         DCA_SOURCE_DIR
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
+  dca_test_env = new dca::testing::DcaMpiTestEnvironment(concurrency, DCA_SOURCE_DIR
                                                          "/test/integration/cluster_solver/ctaux/"
                                                          "square_lattice/Nc4_nn/"
                                                          "input.square_lattice_Nc4_nn.json");

--- a/test/integration/cluster_solver/ctaux/square_lattice/Nc4_onSite_plus_nn/square_lattice_Nc4_onSite_plus_nn.cpp
+++ b/test/integration/cluster_solver/ctaux/square_lattice/Nc4_onSite_plus_nn/square_lattice_Nc4_onSite_plus_nn.cpp
@@ -141,8 +141,9 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
   dca_test_env = new dca::testing::DcaMpiTestEnvironment(
-      argc, argv,
+      concurrency,
       DCA_SOURCE_DIR
       "/test/integration/cluster_solver/ctaux/square_lattice/Nc4_onSite_plus_nn/"
       "input.square_lattice_Nc4_onSite_plus_nn.json");

--- a/test/integration/cluster_solver/ctint/ctint_fe_as_test.cpp
+++ b/test/integration/cluster_solver/ctint/ctint_fe_as_test.cpp
@@ -102,8 +102,10 @@ int main(int argc, char** argv) {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
+
   dca_test_env =
-      new dca::testing::DcaMpiTestEnvironment(argc, argv, input_dir + "fe_as_lattice_input.json");
+      new dca::testing::DcaMpiTestEnvironment(concurrency, input_dir + "fe_as_lattice_input.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/integration/cluster_solver/ctint/ctint_hund_lattice_test.cpp
+++ b/test/integration/cluster_solver/ctint/ctint_hund_lattice_test.cpp
@@ -102,9 +102,9 @@ TEST(CtintHundLatticeTest, Self_Energy) {
 int main(int argc, char** argv) {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
   dca_test_env =
-      new dca::testing::DcaMpiTestEnvironment(argc, argv, input_dir + "hund_lattice_input.json");
+      new dca::testing::DcaMpiTestEnvironment(concurrency, input_dir + "hund_lattice_input.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/integration/cluster_solver/ctint/ctint_square_lattice_test.cpp
+++ b/test/integration/cluster_solver/ctint/ctint_square_lattice_test.cpp
@@ -102,8 +102,10 @@ int main(int argc, char** argv) {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
+
   dca_test_env =
-      new dca::testing::DcaMpiTestEnvironment(argc, argv, input_dir + "square_lattice_input.json");
+     new dca::testing::DcaMpiTestEnvironment(concurrency, input_dir + "square_lattice_input.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/integration/cluster_solver/ss_ct_hyb/NiO_no_change_test.cpp
+++ b/test/integration/cluster_solver/ss_ct_hyb/NiO_no_change_test.cpp
@@ -118,7 +118,9 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  dca_test_env = new dca::testing::DcaMpiTestEnvironment(argc, argv, "");
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
+
+  dca_test_env = new dca::testing::DcaMpiTestEnvironment(concurrency, "");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/integration/coarsegraining/coarsegraining_test.cpp
+++ b/test/integration/coarsegraining/coarsegraining_test.cpp
@@ -192,7 +192,8 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  dca_test_env = new dca::testing::DcaMpiTestEnvironment(argc, argv, "");
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
+  dca_test_env = new dca::testing::DcaMpiTestEnvironment(concurrency, "");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/integration/statistical_tests/FeAs/ctint_fe_as_validation_stattest.cpp
+++ b/test/integration/statistical_tests/FeAs/ctint_fe_as_validation_stattest.cpp
@@ -104,8 +104,9 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
   dca_test_env = new dca::testing::DcaMpiTestEnvironment(
-      argc, argv, dca::testing::test_directory + "fe_as_input.json");
+      concurrency, dca::testing::test_directory + "fe_as_input.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/integration/statistical_tests/bilayer_lattice/ctaux_bilayer_verification_stattest.cpp
+++ b/test/integration/statistical_tests/bilayer_lattice/ctaux_bilayer_verification_stattest.cpp
@@ -117,8 +117,10 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
+
   dca_test_env = new dca::testing::DcaMpiTestEnvironment(
-      argc, argv, dca::testing::test_directory + "bilayer_lattice_input.json");
+      concurrency, dca::testing::test_directory + "bilayer_lattice_input.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/integration/statistical_tests/bilayer_lattice/ctint_hund_validation_stattest.cpp
+++ b/test/integration/statistical_tests/bilayer_lattice/ctint_hund_validation_stattest.cpp
@@ -135,8 +135,9 @@ int main(int argc, char** argv) {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
 
-  dca_test_env = new dca::testing::DcaMpiTestEnvironment(argc, argv, "");
+  dca_test_env = new dca::testing::DcaMpiTestEnvironment(concurrency, "");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/integration/statistical_tests/real_materials/NiO_stattest.cpp
+++ b/test/integration/statistical_tests/real_materials/NiO_stattest.cpp
@@ -180,7 +180,8 @@ TEST(Ni0, GS) {
 int main(int argc, char** argv) {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-  dca_test_env = new dca::testing::DcaMpiTestEnvironment(argc, argv, "");
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
+  dca_test_env = new dca::testing::DcaMpiTestEnvironment(concurrency, "");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
   if (dca_test_env->concurrency.id() != 0) {

--- a/test/system-level/dca/dca_sp_DCA+_mpi_cuda_test.cpp
+++ b/test/system-level/dca/dca_sp_DCA+_mpi_cuda_test.cpp
@@ -54,7 +54,8 @@ TEST(dca_sp_DCAplus_mpi, Self_energy) {
   using DcaDataType = dca::phys::DcaData<ParametersType>;
   using ClusterSolverType =
       dca::phys::solver::CtauxClusterSolver<dca::linalg::CPU, ParametersType, DcaDataType>;
-  using DcaLoopType = dca::phys::DcaLoop<ParametersType, DcaDataType, ClusterSolverType, dca::DistType::NONE>;
+  using DcaLoopType =
+      dca::phys::DcaLoop<ParametersType, DcaDataType, ClusterSolverType, dca::DistType::NONE>;
 
   if (dca_test_env->concurrency.id() == dca_test_env->concurrency.first()) {
     // Copy initial state from an aborted run.
@@ -125,8 +126,9 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
   dca_test_env = new dca::testing::DcaMpiTestEnvironment(
-      argc, argv, DCA_SOURCE_DIR "/test/system-level/dca/input.dca_sp_DCA+_mpi_test.json");
+      concurrency, DCA_SOURCE_DIR "/test/system-level/dca/input.dca_sp_DCA+_mpi_test.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/system-level/dca/dca_sp_DCA+_mpi_test.cpp
+++ b/test/system-level/dca/dca_sp_DCA+_mpi_test.cpp
@@ -143,8 +143,9 @@ int main(int argc, char** argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
   dca_test_env = new dca::testing::DcaMpiTestEnvironment(
-      argc, argv, DCA_SOURCE_DIR "/test/system-level/dca/input.dca_sp_DCA+_mpi_test.json");
+      concurrency, DCA_SOURCE_DIR "/test/system-level/dca/input.dca_sp_DCA+_mpi_test.json");
   ::testing::AddGlobalTestEnvironment(dca_test_env);
 
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();


### PR DESCRIPTION
Nice example of Kernighan's law here. 

MI isn't to be taken lightly virtual base classes more so. That's all still there and should be stripped away but this takes care of the issue with gtest.