### PR TITLE
Fix reading of legacy hdf5 files

### DIFF
--- a/include/dca/io/hdf5/hdf5_reader.hpp
+++ b/include/dca/io/hdf5/hdf5_reader.hpp
@@ -1,11 +1,12 @@
-// Copyright (C) 2018 ETH Zurich
-// Copyright (C) 2018 UT-Battelle, LLC
+// Copyright (C) 2023 ETH Zurich
+// Copyright (C) 2023 UT-Battelle, LLC
 // All rights reserved.
 //
 // See LICENSE for terms of usage.
 // See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
 //
 // Author: Peter Staar (taa@zurich.ibm.com)
+//         Peter W. Doak (doakpw@ornl.gov)
 //
 // HDF5 reader.
 
@@ -17,6 +18,9 @@
 #include <vector>
 
 #include "H5Cpp.h"
+
+#include "dca/config/haves_defines.hpp"
+#include "dca/platform/dca_gpu.h"
 
 #include "dca/io/buffer.hpp"
 #include "dca/function/domains.hpp"
@@ -62,7 +66,7 @@ public:
   void begin_step();
   void end_step();
 
-  std::string get_path();
+  std::string get_path() const;
 
   std::size_t getStepCount();
   
@@ -113,6 +117,7 @@ public:
   }
 
 private:
+  bool buildCheckedFullName(const std::string& name, std::string& full_name) const;
   bool exists(const std::string& name) const;
 
   void read(const std::string& name, H5::DataType type, void* data) const;
@@ -122,6 +127,9 @@ private:
   std::vector<std::string> paths_;
 
   bool verbose_;
+
+  /// work around for Legacy hdf5
+  bool is_legacy_ = false;
 
   int step_ = 0;
   bool in_step_ = false;
