### PR TITLE
Mpi workaround

### DIFF
--- a/build-aux/spock_cray_build.sh
+++ b/build-aux/spock_cray_build.sh
@@ -1,3 +1,4 @@
+
 cmake -DDCA_WITH_CUDA=OFF -DDCA_WITH_HIP=ON \
       -DFFTW_INCLUDE_DIR=${OLCF_FFTW_ROOT}/include \
       -DFFTW_LIBRARY=${OLCF_FFTW_ROOT}/lib/libfftw3.a \
@@ -5,4 +6,6 @@ cmake -DDCA_WITH_CUDA=OFF -DDCA_WITH_HIP=ON \
       -DROCM_ROOT=${ROCM_PATH} \
       -DDCA_WITH_TESTS_FAST=ON -DTEST_RUNNER="srun" \
       -DGPU_TARGETS=gfx906 \
+      -DCMAKE_C_COMPILER=cc \
+      -DCMAKE_CXX_COMPILER=CC \
       ..

--- a/build-aux/spock_load_cray_modules.sh
+++ b/build-aux/spock_load_cray_modules.sh
@@ -8,7 +8,7 @@
 
 module reset
 module load PrgEnv-cray
-module load cmake/3.21
+module load cmake/3.21 # at least 3.21 is required for ROCM
 module load ninja
 module load magma/2.6.1
 module load fftw

--- a/build-aux/summit_load_modules.sh
+++ b/build-aux/summit_load_modules.sh
@@ -6,12 +6,12 @@
 # Usage: source summit_load_modules.sh
 
 module reset
-module load gcc/9.3.0
-module load cuda/11.4.0
+module load gcc/10.2.0
+module load cuda/11.1.1 # ldd shows magma is built with this cuda
 module load magma/2.6.1
 module load hdf5
 module load fftw
-module load cmake
+module load cmake/3.20.2 # at least 3.20 is required
 module load netlib-lapack
 module load essl
 

--- a/cmake/dca_config.cmake
+++ b/cmake/dca_config.cmake
@@ -379,6 +379,14 @@ if(DCA_SYMMETRIZE)
 endif()
 
 ################################################################################
+# Workarounds
+option(DCA_FIX_BROKEN_MPICH "Re-define MPI_CXX_* datatypes as the corresponding MPI_C_* datatypes when mpich is the mpi provider."
+       OFF)
+if(DCA_FIX_BROKEN_MPICH)
+  add_compile_definitions(DCA_FIX_BROKEN_MPICH)
+endif()
+
+################################################################################
 # Generate applications' config files.
 configure_file("${PROJECT_SOURCE_DIR}/include/dca/config/analysis.hpp.in"
   "${CMAKE_BINARY_DIR}/include/dca/config/analysis.hpp" @ONLY)

--- a/include/dca/parallel/mpi_concurrency/dca_mpi.h
+++ b/include/dca/parallel/mpi_concurrency/dca_mpi.h
@@ -1,12 +1,8 @@
 #include <mpi.h>
 
 #ifdef MPICH_NUMVERSION
-// Maybe this is fixed in mpich 4.0? Not checked yet.
-#if MPICH_NUMVERSION < 40000000
-
-/* Fix broken MPI-3 C++ types in mpich */
-// Note: pre-processors only compare numbers, so the comparison
-// has to be done as C/C++ code.
+#ifdef DCA_FIX_BROKEN_MPICH
+/* Fix broken MPI-3 C++ types due to bad compiles of mpich */
 #undef MPI_CXX_BOOL
 #define MPI_CXX_BOOL                MPI_C_BOOL
 
@@ -19,7 +15,5 @@
 #undef MPI_CXX_LONG_DOUBLE_COMPLEX
 #define MPI_CXX_LONG_DOUBLE_COMPLEX MPI_C_LONG_DOUBLE_COMPLEX
 
-#else
-#warning "MPICH may have broken MPI_CXX_FLOAT_COMPLEX definitions."
-#endif // MPICH_NUMVERSION
+#endif // DCA_FIX_BROKEN_MPICH
 #endif // MPICH_NUMVERSION

