### PR TITLE
Fix bugs occurred in arm environment

### DIFF
--- a/include/dca/io/buffer.hpp
+++ b/include/dca/io/buffer.hpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+#include <stdexcept>
 
 namespace dca {
 namespace io {

--- a/include/dca/io/json/json_parser/json_parser.hpp
+++ b/include/dca/io/json/json_parser/json_parser.hpp
@@ -341,6 +341,12 @@ std::pair<wchar_t, JSON_character_class_type> JSON_parser<context_type>::get_nex
     }
 
     nextChar = inputStream.get();
+    if (inputStream.eof()) {
+      nextChar = EOF;
+      nextClass = C_EOF;
+
+      return result;
+    }
     numChar++;
 
     if (nextChar == L'\n')


### PR DESCRIPTION
1. fix missing header required in Arm A64fx environment

2. Fix end of file issue as it should check whether the reading character is eof or not.

The following comments are from arm cluster-admin when looking in to code a while ago.


Take a look at the get_next_character_and_class() function in json_parser.hpp.  Down near the bottom (line 360 of my copy), it tests nextChar for less than 0.  On x86_64, this works, the class is set to C_WHITE which causes the execution to jump back to the top of the loop.  At the top of the loop, it properly detects EOF and handles the situation accordingly.
 
On aarch64, the test for < 0 fails because nextChar is actually unsigned.  If you print its value in the debugger, you get 4294967295.  Note that on both systems, the returned value is 0xFFFFFFFF.  The difference is whether that’s treated as -1 (which is what x86_64 does) or 4.2billion (which is what aarch64 does).  Interestingly, on aarch64, I would expect that test to generate a compiler warning since an unsigned number can never be less than 0.  It might be worth grepping the build logs on aarch64 to see if such a warning was printed.

In all cases, the test really is improper.  It should be something like:
     If (nextChar == traits::eof())

The C++ spec says get() will return traits::eof(), but exactly what traits::eof() is can apparently vary from system to system.   Assuming it’s -1 is clearly incorrect.
