### PR TITLE
Fix hdf5 chemical potential read

### DIFF
--- a/include/dca/io/adios2/adios2_reader.hpp
+++ b/include/dca/io/adios2/adios2_reader.hpp
@@ -77,7 +77,7 @@ public:
    *  file may have multiple iterations in it.
    *  Each iteration is a step in the adios file for many variables.
    */
-  std::size_t getStepCount() { return file_.Steps(); }
+  long getStepCount() { return file_.Steps(); }
   
   // `execute` returns true if the object is read correctly.
 

--- a/include/dca/io/hdf5/hdf5_reader.hpp
+++ b/include/dca/io/hdf5/hdf5_reader.hpp
@@ -68,7 +68,7 @@ public:
 
   std::string get_path() const;
 
-  std::size_t getStepCount();
+  long getStepCount();
   
   template <typename arbitrary_struct_t>
   static void from_file(arbitrary_struct_t& arbitrary_struct, std::string file_name);

--- a/include/dca/io/hdf5/hdf5_writer.hpp
+++ b/include/dca/io/hdf5/hdf5_writer.hpp
@@ -51,7 +51,8 @@ public:
 
   void open_file(std::string file_name_ref, bool overwrite = true);
   void close_file();
-
+  void legacy_close_file();
+  
   bool open_group(std::string new_path);
   void close_group();
 

--- a/include/dca/io/json/json_reader.hpp
+++ b/include/dca/io/json/json_reader.hpp
@@ -42,7 +42,7 @@ public:
   // the root group.
   bool close_group() noexcept;
 
-  std::size_t getStepCount() { return 0; }
+  long getStepCount() { return 0; }
 
   std::string get_path() { return {}; }
   

--- a/include/dca/io/reader.hpp
+++ b/include/dca/io/reader.hpp
@@ -109,7 +109,7 @@ public:
     std::visit([&](auto& var) { var.close_group(); }, reader_);
   }
 
