### PR TITLE
Autocorrelation cleanup

### DIFF
--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -193,8 +193,6 @@ CtauxClusterSolver<device_t, Parameters, Data, DIST>::CtauxClusterSolver(
 
       averaged_(false),
       writer_(writer) {
-  TimeCorrelator<Parameters, typename Walker::Scalar, device>::setG0(g0_);
-
   if (concurrency_.id() == concurrency_.first())
     std::cout << "\n\n\t CT-AUX Integrator is born \n" << std::endl;
 }

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/structs/vertex_pair.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/structs/vertex_pair.hpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2018 ETH Zurich
-// Copyright (C) 2018 UT-Battelle, LLC
+// Copyright (C) 2021 ETH Zurich
+// Copyright (C) 2021 UT-Battelle, LLC
 // All rights reserved.
 //
 // See LICENSE for terms of usage.
@@ -50,7 +50,8 @@ public:
               uint64_t id);
 
   this_type& operator=(const this_type& other_vertex_pair);
-
+  vertex_pair(const this_type& other_vertex_pair) = default;
+  
   uint64_t get_id() const {
     return id_;
   }
@@ -188,6 +189,7 @@ vertex_pair<parameters_type>::vertex_pair(parameters_type& parameters_ref, rng_t
       Bennett(false),
       shuffled(false) {}
 
+// \todo replace this sematic changing operator overload 
 template <class parameters_type>
 vertex_pair<parameters_type>& vertex_pair<parameters_type>::operator=(
     const vertex_pair<parameters_type>& other_vertex_pair)  // --> necessary for push_back

--- a/include/dca/phys/dca_step/cluster_solver/ctint/ctint_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/ctint_cluster_solver.hpp
@@ -1,11 +1,12 @@
-// Copyright (C) 2018 ETH Zurich
-// Copyright (C) 2018 UT-Battelle, LLC
+// Copyright (C) 2021 ETH Zurich
+// Copyright (C) 2021 UT-Battelle, LLC
 // All rights reserved.
 //
 // See LICENSE.txt for terms of usage.
 //  See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Giovanni Balduzzi(gbalduzz@itp.phys.ethz.ch)
+//         Peter Doak(doakpw@ornl.gov)
 //
 // Cluster Monte Carlo integrator based on a CT-INT algorithm.
 
@@ -142,12 +143,12 @@ protected:
   int dca_iteration_ = 0;
   std::shared_ptr<io::Writer<Concurrency>> writer_;
 
+  G0Interpolation<device_t, typename Walker::Scalar> g0_;
 private:
   bool perform_tp_accumulation_;
   const LabelDomain label_dmn_;
   std::unique_ptr<Walker> walker_;
   // Walker input.
-  G0Interpolation<device_t, Real> g0_;
   Rng rng_;
 };
 

--- a/include/dca/phys/dca_step/cluster_solver/ctint/ctint_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/ctint_cluster_solver.hpp
@@ -163,7 +163,6 @@ CtintClusterSolver<DEV, PARAM, use_submatrix, DIST>::CtintClusterSolver(
       rng_(concurrency_.id(), concurrency_.number_of_processors(), parameters_.get_seed())
 {
   Walker::setDMatrixBuilder(g0_);
-  //  TimeCorrelator<Parameters, Real, device_t>::setG0(g0_);
   Walker::setInteractionVertices(data_, parameters_);
 
   if (concurrency_.id() == concurrency_.first())

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_base.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_base.hpp
@@ -246,8 +246,7 @@ void CtintWalkerBase<Parameters, Real, DIST>::initialize(int iteration) {
   sweeps_per_meas_ = parameters_.get_sweeps_per_measurement().at(iteration);
 
   sign_ = 1;
-  // in some DCA-develop code Giovanni has this set to 0
-  mc_log_weight_ = 1.;
+  mc_log_weight_ = 0.;
 
   if (!configuration_.size()) {  // Do not initialize config if it was read.
     while (parameters_.getInitialConfigurationSize() > configuration_.size()) {

--- a/include/dca/phys/dca_step/cluster_solver/ss_ct_hyb/ss_ct_hyb_walker.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ss_ct_hyb/ss_ct_hyb_walker.hpp
@@ -1,7 +1,14 @@
 // Copyright (C) 2010 Philipp Werner
+// Copyright (C) 2021 ETH Zurich
+// Copyright (C) 2021 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Integrated into DCA++ by Peter Staar (taa@zurich.ibm.com) and Bart Ydens.
 // Modified by Andrei Plamada (plamada@itp.phys.ethz.ch).
+//             Peter Doak (doakpw@ornl.gov)
 //
 // This class organizes the MC walker in the SS CT-HYB QMC.
 
@@ -16,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "dca/config/mc_options.hpp"
 #include "dca/io/buffer.hpp"
 #include "dca/function/domains.hpp"
 #include "dca/function/function.hpp"
@@ -75,6 +83,8 @@ public:
   typedef shift_segment_tools<ss_hybridization_walker_routines_type> shift_segment_tools_t;
   typedef swap_segment_tools<ss_hybridization_walker_routines_type> swap_segment_tools_t;
 
+  constexpr static dca::linalg::DeviceType device = device_t;
+  using Scalar = typename dca::config::McOptions::MCScalar;
 public:
   SsCtHybWalker(const parameters_type& parameters_ref, MOMS_type& MOMS_ref, rng_type& rng_ref, int id = 0);
 

--- a/include/dca/phys/dca_step/cluster_solver/ss_ct_hyb/structures/hybridization_vertex.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ss_ct_hyb/structures/hybridization_vertex.hpp
@@ -1,6 +1,13 @@
 // Copyright (C) 2010 Philipp Werner
+// Copyright (C) 2021 ETH Zurich
+// Copyright (C) 2021 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Integrated into DCA++ by Peter Staar (taa@zurich.ibm.com) and Bart Ydens.
+// Modified by Peter Doak (doakpw@ornl.gov)
 //
 // This class organizes a vertex, i.e. it stores the time points of a \f$c\f$ and \f$c^{\dagger}\f$.
 
@@ -34,6 +41,8 @@ public:
     t_end_val = t_end;
   }
 
+  Hybridization_vertex(const Hybridization_vertex& other) = default; 
+  
   this_type& operator=(this_type& other_vertex) {
     t_start_val = other_vertex.t_start();
     t_end_val = other_vertex.t_end();

--- a/test/integration/coarsegraining/coarsegraining_test.cpp
+++ b/test/integration/coarsegraining/coarsegraining_test.cpp
@@ -195,6 +195,8 @@ void computeMockSigma(SigmaType& Sigma) {
 int main(int argc, char** argv) {
   int result = 0;
 
+  std::cout << "This Test is not portable.  Currently passes on summit with build-aux std version\nFails almost everywherer else.";
+  
   ::testing::InitGoogleTest(&argc, argv);
 
   dca::parallel::MPIConcurrency concurrency(argc, argv);


### PR DESCRIPTION
Get rid of raw pointer G0Interpolator in TimeCorrelation.
Also fixed a number of warnings.