### PR TITLE
assert with message if there are no interacting sites

### DIFF
--- a/include/dca/phys/models/general_interaction.hpp
+++ b/include/dca/phys/models/general_interaction.hpp
@@ -76,6 +76,9 @@ void general_interaction<parameters_type>::set_vertex(
 
   // Get a random pair of correlated spin-orbitals.
   const int pos = rng() * correlated_orbitals.size();
+  // This is instead of crashing on segv when module is unknown.
+  // \todo catch earlier in release as well.
+  assert( pos < correlated_orbitals.size() && "It is likely you have specified an unknown model" );
   const int lin_ind = correlated_orbitals[pos];
 
   std::array<int, 6> sub_ind;  // [0]=b1, [1]=s1, [2]=b2, [3]=s2, [4]=r1, [5]=r2
@@ -118,6 +121,7 @@ std::vector<int> general_interaction<parameters_type>::make_correlated_orbitals(
         for (auto b_j : interacting_orbitals) {
           for (int s_i = 0; s_i < SpinDmn::dmn_size(); ++s_i) {
             for (auto b_i : interacting_orbitals) {
+              // This 1.e-3 seems like a very magic number!
               if (std::abs(H_interaction(b_i, s_i, b_j, s_j, delta_r)) > 1.e-3) {
                 int linear_index = get_spin_orbital_pair_domain<BandDmn, SpinDmn, RDmn>()(
                     b_i, s_i, b_j, s_j, r_i, r_j);


### PR DESCRIPTION
In current master a puzzling segv will occur in debug, and generally in release. This occurs if for install you have
"single-band-hubbard-model" instead of "single-band-Hubbard-model" in your input.