-  std::size_t getStepCount() {
+  long getStepCount() {
     return std::visit([&](auto& var) ->std::size_t { return var.getStepCount(); }, reader_);
   }
   

--- a/include/dca/phys/dca_data/dca_data.hpp
+++ b/include/dca/phys/dca_data/dca_data.hpp
@@ -631,10 +631,11 @@ void DcaData<Parameters, DT>::initializeSigma(const std::string& filename) {
     io::Reader reader(concurrency_, sigma_file_io);
     int hdf5_last_iteration = -1;
     reader.open_file(filename);
-    std::size_t step_count = reader.getStepCount();
+    long step_count = reader.getStepCount();
     // Work around odd way hdf5 steps get written
     int completed_iteration = 0;
-    for (std::size_t i = 0; i < step_count; ++i) {
+    if (step_count >= 0) {
+    for (long i = 0; i < step_count; ++i) {
       reader.begin_step();
       std::cerr << "current step " << i << '\n';
       bool has_iteration =
@@ -652,6 +653,7 @@ void DcaData<Parameters, DT>::initializeSigma(const std::string& filename) {
 	reader.end_step();
     }
     reader.begin_step();
+    }
     readSigmaFile(reader);
     reader.close_file();
   }

--- a/include/dca/phys/dca_data/dca_data.hpp
+++ b/include/dca/phys/dca_data/dca_data.hpp
@@ -634,22 +634,22 @@ void DcaData<Parameters, DT>::initializeSigma(const std::string& filename) {
     std::size_t step_count = reader.getStepCount();
     // Work around odd way hdf5 steps get written
     int completed_iteration = 0;
-  find_step:
     for (std::size_t i = 0; i < step_count; ++i) {
       reader.begin_step();
       std::cerr << "current step " << i << '\n';
       bool has_iteration =
           reader.execute("DCA-loop-functions/completed-iteration", completed_iteration);
       std::cerr << "completed_iteration " << completed_iteration << '\n';
-      if (has_iteration && (i >= completed_iteration)) {
-	std::cerr << "past complete iterations " << completed_iteration << "at step " << i << '\n';
+      if (has_iteration)
 	hdf5_last_iteration = completed_iteration;
-	reader.close_file();
-	reader.open_file(filename);
-	step_count = hdf5_last_iteration;
-	goto find_step;	
-      }
       reader.end_step();
+    }
+    reader.close_file();
+    reader.open_file(filename);
+
+    for (std::size_t i = 0; i < hdf5_last_iteration; ++i) {
+	reader.begin_step();
+	reader.end_step();
     }
     reader.begin_step();
     readSigmaFile(reader);
@@ -664,10 +664,10 @@ void DcaData<Parameters, DT>::readSigmaFile(io::Reader<Concurrency>& reader) {
   reader.open_group("DCA-loop-functions");
   std::vector<double> chemical_potentials;
   bool chemical_potential_present = reader.execute("chemical-potential", chemical_potentials);
-  int completed_iteration;
-  bool has_iteration = reader.execute("completed-iteration", completed_iteration);
-  
+  std::vector<int> completed_iterations;
+  bool has_iteration = reader.execute("completed-iteration", completed_iterations);
   if (chemical_potential_present && has_iteration) {
+    int completed_iteration = *std::max_element(completed_iterations.begin(), completed_iterations.end());
     std::cout << "chemical-potential from Sigma file: " << chemical_potentials[completed_iteration]
               << '\n';
     parameters_.get_chemical_potential() = chemical_potentials[completed_iteration];

--- a/include/dca/phys/dca_loop/dca_loop.hpp
+++ b/include/dca/phys/dca_loop/dca_loop.hpp
@@ -63,7 +63,6 @@ public:
   using k_HOST =
       func::dmn_0<domains::cluster_domain<double, ParametersType::lattice_type::DIMENSION, domains::LATTICE_SP,
                                           domains::MOMENTUM_SPACE, domains::BRILLOUIN_ZONE>>;
-
   using cluster_exclusion_type = clustermapping::cluster_exclusion<ParametersType, DcaDataType>;
   using double_counting_correction_type =
       clustermapping::double_counting_correction<ParametersType, DcaDataType>;

--- a/include/dca/phys/dca_step/cluster_mapping/update_chemical_potential.hpp
+++ b/include/dca/phys/dca_step/cluster_mapping/update_chemical_potential.hpp
@@ -131,7 +131,7 @@ void update_chemical_potential<parameters_type, MOMS_type, coarsegraining_type>:
     double n_lb = lower_bound.second;
     double n_ub = upper_bound.second;
 
-    parameters.get_chemical_potential() = get_new_chemical_potential(d_0, mu_lb, mu_ub, n_lb, n_ub);
+    parameters.set_chemical_potential(get_new_chemical_potential(d_0, mu_lb, mu_ub, n_lb, n_ub));
 
     dens = compute_density();
 

--- a/include/dca/phys/parameters/physics_parameters.hpp
+++ b/include/dca/phys/parameters/physics_parameters.hpp
@@ -51,6 +51,8 @@ public:
     return chemical_potential_;
   }
 
+  void set_chemical_potential(double cpot) { chemical_potential_ = cpot; }
+
   bool adjust_chemical_potential() const {
     return adjust_chemical_potential_;
   }

--- a/src/io/hdf5/hdf5_reader.cpp
+++ b/src/io/hdf5/hdf5_reader.cpp
@@ -26,13 +26,13 @@ HDF5Reader::~HDF5Reader() {
     close_file();
 }
 
-std::size_t HDF5Reader::getStepCount() {
-  std::size_t steps;
+long HDF5Reader::getStepCount() {
+  long steps;
   bool has_steps = execute("steps", steps);
   if (!has_steps) {
     is_legacy_ = true;
     std::cerr << "Legacy DCA hdf5 with no step data read.\n";
-    return 0;
+    return -1;
   }
   return steps;
 }

--- a/src/io/hdf5/hdf5_writer.cpp
+++ b/src/io/hdf5/hdf5_writer.cpp
@@ -50,6 +50,15 @@ void HDF5Writer::close_file() {
   }
 }
 
+void HDF5Writer::legacy_close_file() {
+  if (file_) {
+    my_paths_.clear();
+    file_->close();
+    file_.reset(nullptr);
+  }
+}
+
+  
 bool HDF5Writer::open_group(std::string name) {
   my_paths_.push_back(name);
   const std::string path = get_path();

--- a/src/phys/domains/time_and_frequency/frequency_domain.cpp
+++ b/src/phys/domains/time_and_frequency/frequency_domain.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>  // M_PI
 #include <stdexcept>
+#include <iostream>
 
 namespace dca {
 namespace phys {
@@ -27,7 +28,7 @@ std::vector<int> frequency_domain::indices_;
 
 void frequency_domain::initialize(const ScalarType beta, const int num_freqs) {
   if (initialized_)
-    throw std::logic_error("frequency_domain has already been initialzed.");
+    std::cerr << "frequency_domain has already been initialized., if this is not test code, this is likely a serious error!\n";
 
   const int size = 2 * num_freqs;
 

--- a/src/phys/domains/time_and_frequency/time_domain.cpp
+++ b/src/phys/domains/time_and_frequency/time_domain.cpp
@@ -13,6 +13,7 @@
 #include "dca/phys/domains/time_and_frequency/time_domain.hpp"
 #include <cmath>  // for std::pow
 #include <stdexcept>
+#include <iostream>
 
 namespace dca {
 namespace phys {
@@ -26,7 +27,7 @@ std::vector<time_domain::element_type> time_domain::elements_;
 
 void time_domain::initialize(const scalar_type beta, const int time_slices, const scalar_type eps) {
   if (initialized_)
-    throw std::logic_error("time_domain has already been initialized.");
+    std::cerr << "Time has already been initialized., if this is not test code, this is likely a serious error!";
 
   beta_ = beta;
 

--- a/src/phys/domains/time_and_frequency/time_domain_left_oriented.cpp
+++ b/src/phys/domains/time_and_frequency/time_domain_left_oriented.cpp
@@ -12,6 +12,7 @@
 
 #include "dca/phys/domains/time_and_frequency/time_domain_left_oriented.hpp"
 #include <stdexcept>
+#include <iostream>
 
 namespace dca {
 namespace phys {
@@ -24,7 +25,7 @@ std::vector<time_domain_left_oriented::element_type> time_domain_left_oriented::
 
 void time_domain_left_oriented::initialize() {
   if (initialized_)
-    throw std::logic_error("time_domain_left_oriented has already been initialized.");
+    std::cerr << "time_domain_left_oriented has already been initialized., if this is not test code, this is likely a serious error!";
 
   if (!time_domain::is_initialized())
     throw std::logic_error("time_domain must be initialized first.");

--- a/test/unit/io/json_reader_test.cpp
+++ b/test/unit/io/json_reader_test.cpp
@@ -1,3 +1,14 @@
+// Copyright (C) 2022 ETH Zurich
+// Copyright (C) 2022 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Peter Doak (doakpw@ornl.gov)
+//
+// This file provides unit tests or the json reader and writer.
+
 #include "dca/testing/gtest_h_w_warning_blocking.h"
 
 #include "dca/io/json/json_reader.hpp"

--- a/test/unit/phys/CMakeLists.txt
+++ b/test/unit/phys/CMakeLists.txt
@@ -1,6 +1,7 @@
 # test/unit/phys
 
 add_subdirectory(dca_algorithms)
+add_subdirectory(dca_data)
 add_subdirectory(dca_step)
 add_subdirectory(domains)
 add_subdirectory(models)

--- a/test/unit/phys/dca_data/CMakeLists.txt
+++ b/test/unit/phys/dca_data/CMakeLists.txt
@@ -1,0 +1,6 @@
+# IO's unit tests
+
+dca_add_gtest(dca_data_test
+  FAST
+  INCLUDE_DIRS ${DCA_INCLUDE_DIRS};${PROJECT_SOURCE_DIR}
+  LIBS function ${DCA_LIBS})

--- a/test/unit/phys/dca_data/dca_data_test.cpp
+++ b/test/unit/phys/dca_data/dca_data_test.cpp
@@ -108,6 +108,10 @@ using DCADataTest = DCADataTestWrapper<DCADSetup<read_sigma_input_file>>;
 
 TEST_F(DCADataTest, ReadSigma) {
   dca_setup_.data_->initialize();
+  std::cout << "initial_self_energy:" << dca_setup_.parameters_->get_initial_self_energy();
+  dca_setup_.data_->initializeSigma(
+				    "dca_data_test.hdf5");
+  EXPECT_EQ(dca_setup_.parameters_->get_chemical_potential(), 3.0);
 }
 
 int main(int argc, char** argv) {

--- a/test/unit/phys/dca_data/dca_data_test.cpp
+++ b/test/unit/phys/dca_data/dca_data_test.cpp
@@ -1,0 +1,163 @@
+// Copyright (C) 2023 ETH Zurich
+// Copyright (C) 2023 UT-Battelle, LLC
+// All rights reserved.
+//
+// See LICENSE for terms of usage.
+// See CITATION.md for citation guidelines, if DCA++ is used for scientific publications.
+//
+// Author: Peter Doak (doakpw@ornl.gov)
+//
+// This file provides unit tests for dca_data, thus far these just cover specific cases where there
+// have been regressions
+
+#include "dca/testing/gtest_h_w_warning_blocking.h"
+#include "dca/phys/parameters/parameters.hpp"
+#include "dca/phys/models/analytic_hamiltonians/square_lattice.hpp"
+#include "dca/parallel/no_concurrency/no_concurrency.hpp"
+#include "dca/parallel/no_threading/no_threading.hpp"
+#include "dca/phys/dca_data/dca_data.hpp"
+#include "dca/phys/dca_loop/dca_loop_data.hpp"
+#include "test/unit/phys/dca_step/cluster_solver/stub_rng.hpp"
+#include "dca/profiling/null_profiler.hpp"
+
+#ifdef DCA_HAVE_ADIOS2
+adios2::ADIOS* adios_ptr;
+#endif
+
+#ifdef DCA_HAVE_MPI
+#include "dca/parallel/mpi_concurrency/mpi_concurrency.hpp"
+using Concurrency = dca::parallel::MPIConcurrency;
+#else
+#include "dca/parallel/no_concurrency/no_concurrency.hpp"
+using Concurrency = dca::parallel::NoConcurrency;
+#endif
+Concurrency* concurrency_ptr;
+
+namespace dca {
+namespace testing {
+// dca::testing::
+
+using LatticeSquare = phys::models::square_lattice<phys::domains::D4>;
+
+constexpr char dca_data_test_input[] = DCA_SOURCE_DIR "/test/unit/phys/dca_data/input_hdf5.json";
+
+template <typename Scalar, class Concurrency, class Lattice = LatticeSquare,
+          ClusterSolverId solver_name = ClusterSolverId::CT_AUX,
+          const char* input_name = dca_data_test_input, DistType DT = DistType::NONE>
+struct DCADataSetup {
+  using LatticeType = Lattice;
+  using Model = phys::models::TightBindingModel<Lattice>;
+  using RngType = testing::StubRng;
+  using Parameters = phys::params::Parameters<Concurrency, parallel::NoThreading,
+                                              profiling::NullProfiler, Model, RngType, solver_name>;
+  using Data = phys::DcaData<Parameters, DT>;
+  using LoopData = phys::DcaLoopData<Parameters>;
+
+  Concurrency* concurrency_;
+  std::unique_ptr<Parameters> parameters_;
+  std::unique_ptr<Data> data_;
+  std::unique_ptr<LoopData> loop_data_;
+
+  void SetUp(Concurrency* concurrency) {
+    concurrency_ = concurrency;
+    parameters_ = std::make_unique<Parameters>("", *concurrency);
+    try {
+      parameters_->template read_input_and_broadcast<io::JSONReader>(input_name);
+    }
+    catch (const std::exception& r_w) {
+      throw std::runtime_error(r_w.what());
+    }
+    catch (...) {
+      throw std::runtime_error("Input parsing failed!");
+    }
+    parameters_->update_model();
+    static bool domain_initialized = false;
+    if (!domain_initialized) {
+      parameters_->update_domains();
+      domain_initialized = true;
+    }
+    data_ = std::make_unique<Data>(*parameters_);
+    loop_data_ = std::make_unique<LoopData>();
+  }
+
+  void TearDown() {}
+};
+
+}  // namespace testing
+}  // namespace dca
+
+template <const char* INPUTFILE = dca::testing::dca_data_test_input>
+using DCADSetup =
+  dca::testing::DCADataSetup<double, Concurrency ,dca::testing::LatticeSquare, dca::ClusterSolverId::CT_AUX, INPUTFILE>;
+
+template <class DCADATASETUP>
+struct DCADataTestWrapper : public ::testing::Test {
+  DCADATASETUP dca_setup_;
+  virtual void SetUp() {
+    dca_setup_.SetUp(concurrency_ptr);
+  }
+  virtual void TearDown() {
+    dca_setup_.TearDown();
+  }
+};
+
+constexpr char read_sigma_input_file[] =
+    DCA_SOURCE_DIR "/test/unit/phys/dca_data/input_read_hdf5.json";
+
+using DCADataTest = DCADataTestWrapper<DCADSetup<read_sigma_input_file>>;
+
+TEST_F(DCADataTest, ReadSigma) {
+  dca_setup_.data_->initialize();
+}
+
+int main(int argc, char** argv) {
+#ifdef DCA_HAVE_MPI
+  dca::parallel::MPIConcurrency concurrency(argc, argv);
+  concurrency_ptr = &concurrency;
+#else
+  dca::parallel::NoConcurrency concurrency(argc, argv);
+  concurrency_ptr = &concurrency;
+#endif
+
+#ifdef DCA_HAVE_ADIOS2
+  // ADIOS expects MPI_COMM pointer or nullptr
+  adios2::ADIOS adios("", concurrency_ptr->get(), false);
+  adios_ptr = &adios;
+#endif
+  ::testing::InitGoogleTest(&argc, argv);
+
+  {
+    // Make hdf file for testing.
+    DCADSetup<> dca_data;
+    dca_data.SetUp(concurrency_ptr);
+    dca_data.data_->initialize();
+    dca_data.loop_data_->chemical_potential(0) = 1.0;
+    dca_data.loop_data_->last_completed_iteration = 0;
+    std::string format{"HDF5"};
+    dca::io::Writer<Concurrency> writer(
+#ifdef DCA_HAVE_ADIOS2
+        *adios_ptr,
+#endif
+        *concurrency_ptr, format);
+    writer.open_file("dca_data_test.hdf5", true);
+    writer.begin_step();
+    dca_data.data_->write(writer);
+    dca_data.loop_data_->write(writer, *concurrency_ptr);
+    writer.end_step();
+	dca_data.loop_data_->chemical_potential(1) = 2.0;
+    dca_data.loop_data_->last_completed_iteration = 1;
+    writer.begin_step();
+    dca_data.data_->write(writer);
+    dca_data.loop_data_->write(writer, *concurrency_ptr);
+    writer.end_step();
+	dca_data.loop_data_->chemical_potential(2) = 3.0;
+    dca_data.loop_data_->last_completed_iteration = 2;
+    writer.begin_step();
+    dca_data.data_->write(writer);
+    dca_data.loop_data_->write(writer, *concurrency_ptr);
+    writer.end_step();
+    writer.close_file();
+  }
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/test/unit/phys/dca_data/input_hdf5.json
+++ b/test/unit/phys/dca_data/input_hdf5.json
@@ -26,7 +26,7 @@
     "U"       : 2
   },
     "DCA": {
-	"iterations": 3
+	"iterations": 4
     },
   "domains": {
     "real-space-grids": {

--- a/test/unit/phys/dca_data/input_hdf5.json
+++ b/test/unit/phys/dca_data/input_hdf5.json
@@ -1,0 +1,61 @@
+{
+  "output" :
+  {
+    "output-format"         : "HDF5",
+    "output-ED"  : "ed_results.hdf5",
+    "output-QMC" : "output_QMC.hdf5"
+  },
+  "physics" :
+  {
+    "beta"                      :  2,
+    "chemical-potential"        : 0
+  },
+  "bilayer-Hubbard-model":
+  {
+    "t"       : 1,
+    "U"       : 2
+  },
+  "Hund-model": {
+    "t"       : 1,
+    "U"       : 1,
+    "V"       : 1,
+    "Jh"      : 2
+  },
+  "single-band-Hubbard-model": {
+    "t"       : 1,
+    "U"       : 2
+  },
+    "DCA": {
+	"iterations": 3
+    },
+  "domains": {
+    "real-space-grids": {
+      "cluster": [[2, 0],
+        [0, 2]]
+    },
+    "imaginary-time": {
+      "sp-time-intervals": 512
+    },
+    "imaginary-frequency": {
+      "sp-fermionic-frequencies": 512,
+      "four-point-fermionic-frequencies" : 8
+    }
+  },
+  "four-point": {
+    "type": "NONE",
+    "momentum-transfer": [0., 3.1415],
+    "frequency-transfer": 2
+  },
+  "Monte-Carlo-integration" : {
+    "warm-up-sweeps"         : 100,
+    "sweeps-per-measurement" : 1,
+    "measurements" : 500,
+    "seed" : 0
+  },
+  "CT-INT" :
+  {
+    "initial-configuration-size" :5,
+    "alpha-dd-pos" : 0.51,
+    "double-update-probability" : 0
+  }
+}

--- a/test/unit/phys/dca_data/input_read_hdf5.json
+++ b/test/unit/phys/dca_data/input_read_hdf5.json
@@ -1,0 +1,59 @@
+{
+  "output" :
+  {
+    "output-format"         : "HDF5",
+    "output-ED"  : "ed_results.hdf5",
+    "output-QMC" : "output_QMC.hdf5"
+  },
+  "physics" :
+  {
+    "beta"                      :  2,
+    "chemical-potential"        : 0
+  },
+  "bilayer-Hubbard-model":
+  {
+    "t"       : 1,
+    "U"       : 2
+  },
+  "Hund-model": {
+    "t"       : 1,
+    "U"       : 1,
+    "V"       : 1,
+    "Jh"      : 2
+  },
+  "single-band-Hubbard-model": {
+    "t"       : 1,
+    "U"       : 2
+  },
+  "domains": {
+    "real-space-grids": {
+      "cluster": [[2, 0],
+        [0, 2]]
+    },
+    "imaginary-time": {
+      "sp-time-intervals": 512
+    },
+    "imaginary-frequency": {
+      "sp-fermionic-frequencies": 512,
+      "four-point-fermionic-frequencies" : 8
+    }
+  },
+  "four-point": {
+    "type": "NONE",
+    "momentum-transfer": [0., 3.1415],
+    "frequency-transfer": 2
+  },
+  "Monte-Carlo-integration" : {
+    "Sigma-file" : "dca_data_test.hdf5",
+    "warm-up-sweeps"         : 100,
+    "sweeps-per-measurement" : 1,
+    "measurements" : 500,
+    "seed" : 0
+  },
+  "CT-INT" :
+  {
+    "initial-configuration-size" :5,
+    "alpha-dd-pos" : 0.51,
+    "double-update-probability" : 0
+  }
+}

--- a/test/unit/phys/dca_data/input_read_hdf5.json
+++ b/test/unit/phys/dca_data/input_read_hdf5.json
@@ -44,7 +44,7 @@
     "frequency-transfer": 2
   },
   "Monte-Carlo-integration" : {
-    "Sigma-file" : "dca_data_test.hdf5",
+    "initial-self-energy" : "dca_data_test.hdf5",
     "warm-up-sweeps"         : 100,
     "sweeps-per-measurement" : 1,
     "measurements" : 500,

--- a/test/unit/phys/domains/time_and_frequency/frequency_domain_test.cpp
+++ b/test/unit/phys/domains/time_and_frequency/frequency_domain_test.cpp
@@ -41,7 +41,4 @@ TEST(FrequencyDomainTest, Full) {
   EXPECT_EQ(2 * num_freqs, frequency_domain::get_size());
   EXPECT_EQ(elements_expected, frequency_domain::get_elements());
   EXPECT_EQ(indices_expected, frequency_domain::get_indices());
-
-  // The domain can only be initialized once.
-  EXPECT_THROW(frequency_domain::initialize(0.9, 10), std::logic_error);
 }

--- a/test/unit/phys/domains/time_and_frequency/time_domain_left_oriented_test.cpp
+++ b/test/unit/phys/domains/time_and_frequency/time_domain_left_oriented_test.cpp
@@ -19,6 +19,7 @@ using namespace dca::phys::domains;
 TEST(TimeDomainLeftOriented, Basic) {
   EXPECT_EQ("time-domain-left-oriented", time_domain_left_oriented::get_name());
   EXPECT_FALSE(time_domain_left_oriented::is_initialized());
+  // tdlo can't be initialized until after time_domain
   EXPECT_THROW(time_domain_left_oriented::initialize(), std::logic_error);
 
   // First we need to initialize time_domain.
@@ -35,6 +36,4 @@ TEST(TimeDomainLeftOriented, Basic) {
 
   const std::vector<double> elements_check{-beta + eps, -beta / time_slices, 0, beta / time_slices};
   EXPECT_EQ(elements_check, time_domain_left_oriented::get_elements());
-
-  EXPECT_THROW(time_domain_left_oriented::initialize(), std::logic_error);
 }

--- a/test/unit/phys/domains/time_and_frequency/time_domain_test.cpp
+++ b/test/unit/phys/domains/time_and_frequency/time_domain_test.cpp
@@ -38,8 +38,6 @@ TEST(TimeDomainTest, Basic) {
                                            eps,         beta / time_slices,  beta - eps};
   EXPECT_EQ(elements_check, time_domain::get_elements());
 
-  EXPECT_THROW(time_domain::initialize(beta, time_slices, eps), std::logic_error);
-
   // Check initialization of integration domain.
   time_domain::initialize_integration_domain(level, weights, nodes);
 


### PR DESCRIPTION
A regression resulting the chemical potential being read from the starting iteration instead of the final iteration when reading hdf5 files for the initial self energy is fixed in this PR.