@@ -138,9 +146,8 @@ void HDF5Reader::from_file(arbitrary_struct_t& arbitrary_struct, std::string fil
 
 template <typename Scalar>
 bool HDF5Reader::execute(const std::string& name, Scalar& value) {
-  std::string full_name = get_path() + "/" + name;
-
-  if (!exists(full_name)) {
+  std::string full_name;
+  if (!buildCheckedFullName(name, full_name)) {
     return false;
   }
 

--- a/include/dca/io/hdf5/hdf5_writer.hpp
+++ b/include/dca/io/hdf5/hdf5_writer.hpp
@@ -22,6 +22,7 @@
 
 #include <H5Cpp.h>
 
+#include "dca/platform/dca_gpu.h"
 #include "dca/function/domains.hpp"
 #include "dca/io/buffer.hpp"
 #include "dca/function/function.hpp"

--- a/include/dca/io/reader.hpp
+++ b/include/dca/io/reader.hpp
@@ -17,6 +17,9 @@
 #include <string>
 #include <variant>
 
+#include "dca/config/haves_defines.hpp"
+#include "dca/platform/dca_gpu.h"
+
 #include "dca/io/io_types.hpp"
 #include "dca/io/hdf5/hdf5_reader.hpp"
 #include "dca/io/json/json_reader.hpp"

--- a/include/dca/io/writer.hpp
+++ b/include/dca/io/writer.hpp
@@ -89,6 +89,10 @@ public:
   }
 #endif
 
+  bool isHDF5() {
+    return std::holds_alternative<io::HDF5Writer>(writer_);
+  }
+  
   bool isOpen() { return is_open_; }
   
   void begin_step() {
@@ -172,6 +176,8 @@ public:
     std::visit([&](auto& var) { var.set_verbose(verbose); }, writer_);
   }
 
+  Concurrency& get_concurrency() { return concurrency_; }
+  
   dca::parallel::thread_traits::mutex_type& get_mutex() { return mutex_; }
 private:
   dca::parallel::thread_traits::mutex_type mutex_;

--- a/include/dca/phys/dca_data/dca_data.hpp
+++ b/include/dca/phys/dca_data/dca_data.hpp
@@ -610,30 +610,50 @@ void DcaData<Parameters, DT>::initializeSigma(adios2::ADIOS& adios [[maybe_unuse
     io::Reader reader(concurrency_, sigma_file_io);
     reader.open_file(filename);
     std::size_t step_count = reader.getStepCount();
-      for (std::size_t i = 0; i < step_count; ++i) {
-        reader.begin_step();
-        reader.end_step();
-      }
+    for (std::size_t i = 0; i < step_count; ++i) {
+      reader.begin_step();
+      reader.end_step();
+    }
     readSigmaFile(reader);
+    reader.close_file();
   }
   concurrency_.broadcast(parameters_.get_chemical_potential());
   concurrency_.broadcast(Sigma);
 }
 #endif
 
+// Strong assumption here that this only gets called for HDF5 input.
 template <class Parameters, DistType DT>
 void DcaData<Parameters, DT>::initializeSigma(const std::string& filename) {
   if (concurrency_.id() == concurrency_.first()) {
     std::cout << "reading Sigma File\n";
     io::IOType sigma_file_io = io::extensionToIOType(filename);
     io::Reader reader(concurrency_, sigma_file_io);
+    int hdf5_last_iteration = -1;
     reader.open_file(filename);
     std::size_t step_count = reader.getStepCount();
-      for (std::size_t i = 0; i < step_count; ++i) {
-        reader.begin_step();
-        reader.end_step();
+    // Work around odd way hdf5 steps get written
+    int completed_iteration = 0;
+  find_step:
+    for (std::size_t i = 0; i < step_count; ++i) {
+      reader.begin_step();
+      std::cerr << "current step " << i << '\n';
+      bool has_iteration =
+          reader.execute("DCA-loop-functions/completed-iteration", completed_iteration);
+      std::cerr << "completed_iteration " << completed_iteration << '\n';
+      if (has_iteration && (i >= completed_iteration)) {
+	std::cerr << "past complete iterations " << completed_iteration << "at step " << i << '\n';
+	hdf5_last_iteration = completed_iteration;
+	reader.close_file();
+	reader.open_file(filename);
+	step_count = hdf5_last_iteration;
+	goto find_step;	
       }
+      reader.end_step();
+    }
+    reader.begin_step();
     readSigmaFile(reader);
+    reader.close_file();
   }
   concurrency_.broadcast(parameters_.get_chemical_potential());
   concurrency_.broadcast(Sigma);
@@ -648,7 +668,8 @@ void DcaData<Parameters, DT>::readSigmaFile(io::Reader<Concurrency>& reader) {
   bool has_iteration = reader.execute("completed-iteration", completed_iteration);
   
   if (chemical_potential_present && has_iteration) {
-    std::cout << "chemical-potential from Sigma file: " << chemical_potentials[completed_iteration] << '\n';
+    std::cout << "chemical-potential from Sigma file: " << chemical_potentials[completed_iteration]
+              << '\n';
     parameters_.get_chemical_potential() = chemical_potentials[completed_iteration];
   }
   else {

--- a/include/dca/phys/parameters/output_parameters.hpp
+++ b/include/dca/phys/parameters/output_parameters.hpp
@@ -36,7 +36,7 @@ public:
 #else
         output_format_("HDF5"),
         filename_dca_("dca.hdf5"),
-        filename_analysis_("sofqomega.hdf5"),
+        filename_analysis_("sofqomega.bp"),
 #endif
         directory_config_read_(""),
         directory_config_write_(""),
@@ -144,7 +144,7 @@ private:
   bool dump_cluster_Greens_functions_;
   bool dump_Gamma_lattice_;
   bool dump_chi_0_lattice_;
-  bool dump_every_iteration_;
+  bool dump_every_iteration_ = false;
 };
 
 template <typename Concurrency>
@@ -154,6 +154,7 @@ int OutputParameters::getBufferSize(const Concurrency& concurrency) const {
   buffer_size += concurrency.get_buffer_size(directory_);
   buffer_size += concurrency.get_buffer_size(autoresume_);
   buffer_size += concurrency.get_buffer_size(output_format_);
+  buffer_size += concurrency.get_buffer_size(g4_output_format_);
   buffer_size += concurrency.get_buffer_size(filename_g4_);
   buffer_size += concurrency.get_buffer_size(filename_dca_);
   buffer_size += concurrency.get_buffer_size(filename_analysis_);
@@ -178,6 +179,7 @@ void OutputParameters::pack(const Concurrency& concurrency, char* buffer, int bu
   concurrency.pack(buffer, buffer_size, position, directory_);
   concurrency.pack(buffer, buffer_size, position, autoresume_);
   concurrency.pack(buffer, buffer_size, position, output_format_);
+  concurrency.pack(buffer, buffer_size, position, g4_output_format_);
   concurrency.pack(buffer, buffer_size, position, filename_g4_);
   concurrency.pack(buffer, buffer_size, position, filename_dca_);
   concurrency.pack(buffer, buffer_size, position, filename_analysis_);
@@ -200,6 +202,7 @@ void OutputParameters::unpack(const Concurrency& concurrency, char* buffer, int 
   concurrency.unpack(buffer, buffer_size, position, directory_);
   concurrency.unpack(buffer, buffer_size, position, autoresume_);
   concurrency.unpack(buffer, buffer_size, position, output_format_);
+  concurrency.unpack(buffer, buffer_size, position, g4_output_format_);
   concurrency.unpack(buffer, buffer_size, position, filename_g4_);
   concurrency.unpack(buffer, buffer_size, position, filename_dca_);
   concurrency.unpack(buffer, buffer_size, position, filename_analysis_);
@@ -233,7 +236,7 @@ void OutputParameters::readWrite(ReaderOrWriter& reader_or_writer) {
     try_to_read_or_write("autoresume", autoresume_);
     try_to_read_or_write("output-format", output_format_);
     try_to_read_or_write("g4-output-format", g4_output_format_);
-    try_to_read_or_write("filename-g4-", filename_g4_);
+    try_to_read_or_write("filename-g4", filename_g4_);
     try_to_read_or_write("filename-dca", filename_dca_);
     try_to_read_or_write("filename-analysis", filename_analysis_);
     try_to_read_or_write("directory-config-read", directory_config_read_);
@@ -258,7 +261,9 @@ void OutputParameters::readWrite(ReaderOrWriter& reader_or_writer) {
   if (dump_every_iteration_) {
     io ::IOType io_type = io::stringToIOType(output_format_);
     switch (io_type) {
+      // google test cannot handle these cases being combined.?
       case io::IOType::ADIOS2:
+	break;
       case io::IOType::HDF5:
         break;
       case io::IOType::JSON:

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -10,4 +10,8 @@ if (DCA_HAVE_ADIOS2)
 endif()
 
 add_library(dca_io reader.cpp io_types.cpp)
+
+dca_gpu_runtime_link(dca_io)
+dca_gpu_blas_link(dca_io)
+
 target_link_libraries(dca_io PUBLIC ${DCA_IO_LIBS})

--- a/src/io/adios2/adios2_reader.cpp
+++ b/src/io/adios2/adios2_reader.cpp
@@ -51,6 +51,8 @@ void ADIOS2Reader<CT>::close_file() {
   if (verbose_)
     std::cout << "\t ADIOS2Reader: Trying to close read file : " << file_name_ << "\n";
 
+  my_paths_.clear();
+  
   if (file_) {
     file_.Close();
     adios_.RemoveIO(io_name_);

--- a/src/io/hdf5/CMakeLists.txt
+++ b/src/io/hdf5/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(dca_hdf5 STATIC hdf5_reader.cpp hdf5_writer.cpp)
 target_include_directories(dca_hdf5 PUBLIC hdf5::hdf5 hdf5::hdf5_cpp)
-target_link_libraries(dca_hdf5 PUBLIC hdf5::hdf5 hdf5::hdf5_cpp)
+target_link_libraries(dca_hdf5 PUBLIC hdf5::hdf5 hdf5::hdf5_cpp modern_string_utils)
 
 message("CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN : ${CMAKE_CXX_STANDARD_LIBRARIES}")
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -29,3 +29,6 @@ target_link_libraries(signals PUBLIC json dca_hdf5 ${DCA_CONCURRENCY_LIB})
 if (DCA_WITH_ADIOS2)
   target_link_libraries(signals PUBLIC dca_adios2)
 endif ()
+
+add_library(modern_string_utils STATIC ModernStringUtils.cpp)
+target_include_directories(modern_string_utils PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/util/ModernStringUtils.cpp
+++ b/src/util/ModernStringUtils.cpp
@@ -1,0 +1,66 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "ModernStringUtils.hpp"
+#include <algorithm>
+#include <cctype>
+
+namespace dca
+{
+using std::size_t;
+using std::string_view;
+
+
+std::string lowerCase(const std::string_view s)
+{
+  std::string lower_str{s};
+  std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return lower_str;
+}
+
+namespace modernstrutil
+{
+std::vector<std::string_view> split(const string_view s, const string_view delimiters)
+{
+  std::vector<std::string_view> tokens;
+  size_t right = 0;
+  size_t left  = 0;
+  while (true)
+  {
+    left = s.find_first_not_of(delimiters, right);
+    if (left == s.npos)
+      break;
+    else
+      right = s.find_first_of(delimiters, left);
+    if (right == s.npos)
+      right = s.size();
+    size_t count = right - left;
+    tokens.push_back(s.substr(left, count));
+  }
+  return tokens;
+}
+
+std::string_view strip(const string_view s)
+{
+  std::string_view delimiters = " \t\n\0";
+  size_t left                 = s.find_first_not_of(delimiters, 0);
+  if (left != s.npos) {
+    size_t right = s.find_last_not_of(delimiters, s.npos);
+    return s.substr(left, right - left + 1);
+  }
+  else
+    return std::string_view{};
+}
+} // namespace modernstrutil
+
+
+} // namespace qmcplusplus

--- a/src/util/ModernStringUtils.hpp
+++ b/src/util/ModernStringUtils.hpp
@@ -1,0 +1,71 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_MODERNSTRINGUTILS_HPP
+#define QMCPLUSPLUS_MODERNSTRINGUTILS_HPP
+
+#include <charconv>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace dca
+{
+
+/** @ingroup C++17 string utility functions
+ *  @{
+ */
+/** take string_view (or something that can be implicitly converted to one) and return lcase string.
+ *  Don't call on anything but ASCII strings.
+ *
+ *  According to en.cppreference.com std::tolower is only defined for usigned char and EOF. the std::tolower conversion
+ *  is based on the _c_ locale which to makes it unclear on what might happen to char > 127. 
+ *  *  For tags, and keywords where we define explicitly define they are ASCII encoded and this is fine. 
+ *  *  For other XML derived text this should never be used since we should assume that to be UTF-8 encoded.
+ */
+std::string lowerCase(const std::string_view s);
+
+/** prevent clash with string_utils.h */
+namespace modernstrutil {
+  /** return string_view tokens */
+  std::vector<std::string_view> split(const std::string_view s, const std::string_view delimiters);
+  /** remove white space from each beginning and end of string_view */
+  std::string_view strip(const std::string_view s);
+}
+
+/** alternate to string2real
+ *  calls c++ string to real conversion based on T's precision template<typename T>
+ */
+template<typename T>
+inline T string2Real(const std::string_view svalue) {
+  static_assert(std::is_floating_point_v<T>);
+      T result;
+// full support for floating point from char not present until stdlibc++ aligned with gcc11
+// there is still not from_char for floats as of libc++ 15
+#if _GLIBCXX_RELEASE > 10
+  auto [prt, ec] = std::from_chars(svalue.data(), svalue.data() + svalue.size(), result, std::chars_format::general);
+  if (ec != std::errc())
+    throw std::runtime_error("Could not convert from string to real value");
+#else
+  // atof must be given a null terminated string, string_view is not guaranteed to have a null terminator.
+  std::string str_value(svalue);
+  result = static_cast<T>(atof(str_value.c_str()));
+#endif
+  return result;
+}
+  
+/** @} */
+
+} // namespace qmcplusplus
+
+#endif

--- a/test/unit/phys/parameters/output_parameters/input_read_all.json
+++ b/test/unit/phys/parameters/output_parameters/input_read_all.json
@@ -2,6 +2,7 @@
     "output": {
         "directory": "./T=0.5",
         "output-format": "JSON",
+	"g4-output-format": "JSON",
         "autoresume" : true,
         "directory-config-read" : "configuration",
         "directory-config-write" : "configuration",
@@ -13,6 +14,7 @@
         "dump-lattice-self-energy": true,
         "dump-cluster-Greens-functions": true,
         "dump-Gamma-lattice": true,
-        "dump-chi-0-lattice": true
+        "dump-chi-0-lattice": true,
+        "dump-every-iteration": false
     }
 }

--- a/test/unit/phys/parameters/output_parameters/output_parameters_test.cpp
+++ b/test/unit/phys/parameters/output_parameters/output_parameters_test.cpp
@@ -11,20 +11,28 @@
 //
 // TODO: Add tests for get_buffer_size, pack, unpack and writing.
 
+
+#include "dca/config/haves_defines.hpp"
 #include "dca/phys/parameters/output_parameters.hpp"
-#include "gtest/gtest.h"
+#include "dca/testing/gtest_h_w_warning_blocking.h"
 #include "dca/io/json/json_reader.hpp"
 
 TEST(OutputParametersTest, DefaultValues) {
   dca::phys::params::OutputParameters pars;
 
   EXPECT_EQ("./", pars.get_directory());
+#ifdef DCA_HAVE_ADIOS2
+  EXPECT_EQ("ADIOS2", pars.get_output_format());
+  EXPECT_EQ("ADIOS2", pars.get_g4_output_format());
+#else
   EXPECT_EQ("HDF5", pars.get_output_format());
-  EXPECT_EQ(false, pars.autoresume());
+  EXPECT_EQ("", pars.get_g4_output_format());
+#endif
+  EXPECT_FALSE(pars.autoresume());
   EXPECT_EQ("", pars.get_directory_config_read());
   EXPECT_EQ("", pars.get_directory_config_write());
-  EXPECT_EQ("dca.hdf5", pars.get_filename_dca());
-  EXPECT_EQ("sofqomega.hdf5", pars.get_filename_analysis());
+  EXPECT_EQ("dca.bp", pars.get_filename_dca());
+  EXPECT_EQ("sofqomega.bp", pars.get_filename_analysis());
   EXPECT_EQ("ed.hdf5", pars.get_filename_ed());
   EXPECT_EQ("qmc.hdf5", pars.get_filename_qmc());
   EXPECT_EQ("profiling.json", pars.get_filename_profiling());
@@ -32,6 +40,30 @@ TEST(OutputParametersTest, DefaultValues) {
   EXPECT_FALSE(pars.dump_cluster_Greens_functions());
   EXPECT_FALSE(pars.dump_Gamma_lattice());
   EXPECT_FALSE(pars.dump_chi_0_lattice());
+  EXPECT_FALSE(pars.dump_every_iteration());
+
+  // // And nothing except required input should get updated by reading the minimal input
+  // dca::io::JSONReader reader;
+  // reader.open_file(DCA_SOURCE_DIR
+  //               "/test/unit/phys/parameters/output_parameters/input_check_defaults.json");
+  // pars.readWrite(reader);
+  // reader.close_file();
+  // EXPECT_EQ("./", pars.get_directory());
+  // EXPECT_EQ("ADIOS2", pars.get_output_format());
+  // EXPECT_EQ("ADIOS2", pars.get_g4_output_format()),
+  // EXPECT_EQ(false, pars.autoresume());
+  // EXPECT_EQ("", pars.get_directory_config_read());
+  // EXPECT_EQ("", pars.get_directory_config_write());
+  // EXPECT_EQ("dca.bp", pars.get_filename_dca());
+  // EXPECT_EQ("sofqomega.bp", pars.get_filename_analysis());
+  // EXPECT_EQ("ed.hdf5", pars.get_filename_ed());
+  // EXPECT_EQ("qmc.hdf5", pars.get_filename_qmc());
+  // EXPECT_EQ("profiling.json", pars.get_filename_profiling());
+  // EXPECT_FALSE(pars.dump_lattice_self_energy());
+  // EXPECT_FALSE(pars.dump_cluster_Greens_functions());
+  // EXPECT_FALSE(pars.dump_Gamma_lattice());
+  // EXPECT_FALSE(pars.dump_chi_0_lattice());
+  // EXPECT_FALSE(pars.dump_every_iteration());
 }
 
 TEST(OutputParametersTest, ReadAll) {
@@ -47,6 +79,7 @@ TEST(OutputParametersTest, ReadAll) {
   // default.
   EXPECT_EQ("./T=0.5", pars.get_directory());
   EXPECT_EQ("JSON", pars.get_output_format());
+  EXPECT_EQ("JSON", pars.get_g4_output_format());
   EXPECT_EQ(true, pars.autoresume());
   EXPECT_EQ("configuration", pars.get_directory_config_read());
   EXPECT_EQ("configuration", pars.get_directory_config_write());


### PR DESCRIPTION
This should make it possible to use hdf5 file output from previous versions of DCA++ with the current version. 