--- a/include/dca/parallel/mpi_concurrency/dca_mpi.h
+++ b/include/dca/parallel/mpi_concurrency/dca_mpi.h
@@ -1,0 +1,25 @@
+#include <mpi.h>
+
+#ifdef MPICH_NUMVERSION
+// Maybe this is fixed in mpich 4.0? Not checked yet.
+#if MPICH_NUMVERSION < 40000000
+
+/* Fix broken MPI-3 C++ types in mpich */
+// Note: pre-processors only compare numbers, so the comparison
+// has to be done as C/C++ code.
+#undef MPI_CXX_BOOL
+#define MPI_CXX_BOOL                MPI_C_BOOL
+
+#undef MPI_CXX_FLOAT_COMPLEX
+#define MPI_CXX_FLOAT_COMPLEX       MPI_C_FLOAT_COMPLEX
+
+#undef MPI_CXX_DOUBLE_COMPLEX
+#define MPI_CXX_DOUBLE_COMPLEX      MPI_C_DOUBLE_COMPLEX
+
+#undef MPI_CXX_LONG_DOUBLE_COMPLEX
+#define MPI_CXX_LONG_DOUBLE_COMPLEX MPI_C_LONG_DOUBLE_COMPLEX
+
+#else
+#warning "MPICH may have broken MPI_CXX_FLOAT_COMPLEX definitions."
+#endif // MPICH_NUMVERSION
+#endif // MPICH_NUMVERSION

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_max.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_max.hpp
@@ -13,7 +13,7 @@
 #ifndef DCA_PARALLEL_MPI_CONCURRENCY_MPI_COLLECTIVE_MAX_HPP
 #define DCA_PARALLEL_MPI_CONCURRENCY_MPI_COLLECTIVE_MAX_HPP
 
-#include <mpi.h>
+#include "dca_mpi.h"
 #include "dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_type_map.hpp"
 

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_min.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_min.hpp
@@ -13,7 +13,7 @@
 #ifndef DCA_PARALLEL_MPI_CONCURRENCY_MPI_COLLECTIVE_MIN_HPP
 #define DCA_PARALLEL_MPI_CONCURRENCY_MPI_COLLECTIVE_MIN_HPP
 
-#include <mpi.h>
+#include "dca_mpi.h"
 #include "dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_type_map.hpp"
 

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
@@ -23,7 +23,7 @@
 #include <utility>  // std::move, std::swap
 #include <vector>
 
-#include <mpi.h>
+#include "dca_mpi.h"
 
 #include "dca/distribution/dist_types.hpp"
 #include "dca/function/domains.hpp"

--- a/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_concurrency.hpp
@@ -19,7 +19,7 @@
 #include <utility>
 #include <stdexcept>
 
-#include <mpi.h>
+#include "dca_mpi.h"
 
 #include "dca/parallel/mpi_concurrency/mpi_collective_max.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_collective_min.hpp"

--- a/include/dca/parallel/mpi_concurrency/mpi_gang.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_gang.hpp
@@ -12,7 +12,7 @@
 #ifndef DCA_PARALLEL_MPI_CONCURRENCY_MPI_GANG_HPP
 #define DCA_PARALLEL_MPI_CONCURRENCY_MPI_GANG_HPP
 
-#include <mpi.h>
+#include "dca_mpi.h"
 
 #include "dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp"
 

--- a/include/dca/parallel/mpi_concurrency/mpi_gather.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_gather.hpp
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-#include <mpi.h>
+#include "dca_mpi.h"
 
 #include "dca/function/domains.hpp"
 #include "dca/function/function.hpp"

--- a/include/dca/parallel/mpi_concurrency/mpi_packing.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_packing.hpp
@@ -15,7 +15,7 @@
 
 #include <string>
 #include <vector>
-#include <mpi.h>
+#include "dca_mpi.h"
 #include "dca/function/function.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp"
 #include "dca/parallel/mpi_concurrency/mpi_type_map.hpp"

--- a/include/dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp
@@ -17,7 +17,7 @@
 #include <cassert>
 #include <vector>
 
-#include <mpi.h>
+#include "dca_mpi.h"
 
 namespace dca {
 namespace parallel {

--- a/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
@@ -19,7 +19,7 @@
 #include <complex>
 #include <cstdlib>
 #include <type_traits>
-#include <mpi.h>
+#include "dca_mpi.h"
 
 namespace dca {
 namespace parallel {

--- a/include/dca/phys/parameters/mci_parameters.hpp
+++ b/include/dca/phys/parameters/mci_parameters.hpp
@@ -24,7 +24,7 @@
 #include "dca/phys/error_computation_type.hpp"
 
 #ifdef DCA_HAVE_MPI
-#include <mpi.h>
+#include "dca/parallel/mpi_concurrency/dca_mpi.h"
 #endif
 
 namespace dca {


### PR DESCRIPTION
This patch aliases `MPI_CXX_*` types to their corresponding `MPI_C_*` types to work around non-compliance of MPICH 3.4 with the MPI 3.1 standard (https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report/node48.htm#Node48).