### PR TITLE
[AMD Port] Fixing Matrix's use of memoryCopy2D with hip

### DIFF
--- a/include/dca/linalg/matrix.hpp
+++ b/include/dca/linalg/matrix.hpp
@@ -313,18 +313,19 @@ void Matrix<ScalarType, device_name>::resize(std::pair<int, int> new_size) {
   assert(new_size.first >= 0 && new_size.second >= 0);
   if (new_size.first > capacity_.first || new_size.second > capacity_.second) {
     std::pair<int, int> new_capacity = capacityMultipleOfBlockSize(new_size);
-
-    ValueType* new_data = nullptr;
-    new_data = Allocator::allocate(nrElements(new_capacity));
-    const std::pair<int, int> copy_size(std::min(new_size.first, size_.first),
-                                        std::min(new_size.second, size_.second));
-    util::memoryCopy(new_data, new_capacity.first, data_, leadingDimension(), copy_size);
-    Allocator::deallocate(data_);
-
-    data_ = new_data;
-    capacity_ = new_capacity;
-    size_ = new_size;
-  }
+	ValueType* new_data = nullptr;
+	new_data = Allocator::allocate(nrElements(new_capacity));
+	// hip memorycpy2D routines don't tolerate leadingDimension = 0
+	if(capacity_.first > 0) {
+	  const std::pair<int, int> copy_size(std::min(new_size.first, size_.first),
+					    std::min(new_size.second, size_.second));
+	  util::memoryCopy(new_data, new_capacity.first, data_, leadingDimension(), copy_size);
+	}
+	Allocator::deallocate(data_);
+	data_ = new_data;
+	capacity_ = new_capacity;
+	size_ = new_size;
+      }
   else {
     size_ = new_size;
   }

--- a/include/dca/linalg/matrix.hpp
+++ b/include/dca/linalg/matrix.hpp
@@ -316,11 +316,9 @@ void Matrix<ScalarType, device_name>::resize(std::pair<int, int> new_size) {
 	ValueType* new_data = nullptr;
 	new_data = Allocator::allocate(nrElements(new_capacity));
 	// hip memorycpy2D routines don't tolerate leadingDimension = 0
-	if(capacity_.first > 0) {
-	  const std::pair<int, int> copy_size(std::min(new_size.first, size_.first),
+	const std::pair<int, int> copy_size(std::min(new_size.first, size_.first),
 					    std::min(new_size.second, size_.second));
-	  util::memoryCopy(new_data, new_capacity.first, data_, leadingDimension(), copy_size);
-	}
+	util::memoryCopy(new_data, new_capacity.first, data_, leadingDimension(), copy_size);
 	Allocator::deallocate(data_);
 	data_ = new_data;
 	capacity_ = new_capacity;

--- a/include/dca/linalg/reshapable_matrix.hpp
+++ b/include/dca/linalg/reshapable_matrix.hpp
@@ -348,7 +348,6 @@ void ReshapableMatrix<ScalarType, device_name, Allocator>::setAsync(
 
 template <typename ScalarType, DeviceType device_name, class Allocator>
 std::size_t ReshapableMatrix<ScalarType, device_name, Allocator>::nextCapacity(const std::size_t size) {
-  assert(size >= 0);
   constexpr std::size_t block_size = 512;
 
   auto next_power_of_two = [](std::size_t x) {

--- a/include/dca/linalg/util/copy.hpp
+++ b/include/dca/linalg/util/copy.hpp
@@ -40,7 +40,6 @@ void memoryCopyCpu(ScalarType* dest, int ld_dest, const ScalarType* src, int ld_
   assert(size.first <= ld_src);
   assert(size.first >= 0);
   assert(size.second >= 0);
-
   size_t ncols = size.second;
   for (size_t i = 0; i < ncols; ++i) {
     memoryCopyCpu(dest + i * ld_dest, src + i * ld_src, size.first);
@@ -53,6 +52,8 @@ void memoryCopyCpu(ScalarType* dest, int ld_dest, const ScalarType* src, int ld_
 // The host continues the execution of the program when the copy is terminated.
 template <typename ScalarType>
 void memoryCopy(ScalarType* dest, const ScalarType* src, size_t size) {
+  if (size == 0)
+    return;
   cudaError_t ret = cudaMemcpy(dest, src, size * sizeof(ScalarType), cudaMemcpyDefault);
   checkRC(ret);
 }
@@ -64,6 +65,8 @@ void memoryCopy(ScalarType* dest, const ScalarType* src, size_t size) {
 template <typename ScalarType>
 void memoryCopy(ScalarType* dest, int ld_dest, const ScalarType* src, int ld_src,
                 std::pair<int, int> size) {
+  if (ld_dest == 0 || ld_src == 0 || (size.first == 0 && size.second == 0))
+    return;
   cudaError_t ret = cudaMemcpy2D(dest, ld_dest * sizeof(ScalarType), src, ld_src * sizeof(ScalarType),
                                  size.first * sizeof(ScalarType), size.second, cudaMemcpyDefault);
   try {
@@ -78,6 +81,8 @@ void memoryCopy(ScalarType* dest, int ld_dest, const ScalarType* src, int ld_src
 // Asynchronous 1D memory copy.
 template <typename ScalarType>
 void memoryCopyAsync(ScalarType* dest, const ScalarType* src, size_t size, const cudaStream_t stream) {
+  if (size == 0)
+    return;
   cudaError_t ret = cudaMemcpyAsync(dest, src, size * sizeof(ScalarType), cudaMemcpyDefault, stream);
   try {
     checkRC(ret);
@@ -102,6 +107,8 @@ void memoryCopyAsync(ScalarType* dest, const ScalarType* src, size_t size, int t
 template <typename ScalarType>
 void memoryCopyAsync(ScalarType* dest, int ld_dest, const ScalarType* src, int ld_src,
                      std::pair<int, int> size, const cudaStream_t stream) {
+  if (ld_dest == 0 || ld_src == 0 || (size.first == 0 && size.second == 0))
+    return;
   cudaError_t ret =
       cudaMemcpy2DAsync(dest, ld_dest * sizeof(ScalarType), src, ld_src * sizeof(ScalarType),
                         size.first * sizeof(ScalarType), size.second, cudaMemcpyDefault, stream);

--- a/src/linalg/util/error_gpu.cpp
+++ b/src/linalg/util/error_gpu.cpp
@@ -25,6 +25,13 @@ void checkErrorsCudaDebugInternal(std::string function_name, std::string file_na
 
   cudaError_t ret = cudaGetLastError();
 
+#ifdef DCA_HAVE_HIP
+  // hip reports this whenever you call getLastError and the stream is not empty of calls
+  // To us this is not an error we're in an Async regime it's expected
+  if(ret == hipErrorNotReady)
+    return;
+#endif
+
   if (ret != cudaSuccess) {
     std::stringstream s;
 

--- a/test/unit/linalg/reshapable_matrix_cpu_test.cpp
+++ b/test/unit/linalg/reshapable_matrix_cpu_test.cpp
@@ -207,7 +207,7 @@ TEST(MatrixCPUTest, SetAsync) {
   testing::setMatrixElements(mat, [](int i, int j) { return 3 * i * i - j; });
 
   mat2.setAsync(mat, 0, 0);
-
+  checkRC(cudaStreamSynchronize(0));
   EXPECT_EQ(mat, mat2);
 }
 

--- a/test/unit/linalg/reshapable_matrix_cpu_test.cpp
+++ b/test/unit/linalg/reshapable_matrix_cpu_test.cpp
@@ -207,7 +207,8 @@ TEST(MatrixCPUTest, SetAsync) {
   testing::setMatrixElements(mat, [](int i, int j) { return 3 * i * i - j; });
 
   mat2.setAsync(mat, 0, 0);
-  checkRC(cudaStreamSynchronize(0));
+  auto& gpu_stream = dca::linalg::util::getStream(0,0);
+  gpu_stream.sync();
   EXPECT_EQ(mat, mat2);
 }
 


### PR DESCRIPTION
hip can't deal with pitch size of source = 0 for memoryCopy2D