### PR TITLE
Refactor ctint walker

### DIFF
--- a/cmake/dca_config.cmake
+++ b/cmake/dca_config.cmake
@@ -145,6 +145,8 @@ elseif (DCA_LATTICE STREQUAL "Kagome")
     "dca/phys/models/analytic_hamiltonians/Kagome_hubbard.hpp")
 elseif (DCA_LATTICE STREQUAL "hund")
   set(DCA_LATTICE_TYPE dca::phys::models::HundLattice<PointGroup>)
+  set(DCA_LATTICE_INCLUDE
+    "dca/phys/models/analytic_hamiltonians/hund_lattice.hpp")
 elseif (DCA_LATTICE STREQUAL "threeband")
   set(DCA_LATTICE_TYPE dca::phys::models::ThreebandHubbard<PointGroup>)
   set(DCA_LATTICE_INCLUDE

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -117,6 +117,8 @@ public:
     return g0_;
   };
 
+  Walker::Resource& getResource() { return dummy_walker_resource_; };
+
 protected:
   void warmUp(Walker& walker);
 
@@ -161,6 +163,7 @@ protected:
 
   G0Interpolation<device, Scalar> g0_;
 
+  Walker::Resource walker_dummy_resource_;
 private:
   Rng rng_;
 

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_walker.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_walker.hpp
@@ -66,6 +66,9 @@ public:
   constexpr static dca::linalg::DeviceType device = device_t;
   static constexpr bool is_complex = dca::util::IsComplex<Scalar>::value;
 
+  struct DummyResource {};
+  using Resource = DummyResource;
+
 public:
   /** constructor
    *  param[in] id    thread id

--- a/include/dca/phys/dca_step/cluster_solver/ctint/ctint_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/ctint_cluster_solver.hpp
@@ -75,6 +75,8 @@ public:
   using Data = DcaData<Parameters, DIST>;
   static constexpr linalg::DeviceType device = device_t;
 
+  using DMatrixBuilder = ctint::DMatrixBuilder<device_t, Scalar>;
+
   CtintClusterSolver(Parameters& parameters_ref, Data& Data_ref,
                      std::shared_ptr<io::Writer<Concurrency>> writer);
 
@@ -109,7 +111,7 @@ public:
   // Returns the function G(k,w) without averaging across MPI ranks.
   auto local_G_k_w() const;
 
-  
+  DMatrixBuilder& getResource() { return *d_matrix_builder_; };
 protected:  // thread jacket interface.  
   using ParametersType = Parameters;
   using DataType = Data;
@@ -119,7 +121,6 @@ protected:  // thread jacket interface.
   using Lattice = typename Parameters::lattice_type;
 
   using Walker = ctint::CtintWalkerChoice<device_t, Parameters, use_submatrix, DIST>;
-  using DMatrixBuilder = ctint::DMatrixBuilder<device_t, Scalar>;
   using Accumulator = ctint::CtintAccumulator<Parameters, device_t, DIST>;
 
 private:
@@ -194,7 +195,7 @@ void CtintClusterSolver<device_t, Parameters, use_submatrix, DIST>::initialize(i
   
   g0_.initializeShrinked(data_.G0_r_t_cluster_excluded);
 
-  d_matrix_builder_.setAlphas(parameters_.getAlphas(), parameters_.adjustAlphaDd());
+  d_matrix_builder_->setAlphas(parameters_.getAlphas(), parameters_.adjustAlphaDd());
 
   // It is a waiting to happen bug for this to be here and in CtintAccumulator
   accumulator_.initialize(dca_iteration_);

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_base.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_base.hpp
@@ -91,6 +91,8 @@ public:
 
   virtual void doStep() = 0;
 
+  virtual void doSweep() = 0;
+  
   template<linalg::DeviceType DEVICE>
   void setMFromConfigImpl(DMatrixBuilder<DEVICE, Scalar>& d_matrix_builder);
   

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_base.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_base.hpp
@@ -345,6 +345,42 @@ void CtintWalkerBase<Parameters,DIST>::computeM(MatrixPair& m_accum) const {
   m_accum = M_;
 }
 
+// template<class WALKER, linalg::DeviceType DEVICE>  
+// void setMFromConfigHelper(WALKER& walker, DMatrixBuilder<DEVICE, Scalar>& d_matrix_builder) {
+//   walker.mc_log_weight_ = 0.;
+//   walker.phase_.reset();
+
+//   for (int s = 0; s < 2; ++s) {
+//     // compute Mij = g0(t_i,t_j) - I* alpha(s_i)
+
+//     const auto& sector = walker.configuration_.getSector(s);
+//     auto& M = walker.M_[s];
+//     const int n = sector.size();
+//     M.resize(n);
+//     if (!n)
+//       continue;
+//     for (int j = 0; j < n; ++j)
+//       for (int i = 0; i < n; ++i)
+//         M(i, j) = d_matrix_builder.computeD(i, j, sector);
+
+//     if (M.nrRows()) {
+//       const auto [log_det, phase] = linalg::matrixop::inverseAndLogDeterminant(M);
+
+//       walker.mc_log_weight_ -= log_det;  // Weight proportional to det(M^{-1})
+//       walker.phase_.divide(phase);
+//     }
+//   }
+
+//   // So what is going on here.
+//   for (int i = 0; i < walker.configuration_.size(); ++i) {
+//     // This is actual interaction strength of the vertex i.e H_int(nu1, nu2, delta_r)
+//     const typename decltype(walker)::Real term = -walker.configuration_.getStrength(i);
+//     walker.mc_log_weight_ += std::log(std::abs(term));
+//     walker.phase_.multiply(term);
+//   }
+// }
+  
+     
 template <class Parameters, DistType DIST>
 template <linalg::DeviceType DEVICE>
 void CtintWalkerBase<Parameters, DIST>::setMFromConfigImpl(DMatrixBuilder<DEVICE, Scalar>& d_matrix_builder) {

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_cpu.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_cpu.hpp
@@ -52,7 +52,7 @@ public:
 public:
   CtintWalker(const Parameters& pars_ref, const Data& /*data*/, Rng& rng_ref, DMatrixBuilder<linalg::CPU, Scalar>& d_matrix_builder, int id = 0);
 
-  void doSweep();
+  void doSweep() override;
 
   void markThermalized() override;
 protected:

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_cpu.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_cpu.hpp
@@ -49,6 +49,8 @@ public:
   using MatrixView = typename linalg::MatrixView<Scalar, linalg::CPU>;
   using ConstView = typename linalg::MatrixView<const Scalar, linalg::CPU>;
 
+  using Resource = DMatrixBuilder<linalg::CPU, Scalar>;
+
 public:
   CtintWalker(const Parameters& pars_ref, const Data& /*data*/, Rng& rng_ref, DMatrixBuilder<linalg::CPU, Scalar>& d_matrix_builder, int id = 0);
 

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_cpu_submatrix.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_cpu_submatrix.hpp
@@ -53,6 +53,8 @@ public:
   using typename BaseClass::Real;
   using typename BaseClass::Scalar;
 
+  using Resource = DMatrixBuilder<linalg::CPU, Scalar>;
+
   CtintWalkerSubmatrixCpu(const Parameters& pars_ref, const Data& /*data*/, Rng& rng_ref, DMatrixBuilder<linalg::CPU, Scalar>& d_matrix_builder, int id = 0);
 
   virtual ~CtintWalkerSubmatrixCpu() = default;

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_cpu_submatrix.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_cpu_submatrix.hpp
@@ -31,6 +31,7 @@
 #include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.hpp"
 #include "dca/phys/dca_step/cluster_solver/shared_tools/interpolation/g0_interpolation.hpp"
 #include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/walker_methods.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_submatrix_base.hpp"
 #include "dca/phys/parameters/parameters.hpp"
 #include "dca/util/integer_division.hpp"
 
@@ -40,9 +41,10 @@ namespace solver {
 namespace ctint {
 
 template <class Parameters, DistType DIST>
-class CtintWalkerSubmatrixCpu : public CtintWalkerBase<Parameters, DIST> {
+class CtintWalkerSubmatrixCpu : public CtintWalkerSubmatrixBase<Parameters, DIST> {
 public:
   using this_type = CtintWalkerSubmatrixCpu;
+  using SubmatrixBase = CtintWalkerSubmatrixBase<Parameters, DIST>;
   using BaseClass = CtintWalkerBase<Parameters, DIST>;
   using typename BaseClass::Rng;
   using typename BaseClass::Data;
@@ -55,15 +57,12 @@ public:
 
   virtual ~CtintWalkerSubmatrixCpu() = default;
 
-  void doSweep() override;
-
   void computeM(typename BaseClass::MatrixPair& m_accum);
 
   using BaseClass::order;
 
   void setMFromConfig() override;
 protected:
-  void doStep() override;
   void doSteps();
   void generateDelayedMoves(int nbr_of_movesto_delay);
 
@@ -85,14 +84,11 @@ protected:
 
   void markThermalized() override;
 
-  void updateM();
+  void updateM() override;
 
   void transformM();
 
-  // For testing purposes.
-  void doStep(const int nbr_of_movesto_delay);
-
-  const DMatrixBuilder<linalg::CPU, Scalar>& d_matrix_builder_;
+  DMatrixBuilder<linalg::CPU, Scalar>& d_matrix_builder_;
 private:
 
   void doSubmatrixUpdate();
@@ -105,10 +101,10 @@ private:
 
   void removeRowAndColOfGammaInv();
 
-  void computeMInit();
+  void computeMInit() override;
 
   //  void computeG0Init();
-  void computeGInit();
+  void computeGInit() override;
 
   Move generateMoveType();
 
@@ -121,11 +117,6 @@ private:
   void findSectorIndices(const int s);
 
   void recomputeGammaInv();
-
-  bool recentlyAdded(int move_idx, int s) const {
-    assert(move_idx < sector_indices_[s].size());
-    return sector_indices_[s][move_idx] >= n_init_[s];
-  }
 
 protected:
   using MatrixView = linalg::MatrixView<Scalar, linalg::CPU>;
@@ -152,88 +143,50 @@ protected:
   using BaseClass::n_accepted_;
 
 protected:
-  int max_submatrix_size_;
+  using SubmatrixBase::max_submatrix_size_;
 
-  struct DelayedMoveType {
-    Move move_type;
-    std::array<double, 3> removal_rng{1., 1., 1.};
-    Real acceptance_rng;
-    std::array<int, 2> indices{-1, -1};
-  };
-
+  using typename SubmatrixBase::DelayedMoveType;
+  using SubmatrixBase::f_;
+  using SubmatrixBase::gamma_values_;
+  using SubmatrixBase::prob_const_;
+  using SubmatrixBase::nb_steps_per_sweep_;
+  using SubmatrixBase::n_max_;
+  using SubmatrixBase::n_init_;
+  using SubmatrixBase::D_;
+  using SubmatrixBase::G_;
+  using SubmatrixBase::M_;
+  using SubmatrixBase::s_;
+  using SubmatrixBase::Gamma_indices_;
+  using SubmatrixBase::Gamma_inv_;
+  using SubmatrixBase::Gamma_inv_cpy_;
+  using SubmatrixBase::Gamma_q_;
+  using SubmatrixBase::workspace_;
+  using SubmatrixBase::r_;
+  using SubmatrixBase::move_indices_;
+  using SubmatrixBase::gamma_;
+  using SubmatrixBase::source_list_;
+  using SubmatrixBase::removal_list_;
+  using SubmatrixBase::conf_removal_list_;
+  using SubmatrixBase::sector_indices_;
+  using SubmatrixBase::index_;
+  using SubmatrixBase::nbr_of_indices_;
+  using SubmatrixBase::q_;
+  using SubmatrixBase::det_ratio_;
 protected:
   using BaseClass::acceptance_prob_;
 
 protected:
-  static constexpr Scalar the_one_ = dca::util::TheOne<Scalar>::value;
-
-  std::vector<DelayedMoveType> delayed_moves_;
-
-  using MatrixPair = std::array<linalg::Matrix<Scalar, linalg::CPU>, 2>;
-  MatrixPair G_;
-  MatrixPair G0_;
-  MatrixPair Gamma_inv_;      // TODO: don't pin
-  MatrixPair Gamma_inv_cpy_;  // TODO: don't pin
-  MatrixPair q_;              // TODO: don't pin or store in Gamma inv
-  MatrixPair r_;
-  MatrixPair s_;
-  std::array<std::vector<Real>, 2> gamma_;
-
-  Scalar det_ratio_;
-  std::map<int, std::array<Real, n_bands_>> f_;
-  std::map<int, std::array<Real, n_bands_>> prob_const_;
-  std::map<std::pair<int, int>, std::array<Real, n_bands_>> gamma_values_;
-
-  using BaseClass::nb_steps_per_sweep_;
-  int nbr_of_steps_;
-  int nbr_of_moves_to_delay_;
-  int max_nbr_of_moves;
-
-  std::array<int, 2> Gamma_size_;
-  std::array<std::vector<int>, 2> Gamma_indices_;
-  std::array<std::vector<int>, 2> sector_indices_;
-
-  const DelayedMoveType* current_move_;
-
-  std::array<unsigned, 2> nbr_of_indices_;
-
-  std::vector<int> index_;
-
-  // Initial configuration size.
-  unsigned config_size_init_;
-
-  // Initial and current sector sizes.
-  std::array<unsigned, 2> n_init_;
-  unsigned n_;
-
-  // Maximal sector size after submatrix update.
-
-  std::array<unsigned, 2> n_max_;
-
-  std::array<linalg::util::HostVector<int>, 2> move_indices_;
-  std::array<linalg::util::HostVector<int>, 2> removal_list_;
-  std::array<linalg::util::HostVector<int>, 2> source_list_;
-  std::array<std::vector<int>, 2> insertion_list_;
-  std::array<std::vector<int>, 2> insertion_Gamma_indices_;
-
-  std::vector<int> conf_removal_list_;
-
-  std::vector<int>::iterator insertion_list_it_;
-
-  std::array<Matrix, 2> Gamma_q_;
-  Matrix workspace_;
-  Matrix D_;
 
   using BaseClass::flop_;
 };
 
 template <class Parameters, DistType DIST>
-CtintWalkerSubmatrixCpu<Parameters, DIST>::CtintWalkerSubmatrixCpu(const Parameters& parameters_ref,
-                                                                   const Data& /*data*/,
-                                                                   Rng& rng_ref, DMatrixBuilder<linalg::CPU, Scalar>& d_matrix_builder,
-								   int id)
-  : BaseClass(parameters_ref, rng_ref, id), d_matrix_builder_(d_matrix_builder) {
-  for (int b = 0; b < n_bands_; ++b) {
+CtintWalkerSubmatrixCpu<Parameters, DIST>::CtintWalkerSubmatrixCpu(
+    const Parameters& parameters_ref, const Data& data, Rng& rng_ref,
+    DMatrixBuilder<linalg::CPU, Scalar>& d_matrix_builder, int id)
+    : SubmatrixBase(parameters_ref, data, rng_ref, id), d_matrix_builder_(d_matrix_builder) {
+
+    for (int b = 0; b < n_bands_; ++b) {
     for (int i = 1; i <= 3; ++i) {
       f_[i][b] = d_matrix_builder_.computeF(i, b);
       f_[-i][b] = d_matrix_builder_.computeF(-i, b);
@@ -248,13 +201,11 @@ CtintWalkerSubmatrixCpu<Parameters, DIST>::CtintWalkerSubmatrixCpu(const Paramet
     f_[0][b] = 1;
   }
 
-  if (BaseClass::concurrency_.id() == BaseClass::concurrency_.first() && thread_id_ == 0)
-    std::cout << "\nCT-INT submatrix walker created." << std::endl;
 }
 
 template <class Parameters, DistType DIST>
 void CtintWalkerSubmatrixCpu<Parameters, DIST>::setMFromConfig() {
-  setMFromConfig();
+  BaseClass::setMFromConfigImpl(d_matrix_builder_);
   transformM();
 }
 
@@ -274,333 +225,6 @@ void CtintWalkerSubmatrixCpu<Parameters,DIST>::markThermalized() {
 #ifndef NDEBUG
   //writeAlphas();
 #endif
-}
-
-template <class Parameters, DistType DIST>
-void CtintWalkerSubmatrixCpu<Parameters, DIST>::doSweep() {
-  Profiler profiler(__FUNCTION__, "CT-INT walker", __LINE__, thread_id_);
-  doSteps();
-}
-
-template <class Parameters, DistType DIST>
-void CtintWalkerSubmatrixCpu<Parameters, DIST>::doSteps() {
-  // Here nbr_of_steps is the number of single steps/moves during the current sweep,
-  // while nbr_of_submatrix_steps is the number of times the entire submatrix algorithm  is run.
-
-  if (nb_steps_per_sweep_ < 0)  // Not thermalized or fixed.
-    nbr_of_steps_ = BaseClass::avgOrder() + 1;
-  else
-    nbr_of_steps_ = nb_steps_per_sweep_;
-
-  // Get the maximum of Monte Carlo steps/moves that can be performed during one submatrix step.
-  max_nbr_of_moves = parameters_.getMaxSubmatrixSize();
-
-  BaseClass::n_steps_ += nbr_of_steps_;
-  while (nbr_of_steps_ > 0) {
-    nbr_of_moves_to_delay_ = std::min(nbr_of_steps_, max_nbr_of_moves);
-    nbr_of_steps_ -= nbr_of_moves_to_delay_;
-
-    doStep();
-  }
-
-  BaseClass::updateSweepAverages();
-}
-
-template <class Parameters, DistType DIST>
-void CtintWalkerSubmatrixCpu<Parameters, DIST>::doStep() {
-  generateDelayedMoves(nbr_of_moves_to_delay_);
-  doSubmatrixUpdate();
-}
-
-// Do one step with arbitrary number of moves. For testing.
-template <class Parameters, DistType DIST>
-void CtintWalkerSubmatrixCpu<Parameters, DIST>::doStep(const int nbr_of_movesto_delay) {
-  std::cout << "\nStarted doStep() function for testing." << std::endl;
-
-  generateDelayedMoves(nbr_of_movesto_delay);
-
-  std::cout << "\nGenerated " << nbr_of_movesto_delay << " moves for testing.\n" << std::endl;
-
-  doSubmatrixUpdate();
-}
-
-template <class Parameters, DistType DIST>
-void CtintWalkerSubmatrixCpu<Parameters, DIST>::generateDelayedMoves(const int nbr_of_movesto_delay) {
-  assert(nbr_of_movesto_delay > 0);
-
-  delayed_moves_.clear();
-
-  for (int s = 0; s < 2; ++s) {
-    n_init_[s] = configuration_.getSector(s).size();
-  }
-  n_ = config_size_init_ = configuration_.size();
-
-  // Generate delayed moves.
-  for (int i = 0; i < nbr_of_movesto_delay; ++i) {
-    DelayedMoveType delayed_move;
-
-    delayed_move.move_type = generateMoveType();
-
-    switch (delayed_move.move_type) {
-      case REMOVAL:
-        if (configuration_.getDoubleUpdateProb())
-          delayed_move.removal_rng = {rng_(), rng_(), rng_()};
-        else
-          delayed_move.removal_rng[0] = rng_();
-        break;
-
-      case INSERTION:
-        configuration_.insertRandom(rng_);
-        for (int i = 0; i < configuration_.lastInsertionSize(); ++i)
-          delayed_move.indices[i] = configuration_.size() - configuration_.lastInsertionSize() + i;
-        break;
-
-      default:
-        throw(std::logic_error("Unknown move type encountered."));
-    }
-
-    delayed_move.acceptance_rng = rng_();
-    delayed_moves_.push_back(delayed_move);
-  }
-
-  for (int s = 0; s < 2; ++s) {
-    n_max_[s] = configuration_.getSector(s).size();
-  }
-
-  const int config_size_final = configuration_.size();
-  conf_removal_list_.resize(config_size_final - config_size_init_);
-  std::iota(conf_removal_list_.begin(), conf_removal_list_.end(), config_size_init_);
-}
-
-template <class Parameters, DistType DIST>
-void CtintWalkerSubmatrixCpu<Parameters, DIST>::doSubmatrixUpdate() {
-  computeMInit();
-  computeGInit();
-  mainSubmatrixProcess();
-  updateM();
-}
-
-template <class Parameters, DistType DIST>
-void CtintWalkerSubmatrixCpu<Parameters, DIST>::mainSubmatrixProcess() {
-  Profiler profiler(__FUNCTION__, "CT-INT walker", __LINE__, thread_id_);
-
-  for (int s = 0; s < 2; ++s) {
-    Gamma_inv_[s].resizeNoCopy(0);
-    gamma_[s].clear();
-
-    move_indices_[s].clear();
-    insertion_list_[s].clear();
-    insertion_Gamma_indices_[s].clear();
-  }
-
-  std::vector<int> aux_spin_type, new_aux_spin_type, move_band;
-
-  acceptance_prob_ = 1.0;
-  for (int delay_ind = 0; delay_ind < delayed_moves_.size(); ++delay_ind) {
-    current_move_ = &delayed_moves_[delay_ind];
-    const auto move_type = current_move_->move_type;
-
-    det_ratio_ = 1.;
-    std::array<int, 2> indices_array;
-
-    if (move_type == INSERTION) {
-      indices_array = current_move_->indices;
-    }
-    else {  // move_type == REMOVAL
-      indices_array = configuration_.randomRemovalCandidate(delayed_moves_[delay_ind].removal_rng);
-    }
-
-    index_.clear();
-    for (auto idx : indices_array) {
-      if (idx >= 0)
-        index_.push_back(idx);
-    }
-
-    // This leads to a bunch of complex branchy and premature looking optimization
-    // The branch predictor must be weeping
-    bool at_least_one_recently_added = false;
-    bool all_recently_added = false;
-    if (move_type == REMOVAL) {
-      // Check if the vertex to remove was inserted during the current submatrix update.
-      const auto recently_added = [=](int id) { return id >= config_size_init_; };
-      all_recently_added = math::util::all(index_, recently_added);
-      at_least_one_recently_added = math::util::any(index_, recently_added);
-    }
-
-    for (int s = 0; s < 2; ++s) {
-      Gamma_indices_[s].clear();
-      new_aux_spin_type.clear();
-      aux_spin_type.clear();
-      move_band.clear();
-
-      findSectorIndices(s);
-
-      if (move_type == INSERTION) {
-        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
-          new_aux_spin_type.push_back(
-              configuration_.getSector(s).getAuxFieldType(sector_indices_[s][ind]));
-          aux_spin_type.push_back(0);
-        }
-      }
-      else if (move_type == REMOVAL) {
-        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
-          new_aux_spin_type.push_back(0);
-          aux_spin_type.push_back(
-              configuration_.getSector(s).getAuxFieldType(sector_indices_[s][ind]));
-
-          if (recentlyAdded(ind, s)) {
-            // Find pre-existing Gamma_indices_.
-            insertion_list_it_ = std::find(insertion_list_[s].begin(), insertion_list_[s].end(),
-                                           sector_indices_[s][ind]);
-            Gamma_indices_[s].push_back(insertion_Gamma_indices_[s][std::distance(
-                insertion_list_[s].begin(), insertion_list_it_)]);
-          }
-        }
-      }  // endif removal
-      for (int index : sector_indices_[s])
-        move_band.push_back(configuration_.getSector(s).getLeftB(index));
-
-      for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
-        if (move_type == INSERTION || !recentlyAdded(ind, s))
-          gamma_[s].push_back(
-              gamma_values_[std::make_pair(aux_spin_type[ind], new_aux_spin_type[ind])][move_band[ind]]);
-        else {
-          // TODO: find instead of adding.
-          gamma_[s].push_back(
-              gamma_values_[std::make_pair(new_aux_spin_type[ind], aux_spin_type[ind])][move_band[ind]]);
-        }
-      }
-
-      if (!at_least_one_recently_added)
-        computeInsertionMatrices(sector_indices_[s], s);
-      else {
-        if (all_recently_added)
-          computeRemovalMatrix(s);
-        else
-          computeMixedInsertionAndRemoval(s);
-      }
-
-      det_ratio_ *= details::smallDeterminant(s_[s]);
-    }  // s loop.
-
-    if (n_ == 0 && move_type == REMOVAL)
-      continue;
-
-    // Compute acceptance probability.
-    auto [acceptance_prob, mc_weight_ratio] = computeAcceptanceProbability();
-    acceptance_prob_ = acceptance_prob;
-
-    // Note: acceptance and rejection can be forced for testing with the appropriate "acceptance_rng".
-    const bool accepted =
-        delayed_moves_[delay_ind].acceptance_rng < std::min(std::abs(acceptance_prob_), Real(1.));
-
-    // NB: recomputeGammaInv is just a inefficient alternative to updateGammaInv. Only for testing
-    // or debbuging.
-    // recomputeGammaInv();
-
-    // Update
-    if (accepted) {
-      ++BaseClass::n_accepted_;
-
-      BaseClass::mc_log_weight_ += std::log(std::abs(mc_weight_ratio));
-
-      // Are we capturing the avg sign properly wrt multiple delayed moves
-      phase_.multiply(acceptance_prob_);
-
-      // Update GammaInv if necessary.
-      if (!at_least_one_recently_added)
-        for (int s = 0; s < 2; ++s)
-          updateGammaInv(s);
-      else {
-        removeRowAndColOfGammaInv();
-        for (int s = 0; s < 2; ++s) {
-          for (int ind = sector_indices_[s].size() - 1; ind >= 0; --ind) {
-            if (!recentlyAdded(ind, s))
-              continue;
-            insertion_list_[s].erase(std::remove(insertion_list_[s].begin(),
-                                                 insertion_list_[s].end(), sector_indices_[s][ind]),
-                                     insertion_list_[s].end());
-          }
-          for (int ind = Gamma_indices_[s].size() - 1; ind >= 0; --ind) {
-            insertion_Gamma_indices_[s].erase(std::remove(insertion_Gamma_indices_[s].begin(),
-                                                          insertion_Gamma_indices_[s].end(),
-                                                          Gamma_indices_[s][ind]),
-                                              insertion_Gamma_indices_[s].end());
-            gamma_[s].erase(gamma_[s].begin() + Gamma_indices_[s][ind]);
-
-            for (int i = 0; i < insertion_Gamma_indices_[s].size(); ++i) {
-              if (insertion_Gamma_indices_[s][i] > Gamma_indices_[s][ind])
-                --insertion_Gamma_indices_[s][i];
-            }
-          }
-        }
-      }
-
-      for (int s = 0; s < 2; ++s) {
-        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
-          if (move_type == INSERTION || !recentlyAdded(ind, s)) {
-            move_indices_[s].push_back(sector_indices_[s][ind]);
-          }
-          else {
-            gamma_[s].pop_back();
-            move_indices_[s].erase(std::remove(move_indices_[s].begin(), move_indices_[s].end(),
-                                               sector_indices_[s][ind]),
-                                   move_indices_[s].end());
-          }
-        }
-      }
-
-      if (move_type == INSERTION) {
-        n_ += index_.size();
-        for (auto idx : index_)
-          configuration_.commitInsertion(idx);
-
-        for (int s = 0; s < 2; ++s) {
-          for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
-            insertion_list_[s].push_back(sector_indices_[s][ind]);
-            insertion_Gamma_indices_[s].push_back(Gamma_inv_[s].nrRows() - nbr_of_indices_[s] + ind);
-          }
-        }
-
-        // TODO: cleanup
-        for (int idx : index_)
-          conf_removal_list_.erase(
-              std::remove(conf_removal_list_.begin(), conf_removal_list_.end(), idx),
-              conf_removal_list_.end());
-      }
-      else if (move_type == REMOVAL) {
-        n_ -= index_.size();
-        for (auto idx : index_)
-          configuration_.markForRemoval(idx);
-
-        // TODO: cleanup.
-        for (int idx : index_)
-          conf_removal_list_.push_back(idx);
-      }
-    }
-    else {  // The move is rejected:
-      for (int s = 0; s < 2; ++s) {
-        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind)
-          gamma_[s].pop_back();
-      }
-      if (at_least_one_recently_added && !all_recently_added)
-        for (int s = 0; s < 2; ++s) {
-          Gamma_inv_[s].swap(Gamma_inv_cpy_[s]);
-        }
-    }
-  }
-
-  // This seems correct in that we count all steps
-  // just as is done for the non submatrix cpu version
-  BaseClass::n_steps_ += delayed_moves_.size();
-}
-
-template <class Parameters, DistType DIST>
-Move CtintWalkerSubmatrixCpu<Parameters, DIST>::generateMoveType() {
-  if (rng_() <= 0.5)
-    return INSERTION;
-  else
-    return REMOVAL;
 }
 
 // Extend M by adding non-interacting vertices.
@@ -681,76 +305,6 @@ void CtintWalkerSubmatrixCpu<Parameters, DIST>::computeGInit() {
       flop_ += 2. * M_[s].nrRows() * M_[s].nrCols() * G0.nrCols();
     }
   }
-}
-
-template <class Parameters, DistType DIST>
-auto CtintWalkerSubmatrixCpu<Parameters, DIST>::computeAcceptanceProbability() {
-  Scalar acceptance_probability = det_ratio_;
-
-  Scalar gamma_factor = the_one_;
-  const auto move_type = current_move_->move_type;
-  for (int s = 0; s < 2; ++s) {
-    if (!sector_indices_[s].size())
-      continue;
-
-    for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
-      if (move_type == INSERTION || !recentlyAdded(ind, s))
-        gamma_factor *= gamma_[s].at(gamma_[s].size() - nbr_of_indices_[s] + ind);
-      else
-        gamma_factor /= gamma_[s].at(gamma_[s].size() - nbr_of_indices_[s] + ind);
-    }
-  }
-  acceptance_probability *= gamma_factor;
-
-  const int delta_vertices = index_.size();
-  const int interaction_sign = configuration_.getSign(index_[0]);
-  const int non_empty_sector = sector_indices_[0].size() ? 0 : 1;
-
-  Scalar mc_weight_ratio = acceptance_probability;
-  Real K = total_interaction_;
-
-  for (int v_id = 0; v_id < delta_vertices; ++v_id) {
-    const auto field_type = configuration_.getSector(non_empty_sector)
-                                .getAuxFieldType(sector_indices_[non_empty_sector][v_id]);
-    const auto b =
-        configuration_.getSector(non_empty_sector).getLeftB(sector_indices_[non_empty_sector][v_id]);
-    K *= beta_ * prob_const_[field_type][b] * interaction_sign;
-
-    const Scalar weight_term = prob_const_[field_type][b] * configuration_.getStrength(index_[v_id]);
-    if (move_type == INSERTION)
-      mc_weight_ratio *= weight_term;
-    else
-      mc_weight_ratio /= weight_term;
-  }
-
-  // Account for combinatorial factor and update acceptance probability.
-  if (move_type == INSERTION) {
-    if (delta_vertices == 1) {
-      acceptance_probability *= K / (n_ + 1);
-    }
-    else if (delta_vertices == 2) {
-      const Real possible_partners = configuration_.possiblePartners(index_[0]);
-      const Real combinatorial_factor =
-          (n_ + 2) * (configuration_.nPartners(index_[0]) + 1) / possible_partners;
-      acceptance_probability *= configuration_.getStrength(index_[1]) * K / combinatorial_factor;
-    }
-    else
-      throw(std::logic_error("Not implemented"));
-  }
-  else if (move_type == REMOVAL) {
-    if (delta_vertices == 1) {
-      acceptance_probability *= n_ / K;
-    }
-    else if (delta_vertices == 2) {
-      const Real possible_partners = configuration_.possiblePartners(index_[0]);
-      const Real combinatorial_factor = n_ * configuration_.nPartners(index_[0]) / possible_partners;
-      acceptance_probability *= combinatorial_factor / (configuration_.getStrength(index_[1]) * K);
-    }
-    else
-      throw(std::logic_error("Not implemented"));
-  }
-
-  return std::make_tuple(acceptance_probability, mc_weight_ratio);
 }
 
 template <class Parameters, DistType DIST>
@@ -1024,7 +578,7 @@ void CtintWalkerSubmatrixCpu<Parameters, DIST>::computeMixedInsertionAndRemoval(
   // TODO: avoid reallocation.
   std::vector<int> insertion_indices;
   for (int i = 0; i < nbr_of_indices_[s]; ++i)
-    if (!recentlyAdded(i, s))
+    if (!SubmatrixBase::recentlyAdded(i, s))
       insertion_indices.push_back(sector_indices_[s][i]);
   assert(Gamma_indices_[s].size() + insertion_indices.size() == sector_indices_.size());
 

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_gpu_submatrix.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_gpu_submatrix.hpp
@@ -49,6 +49,8 @@ public:
   using typename BaseClass::Real;
   using typename BaseClass::Scalar;
 
+  using Resource = DMatrixBuilder<linalg::GPU, Scalar>;
+
   template <linalg::DeviceType dev>
   using MatrixView = linalg::MatrixView<Scalar, dev>;
   template <linalg::DeviceType dev>

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_gpu_submatrix.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_gpu_submatrix.hpp
@@ -35,10 +35,11 @@ namespace solver {
 namespace ctint {
 
 template <class Parameters, DistType DIST>
-class CtintWalkerSubmatrixGpu : public CtintWalkerBase<Parameters, DIST> {
+class CtintWalkerSubmatrixGpu : public CtintWalkerSubmatrixCpu<Parameters, DIST> {
 public:
   using this_type = CtintWalkerSubmatrixGpu<Parameters, DIST>;
-  using BaseClass = CtintWalkerBase<Parameters, DIST>;
+  using BaseClass = CtintWalkerSubmatrixCpu<Parameters, DIST>;
+  using RootClass = CtintWalkerBase<Parameters, DIST>;
 
   using typename BaseClass::Data;
   using typename BaseClass::Profiler;
@@ -149,7 +150,7 @@ CtintWalkerSubmatrixGpu<Parameters, DIST>::CtintWalkerSubmatrixGpu(
   
 template <class Parameters, DistType DIST>
 void CtintWalkerSubmatrixGpu<Parameters, DIST>::setMFromConfig() {
-  setMFromConfigImpl(d_matrix_builder_);
+  RootClass::setMFromConfigImpl(d_matrix_builder_);
   for (int s = 0; s < 2; ++s) {
     M_dev_[s].setAsync(M_[s], get_stream(s));
   }

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_submatrix_base.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_submatrix_base.hpp
@@ -1,0 +1,868 @@
+#ifndef DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_CTINT_WALKER_SUBMATRIX_BASE_HPP
+#define DCA_PHYS_DCA_STEP_CLUSTER_SOLVER_CTINT_WALKER_CTINT_WALKER_SUBMATRIX_BASE_HPP
+
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/ctint_walker_base.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <map>
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+#include <ctime>
+
+#include "dca/linalg/linalg.hpp"
+#include "dca/math/util/vector_operations.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/structs/solver_configuration.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/move.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.hpp"
+#include "dca/phys/dca_step/cluster_solver/shared_tools/interpolation/g0_interpolation.hpp"
+#include "dca/phys/dca_step/cluster_solver/ctint/walker/tools/walker_methods.hpp"
+#include "dca/phys/parameters/parameters.hpp"
+#include "dca/util/integer_division.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+
+template <class Parameters, DistType DIST>
+class CtintWalkerSubmatrixBase : public CtintWalkerBase<Parameters, DIST> {
+public:
+  using this_type = CtintWalkerSubmatrixBase;
+  using BaseClass = CtintWalkerBase<Parameters, DIST>;
+  using typename BaseClass::Rng;
+  using typename BaseClass::Data;
+  using typename BaseClass::Profiler;
+  using typename BaseClass::GpuStream;
+  using typename BaseClass::Real;
+  using typename BaseClass::Scalar;
+
+  CtintWalkerSubmatrixBase(const Parameters& pars_ref, const Data& /*data*/, Rng& rng_ref, int id = 0);
+
+  virtual ~CtintWalkerSubmatrixBase() = default;
+
+  void doSweep() override;
+
+  void computeM(typename BaseClass::MatrixPair& m_accum);
+
+  using BaseClass::order;
+
+  virtual void setMFromConfig() = 0;
+protected:
+  virtual void doStep() override;
+  void doSteps();
+  void generateDelayedMoves(int nbr_of_movesto_delay);
+
+  /** This does a bunch of things, this is the majority of a step
+   *  For each delayed_move it:
+   *  * computes the acceptance prob
+   *  * compares std::abs(acceptance prob) and random value
+   *    * Does an update of the log_weight for a configuration
+   *        mc_weight_ratio = acceptance_probability;
+   *      For a new vertex
+   *        mc_weight ratio *= weight_term
+   *      For a removed vertes
+   *        mc_weight_ratio /= weight_term
+   *      with
+   *        weight_term = prob_const_[field_type][b] * the vertex interaction strength;
+   *        BaseClass::mc_log_weight_ += std::log(std::abs(mc_weight_ratio));
+   */
+  void mainSubmatrixProcess();
+
+  void markThermalized() override;
+
+  void transformM();
+
+  // For testing purposes.
+  virtual void doStep(const int nbr_of_movesto_delay);
+
+  virtual void updateM() = 0;
+
+private:
+
+  void doSubmatrixUpdate();
+
+  /** returns [acceptance_probability , mc_weight_ratio ]
+   */
+  auto computeAcceptanceProbability();
+
+  void updateGammaInv(int s);
+
+  void removeRowAndColOfGammaInv();
+
+  virtual void computeMInit() = 0;
+
+  //  void computeG0Init();
+  virtual void computeGInit() = 0;
+
+  Move generateMoveType();
+
+  void computeInsertionMatrices(const std::vector<int>& indices, const int s);
+
+  void computeRemovalMatrix(int s);
+
+  void computeMixedInsertionAndRemoval(int s);
+
+  void findSectorIndices(const int s);
+
+  void recomputeGammaInv();
+
+  bool recentlyAdded(int move_idx, int s) const {
+    assert(move_idx < sector_indices_[s].size());
+    return sector_indices_[s][move_idx] >= n_init_[s];
+  }
+
+protected:
+  using MatrixView = linalg::MatrixView<Scalar, linalg::CPU>;
+  using Matrix = linalg::Matrix<Scalar, linalg::CPU>;
+
+  using BaseClass::parameters_;
+  using BaseClass::configuration_;
+  using BaseClass::rng_;
+  using BaseClass::thread_id_;
+  using BaseClass::total_interaction_;
+  using BaseClass::phase_;
+  using BaseClass::M_;
+  using BaseClass::n_bands_;
+  using BaseClass::beta_;
+
+  using BaseClass::thermalized_;
+  using BaseClass::sweeps_per_meas_;
+  using BaseClass::partial_order_avg_;
+  using BaseClass::thermalization_steps_;
+  using BaseClass::order_avg_;
+  using BaseClass::sign_avg_;
+  using BaseClass::n_steps_;
+  using BaseClass::mc_log_weight_;
+  using BaseClass::n_accepted_;
+
+protected:
+  int max_submatrix_size_;
+
+  struct DelayedMoveType {
+    Move move_type;
+    std::array<double, 3> removal_rng{1., 1., 1.};
+    Real acceptance_rng;
+    std::array<int, 2> indices{-1, -1};
+  };
+
+protected:
+  using BaseClass::acceptance_prob_;
+
+protected:
+  static constexpr Scalar the_one_ = dca::util::TheOne<Scalar>::value;
+
+  std::vector<DelayedMoveType> delayed_moves_;
+
+  using MatrixPair = std::array<linalg::Matrix<Scalar, linalg::CPU>, 2>;
+  MatrixPair G_;
+  MatrixPair G0_;
+  MatrixPair Gamma_inv_;      // TODO: don't pin
+  MatrixPair Gamma_inv_cpy_;  // TODO: don't pin
+  MatrixPair q_;              // TODO: don't pin or store in Gamma inv
+  MatrixPair r_;
+  MatrixPair s_;
+  std::array<std::vector<Real>, 2> gamma_;
+
+  Scalar det_ratio_;
+  std::map<int, std::array<Real, n_bands_>> f_;
+  std::map<int, std::array<Real, n_bands_>> prob_const_;
+  std::map<std::pair<int, int>, std::array<Real, n_bands_>> gamma_values_;
+
+  using BaseClass::nb_steps_per_sweep_;
+  int nbr_of_steps_;
+  int nbr_of_moves_to_delay_;
+  int max_nbr_of_moves;
+
+  std::array<int, 2> Gamma_size_;
+  std::array<std::vector<int>, 2> Gamma_indices_;
+  std::array<std::vector<int>, 2> sector_indices_;
+
+  const DelayedMoveType* current_move_;
+
+  std::array<unsigned, 2> nbr_of_indices_;
+
+  std::vector<int> index_;
+
+  // Initial configuration size.
+  unsigned config_size_init_;
+
+  // Initial and current sector sizes.
+  std::array<unsigned, 2> n_init_;
+  unsigned n_;
+
+  // Maximal sector size after submatrix update.
+
+  std::array<unsigned, 2> n_max_;
+
+  std::array<linalg::util::HostVector<int>, 2> move_indices_;
+  std::array<linalg::util::HostVector<int>, 2> removal_list_;
+  std::array<linalg::util::HostVector<int>, 2> source_list_;
+  std::array<std::vector<int>, 2> insertion_list_;
+  std::array<std::vector<int>, 2> insertion_Gamma_indices_;
+
+  std::vector<int> conf_removal_list_;
+
+  std::vector<int>::iterator insertion_list_it_;
+
+  std::array<Matrix, 2> Gamma_q_;
+  Matrix workspace_;
+  Matrix D_;
+
+  using BaseClass::flop_;
+};
+
+template <class Parameters, DistType DIST>
+CtintWalkerSubmatrixBase<Parameters, DIST>::CtintWalkerSubmatrixBase(const Parameters& parameters_ref,
+                                                                   const Data& /*data*/,
+                                                                   Rng& rng_ref,
+								   int id)
+  : BaseClass(parameters_ref, rng_ref, id) {
+  if (BaseClass::concurrency_.id() == BaseClass::concurrency_.first() && thread_id_ == 0)
+    std::cout << "\nCT-INT submatrix walker created." << std::endl;
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters,DIST>::markThermalized() {
+  thermalized_ = true;
+
+  nb_steps_per_sweep_ = std::max(1., std::ceil(sweeps_per_meas_ * partial_order_avg_.mean()));
+  thermalization_steps_ = n_steps_;
+
+  order_avg_.reset();
+  sign_avg_.reset();
+  n_accepted_ = 0;
+
+  // Recompute the Monte Carlo weight.
+  setMFromConfig();
+#ifndef NDEBUG
+  //writeAlphas();
+#endif
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::doSweep() {
+  Profiler profiler(__FUNCTION__, "CT-INT walker", __LINE__, thread_id_);
+  doSteps();
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::doSteps() {
+  // Here nbr_of_steps is the number of single steps/moves during the current sweep,
+  // while nbr_of_submatrix_steps is the number of times the entire submatrix algorithm  is run.
+
+  if (nb_steps_per_sweep_ < 0)  // Not thermalized or fixed.
+    nbr_of_steps_ = BaseClass::avgOrder() + 1;
+  else
+    nbr_of_steps_ = nb_steps_per_sweep_;
+
+  // Get the maximum of Monte Carlo steps/moves that can be performed during one submatrix step.
+  max_nbr_of_moves = parameters_.getMaxSubmatrixSize();
+
+  BaseClass::n_steps_ += nbr_of_steps_;
+  while (nbr_of_steps_ > 0) {
+    nbr_of_moves_to_delay_ = std::min(nbr_of_steps_, max_nbr_of_moves);
+    nbr_of_steps_ -= nbr_of_moves_to_delay_;
+
+    doStep();
+  }
+
+  BaseClass::updateSweepAverages();
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::doStep() {
+  generateDelayedMoves(nbr_of_moves_to_delay_);
+  doSubmatrixUpdate();
+}
+
+// Do one step with arbitrary number of moves. For testing.
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::doStep(const int nbr_of_movesto_delay) {
+  std::cout << "\nStarted doStep() function for testing." << std::endl;
+
+  generateDelayedMoves(nbr_of_movesto_delay);
+
+  std::cout << "\nGenerated " << nbr_of_movesto_delay << " moves for testing.\n" << std::endl;
+
+  doSubmatrixUpdate();
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::generateDelayedMoves(const int nbr_of_movesto_delay) {
+  assert(nbr_of_movesto_delay > 0);
+
+  delayed_moves_.clear();
+
+  for (int s = 0; s < 2; ++s) {
+    n_init_[s] = configuration_.getSector(s).size();
+  }
+  n_ = config_size_init_ = configuration_.size();
+
+  // Generate delayed moves.
+  for (int i = 0; i < nbr_of_movesto_delay; ++i) {
+    DelayedMoveType delayed_move;
+
+    delayed_move.move_type = generateMoveType();
+
+    switch (delayed_move.move_type) {
+      case REMOVAL:
+        if (configuration_.getDoubleUpdateProb())
+          delayed_move.removal_rng = {rng_(), rng_(), rng_()};
+        else
+          delayed_move.removal_rng[0] = rng_();
+        break;
+
+      case INSERTION:
+        configuration_.insertRandom(rng_);
+        for (int i = 0; i < configuration_.lastInsertionSize(); ++i)
+          delayed_move.indices[i] = configuration_.size() - configuration_.lastInsertionSize() + i;
+        break;
+
+      default:
+        throw(std::logic_error("Unknown move type encountered."));
+    }
+
+    delayed_move.acceptance_rng = rng_();
+    delayed_moves_.push_back(delayed_move);
+  }
+
+  for (int s = 0; s < 2; ++s) {
+    n_max_[s] = configuration_.getSector(s).size();
+  }
+
+  const int config_size_final = configuration_.size();
+  conf_removal_list_.resize(config_size_final - config_size_init_);
+  std::iota(conf_removal_list_.begin(), conf_removal_list_.end(), config_size_init_);
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::doSubmatrixUpdate() {
+  computeMInit();
+  computeGInit();
+  mainSubmatrixProcess();
+  updateM();
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::mainSubmatrixProcess() {
+  Profiler profiler(__FUNCTION__, "CT-INT walker", __LINE__, thread_id_);
+
+  for (int s = 0; s < 2; ++s) {
+    Gamma_inv_[s].resizeNoCopy(0);
+    gamma_[s].clear();
+
+    move_indices_[s].clear();
+    insertion_list_[s].clear();
+    insertion_Gamma_indices_[s].clear();
+  }
+
+  std::vector<int> aux_spin_type, new_aux_spin_type, move_band;
+
+  acceptance_prob_ = 1.0;
+  for (int delay_ind = 0; delay_ind < delayed_moves_.size(); ++delay_ind) {
+    current_move_ = &delayed_moves_[delay_ind];
+    const auto move_type = current_move_->move_type;
+
+    det_ratio_ = 1.;
+    std::array<int, 2> indices_array;
+
+    if (move_type == INSERTION) {
+      indices_array = current_move_->indices;
+    }
+    else {  // move_type == REMOVAL
+      indices_array = configuration_.randomRemovalCandidate(delayed_moves_[delay_ind].removal_rng);
+    }
+
+    index_.clear();
+    for (auto idx : indices_array) {
+      if (idx >= 0)
+        index_.push_back(idx);
+    }
+
+    // This leads to a bunch of complex branchy and premature looking optimization
+    // The branch predictor must be weeping
+    bool at_least_one_recently_added = false;
+    bool all_recently_added = false;
+    if (move_type == REMOVAL) {
+      // Check if the vertex to remove was inserted during the current submatrix update.
+      const auto recently_added = [=](int id) { return id >= config_size_init_; };
+      all_recently_added = math::util::all(index_, recently_added);
+      at_least_one_recently_added = math::util::any(index_, recently_added);
+    }
+
+    for (int s = 0; s < 2; ++s) {
+      Gamma_indices_[s].clear();
+      new_aux_spin_type.clear();
+      aux_spin_type.clear();
+      move_band.clear();
+
+      findSectorIndices(s);
+
+      if (move_type == INSERTION) {
+        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+          new_aux_spin_type.push_back(
+              configuration_.getSector(s).getAuxFieldType(sector_indices_[s][ind]));
+          aux_spin_type.push_back(0);
+        }
+      }
+      else if (move_type == REMOVAL) {
+        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+          new_aux_spin_type.push_back(0);
+          aux_spin_type.push_back(
+              configuration_.getSector(s).getAuxFieldType(sector_indices_[s][ind]));
+
+          if (recentlyAdded(ind, s)) {
+            // Find pre-existing Gamma_indices_.
+            insertion_list_it_ = std::find(insertion_list_[s].begin(), insertion_list_[s].end(),
+                                           sector_indices_[s][ind]);
+            Gamma_indices_[s].push_back(insertion_Gamma_indices_[s][std::distance(
+                insertion_list_[s].begin(), insertion_list_it_)]);
+          }
+        }
+      }  // endif removal
+      for (int index : sector_indices_[s])
+        move_band.push_back(configuration_.getSector(s).getLeftB(index));
+
+      for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+        if (move_type == INSERTION || !recentlyAdded(ind, s))
+          gamma_[s].push_back(
+              gamma_values_[std::make_pair(aux_spin_type[ind], new_aux_spin_type[ind])][move_band[ind]]);
+        else {
+          // TODO: find instead of adding.
+          gamma_[s].push_back(
+              gamma_values_[std::make_pair(new_aux_spin_type[ind], aux_spin_type[ind])][move_band[ind]]);
+        }
+      }
+
+      if (!at_least_one_recently_added)
+        computeInsertionMatrices(sector_indices_[s], s);
+      else {
+        if (all_recently_added)
+          computeRemovalMatrix(s);
+        else
+          computeMixedInsertionAndRemoval(s);
+      }
+
+      det_ratio_ *= details::smallDeterminant(s_[s]);
+    }  // s loop.
+
+    if (n_ == 0 && move_type == REMOVAL)
+      continue;
+
+    // Compute acceptance probability.
+    auto [acceptance_prob, mc_weight_ratio] = computeAcceptanceProbability();
+    acceptance_prob_ = acceptance_prob;
+
+    // Note: acceptance and rejection can be forced for testing with the appropriate "acceptance_rng".
+    const bool accepted =
+        delayed_moves_[delay_ind].acceptance_rng < std::min(std::abs(acceptance_prob_), Real(1.));
+
+    // NB: recomputeGammaInv is just a inefficient alternative to updateGammaInv. Only for testing
+    // or debbuging.
+    // recomputeGammaInv();
+
+    // Update
+    if (accepted) {
+      ++BaseClass::n_accepted_;
+
+      BaseClass::mc_log_weight_ += std::log(std::abs(mc_weight_ratio));
+
+      // Are we capturing the avg sign properly wrt multiple delayed moves
+      phase_.multiply(acceptance_prob_);
+
+      // Update GammaInv if necessary.
+      if (!at_least_one_recently_added)
+        for (int s = 0; s < 2; ++s)
+          updateGammaInv(s);
+      else {
+        removeRowAndColOfGammaInv();
+        for (int s = 0; s < 2; ++s) {
+          for (int ind = sector_indices_[s].size() - 1; ind >= 0; --ind) {
+            if (!recentlyAdded(ind, s))
+              continue;
+            insertion_list_[s].erase(std::remove(insertion_list_[s].begin(),
+                                                 insertion_list_[s].end(), sector_indices_[s][ind]),
+                                     insertion_list_[s].end());
+          }
+          for (int ind = Gamma_indices_[s].size() - 1; ind >= 0; --ind) {
+            insertion_Gamma_indices_[s].erase(std::remove(insertion_Gamma_indices_[s].begin(),
+                                                          insertion_Gamma_indices_[s].end(),
+                                                          Gamma_indices_[s][ind]),
+                                              insertion_Gamma_indices_[s].end());
+            gamma_[s].erase(gamma_[s].begin() + Gamma_indices_[s][ind]);
+
+            for (int i = 0; i < insertion_Gamma_indices_[s].size(); ++i) {
+              if (insertion_Gamma_indices_[s][i] > Gamma_indices_[s][ind])
+                --insertion_Gamma_indices_[s][i];
+            }
+          }
+        }
+      }
+
+      for (int s = 0; s < 2; ++s) {
+        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+          if (move_type == INSERTION || !recentlyAdded(ind, s)) {
+            move_indices_[s].push_back(sector_indices_[s][ind]);
+          }
+          else {
+            gamma_[s].pop_back();
+            move_indices_[s].erase(std::remove(move_indices_[s].begin(), move_indices_[s].end(),
+                                               sector_indices_[s][ind]),
+                                   move_indices_[s].end());
+          }
+        }
+      }
+
+      if (move_type == INSERTION) {
+        n_ += index_.size();
+        for (auto idx : index_)
+          configuration_.commitInsertion(idx);
+
+        for (int s = 0; s < 2; ++s) {
+          for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+            insertion_list_[s].push_back(sector_indices_[s][ind]);
+            insertion_Gamma_indices_[s].push_back(Gamma_inv_[s].nrRows() - nbr_of_indices_[s] + ind);
+          }
+        }
+
+        // TODO: cleanup
+        for (int idx : index_)
+          conf_removal_list_.erase(
+              std::remove(conf_removal_list_.begin(), conf_removal_list_.end(), idx),
+              conf_removal_list_.end());
+      }
+      else if (move_type == REMOVAL) {
+        n_ -= index_.size();
+        for (auto idx : index_)
+          configuration_.markForRemoval(idx);
+
+        // TODO: cleanup.
+        for (int idx : index_)
+          conf_removal_list_.push_back(idx);
+      }
+    }
+    else {  // The move is rejected:
+      for (int s = 0; s < 2; ++s) {
+        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind)
+          gamma_[s].pop_back();
+      }
+      if (at_least_one_recently_added && !all_recently_added)
+        for (int s = 0; s < 2; ++s) {
+          Gamma_inv_[s].swap(Gamma_inv_cpy_[s]);
+        }
+    }
+  }
+
+  // This seems correct in that we count all steps
+  // just as is done for the non submatrix cpu version
+  BaseClass::n_steps_ += delayed_moves_.size();
+}
+
+template <class Parameters, DistType DIST>
+Move CtintWalkerSubmatrixBase<Parameters, DIST>::generateMoveType() {
+  if (rng_() <= 0.5)
+    return INSERTION;
+  else
+    return REMOVAL;
+}
+
+template <class Parameters, DistType DIST>
+auto CtintWalkerSubmatrixBase<Parameters, DIST>::computeAcceptanceProbability() {
+  Scalar acceptance_probability = det_ratio_;
+
+  Scalar gamma_factor = the_one_;
+  const auto move_type = current_move_->move_type;
+  for (int s = 0; s < 2; ++s) {
+    if (!sector_indices_[s].size())
+      continue;
+
+    for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+      if (move_type == INSERTION || !recentlyAdded(ind, s))
+        gamma_factor *= gamma_[s].at(gamma_[s].size() - nbr_of_indices_[s] + ind);
+      else
+        gamma_factor /= gamma_[s].at(gamma_[s].size() - nbr_of_indices_[s] + ind);
+    }
+  }
+  acceptance_probability *= gamma_factor;
+
+  const int delta_vertices = index_.size();
+  const int interaction_sign = configuration_.getSign(index_[0]);
+  const int non_empty_sector = sector_indices_[0].size() ? 0 : 1;
+
+  Scalar mc_weight_ratio = acceptance_probability;
+  Real K = total_interaction_;
+
+  for (int v_id = 0; v_id < delta_vertices; ++v_id) {
+    const auto field_type = configuration_.getSector(non_empty_sector)
+                                .getAuxFieldType(sector_indices_[non_empty_sector][v_id]);
+    const auto b =
+        configuration_.getSector(non_empty_sector).getLeftB(sector_indices_[non_empty_sector][v_id]);
+    K *= beta_ * prob_const_[field_type][b] * interaction_sign;
+
+    const Scalar weight_term = prob_const_[field_type][b] * configuration_.getStrength(index_[v_id]);
+    if (move_type == INSERTION)
+      mc_weight_ratio *= weight_term;
+    else
+      mc_weight_ratio /= weight_term;
+  }
+
+  // Account for combinatorial factor and update acceptance probability.
+  if (move_type == INSERTION) {
+    if (delta_vertices == 1) {
+      acceptance_probability *= K / (n_ + 1);
+    }
+    else if (delta_vertices == 2) {
+      const Real possible_partners = configuration_.possiblePartners(index_[0]);
+      const Real combinatorial_factor =
+          (n_ + 2) * (configuration_.nPartners(index_[0]) + 1) / possible_partners;
+      acceptance_probability *= configuration_.getStrength(index_[1]) * K / combinatorial_factor;
+    }
+    else
+      throw(std::logic_error("Not implemented"));
+  }
+  else if (move_type == REMOVAL) {
+    if (delta_vertices == 1) {
+      acceptance_probability *= n_ / K;
+    }
+    else if (delta_vertices == 2) {
+      const Real possible_partners = configuration_.possiblePartners(index_[0]);
+      const Real combinatorial_factor = n_ * configuration_.nPartners(index_[0]) / possible_partners;
+      acceptance_probability *= combinatorial_factor / (configuration_.getStrength(index_[1]) * K);
+    }
+    else
+      throw(std::logic_error("Not implemented"));
+  }
+
+  return std::make_tuple(acceptance_probability, mc_weight_ratio);
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::updateGammaInv(int s) {
+  Profiler profiler(__FUNCTION__, "CT-INT walker", __LINE__, thread_id_);
+  const int delta = s_[s].nrRows();
+  if (delta == 0)
+    return;
+  const int old_size = Gamma_inv_[s].nrRows();
+  Gamma_inv_[s].resize(old_size + delta);
+
+  if (old_size > 0) {
+    MatrixView bulk(Gamma_inv_[s], 0, 0, old_size, old_size);
+    MatrixView q_inv(Gamma_inv_[s], 0, old_size, old_size, delta);
+    MatrixView r_inv(Gamma_inv_[s], old_size, 0, delta, old_size);
+    MatrixView s_inv(Gamma_inv_[s], old_size, old_size, delta, delta);
+
+    details::smallInverse(s_[s], s_inv);
+
+    auto& Gamma_q = Gamma_q_[s];
+    linalg::matrixop::gemm(Scalar(-1.), Gamma_q, s_inv, Scalar(0.), q_inv);
+
+    auto& r_Gamma = workspace_;
+    r_Gamma.resizeNoCopy(r_[s].size());
+    linalg::matrixop::gemm(r_[s], bulk, r_Gamma);
+    linalg::matrixop::gemm(Scalar(-1.), s_inv, r_Gamma, Scalar(0.), r_inv);
+
+    // Gamma_ += Gamma_ * q_ * s_^-1 * r_ * Gamma_
+    linalg::matrixop::gemm(Scalar(-1.), q_inv, r_Gamma, Scalar(1.), bulk);
+  }
+  else {
+    Gamma_inv_[s].resizeNoCopy(delta);
+    details::smallInverse(s_[s], Gamma_inv_[s]);
+  }
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::findSectorIndices(const int s) {
+  sector_indices_[s].clear();
+  for (auto index : index_) {
+    configuration_.findIndices(sector_indices_[s], index, s);
+  }
+
+  if (index_.size() > 1)
+    std::sort(sector_indices_[s].begin(), sector_indices_[s].end());
+  nbr_of_indices_[s] = sector_indices_[s].size();
+}
+
+// Remove row and column of Gamma_inv with Woodbury's formula.
+// Gamma <- Gamma - U.V => GammaInv <- GammaInv + GammaInv.U.(Id-V.GammaInv.U)^(-1).V.GammaInv.
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::removeRowAndColOfGammaInv() {
+  Profiler profiler(__FUNCTION__, "CT-INT walker", __LINE__, thread_id_);
+  for (int s = 0; s < 2; ++s) {
+    const int delta = Gamma_indices_[s].size();
+    if (delta == 0)
+      continue;
+    const int n_init = Gamma_inv_[s].nrRows();
+    const int n = n_init - delta;
+
+    if (n) {
+      q_[s].resizeNoCopy(std::make_pair(n, delta));
+      r_[s].resizeNoCopy(std::make_pair(delta, n));
+      auto& q_s = workspace_;
+      q_s.resizeNoCopy(q_[s].size());
+
+      //  TODO: check if gamma indices are ordered.
+      for (int j = 0; j < delta; ++j) {
+        int idx = 0;
+        for (int i = 0; i < n_init; ++i) {
+          if (idx == delta || i != Gamma_indices_[s][idx])
+            q_[s](i - idx, j) = Gamma_inv_[s](i, Gamma_indices_[s][j]);
+          else
+            ++idx;
+        }
+      }
+
+      int idx = 0;
+      for (int j = 0; j < n_init; ++j) {
+        if (idx == delta || j != Gamma_indices_[s][idx])
+          for (int i = 0; i < delta; ++i)
+            r_[s](i, j - idx) = Gamma_inv_[s](Gamma_indices_[s][i], j);
+        else
+          ++idx;
+      }
+
+      // TODO: this could be avoided in the case of pure removal.
+      s_[s].resizeNoCopy(delta);
+      for (int j = 0; j < delta; ++j)
+        for (int i = 0; i < delta; ++i)
+          s_[s](i, j) = Gamma_inv_[s](Gamma_indices_[s][i], Gamma_indices_[s][j]);
+
+      for (int ind = delta - 1; ind >= 0; --ind)
+        linalg::matrixop::removeRowAndCol(Gamma_inv_[s], Gamma_indices_[s][ind]);
+
+      details::smallInverse(s_[s]);
+
+      linalg::matrixop::gemm(q_[s], s_[s], q_s);
+
+      // Gamma_inv_ -= Q*S^-1*R
+      linalg::matrixop::gemm(Scalar(-1.), q_s, r_[s], Scalar(1.), Gamma_inv_[s]);
+    }  // if n
+    else {
+      Gamma_inv_[s].resizeNoCopy(0);
+    }
+  }
+}
+
+// This method is unused and left to potentially use as a testing reference.
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::recomputeGammaInv() {
+  for (int s = 0; s < 2; ++s) {
+    if (Gamma_inv_[s].nrRows() > 0)
+      linalg::matrixop::inverse(Gamma_inv_[s]);
+
+    Gamma_inv_[s].resize(Gamma_inv_[s].nrRows() + nbr_of_indices_[s]);
+
+    for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+      for (int i = 0; i < Gamma_inv_[s].nrRows(); ++i) {
+        Gamma_inv_[s](Gamma_inv_[s].nrRows() + ind, i) =
+            G_[s](sector_indices_[s][ind], move_indices_[s][i]);
+        Gamma_inv_[s](i, Gamma_inv_[s].nrRows() + ind) =
+            G_[s](move_indices_[s][i], sector_indices_[s][ind]);
+      }
+
+      for (int ind_2 = 0; ind_2 < nbr_of_indices_[s]; ++ind_2) {
+        Gamma_inv_[s](Gamma_inv_[s].nrRows() + ind, Gamma_inv_[s].nrRows() + ind_2) =
+            G_[s](sector_indices_[s][ind], sector_indices_[s][ind_2]);
+      }
+      Gamma_inv_[s](Gamma_inv_[s].nrRows() + ind, Gamma_inv_[s].nrRows() + ind) -=
+          (1 + gamma_[s].end()[-nbr_of_indices_[s] + ind]) /
+          gamma_[s].end()[-nbr_of_indices_[s] + ind];
+    }
+
+    Gamma_inv_[s].nrRows() = Gamma_inv_[s].nrRows();
+
+    if (Gamma_inv_[s].nrRows() > 0)
+      details::smallInverse(Gamma_inv_[s]);
+  }
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::transformM() {
+  for (int s = 0; s < 2; ++s) {
+    for (int j = 0; j < M_[s].size().second; ++j) {
+      for (int i = 0; i < M_[s].size().first; ++i) {
+        const auto field_type = configuration_.getSector(s).getAuxFieldType(i);
+        const auto b = configuration_.getSector(s).getLeftB(i);
+        const Scalar f_i = -(f_[field_type][b] - 1);
+        M_[s](i, j) /= f_i;
+      }
+    }
+  }
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::computeInsertionMatrices(
+    const std::vector<int>& insertion_indices, const int s) {
+  const int delta = insertion_indices.size();
+
+  s_[s].resizeNoCopy(delta);
+  if (delta == 0)
+    return;
+
+  for (int i = 0; i < delta; ++i)
+    for (int j = 0; j < delta; ++j) {
+      s_[s](i, j) = G_[s](insertion_indices[i], insertion_indices[j]);
+      if (i == j) {
+        const Real gamma_val = gamma_[s].at(gamma_[s].size() + i - nbr_of_indices_[s]);
+        s_[s](i, j) -= (1 + gamma_val) / gamma_val;
+      }
+    }
+
+  assert(Gamma_inv_[s].nrRows() == move_indices_[s].size());
+  if (Gamma_inv_[s].nrRows() > 0) {
+    q_[s].resizeNoCopy(std::make_pair(Gamma_inv_[s].nrRows(), delta));
+    r_[s].resizeNoCopy(std::make_pair(delta, Gamma_inv_[s].nrRows()));
+
+    for (int i = 0; i < Gamma_inv_[s].nrRows(); ++i)
+      for (int j = 0; j < delta; ++j) {
+        q_[s](i, j) = G_[s](move_indices_[s][i], insertion_indices[j]);
+        r_[s](j, i) = G_[s](insertion_indices[j], move_indices_[s][i]);
+      }
+
+    auto& Gamma_q = Gamma_q_[s];
+    Gamma_q.resizeNoCopy(q_[s].size());
+    linalg::matrixop::gemm(Gamma_inv_[s], q_[s], Gamma_q);
+    linalg::matrixop::gemm(Scalar(-1.), r_[s], Gamma_q, Scalar(1.), s_[s]);
+  }
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::computeRemovalMatrix(const int s) {
+  const int delta = Gamma_indices_[s].size();
+  s_[s].resizeNoCopy(delta);
+  for (int j = 0; j < delta; ++j)
+    for (int i = 0; i < delta; ++i)
+      s_[s](i, j) = Gamma_inv_[s](Gamma_indices_[s][i], Gamma_indices_[s][j]);
+}
+
+template <class Parameters, DistType DIST>
+void CtintWalkerSubmatrixBase<Parameters, DIST>::computeMixedInsertionAndRemoval(int s) {
+  Gamma_inv_cpy_[s] = Gamma_inv_[s];
+
+  if (sector_indices_[s].size() == 0) {
+    s_[s].resizeNoCopy(0);
+    return;
+  }
+
+  // TODO: avoid reallocation.
+  std::vector<int> insertion_indices;
+  for (int i = 0; i < nbr_of_indices_[s]; ++i)
+    if (!recentlyAdded(i, s))
+      insertion_indices.push_back(sector_indices_[s][i]);
+  assert(Gamma_indices_[s].size() + insertion_indices.size() == sector_indices_.size());
+
+  computeInsertionMatrices(insertion_indices, s);
+  det_ratio_ *= details::smallDeterminant(s_[s]);
+  updateGammaInv(s);
+
+  computeRemovalMatrix(s);
+}
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/submat_impl.cpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/submat_impl.cpp
@@ -1,0 +1,221 @@
+#include "submat_impl.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+
+template <typename SCALAR>
+void SubmatImpl<SCALAR>::mainSubmatrixProcess() {
+  for (int s = 0; s < 2; ++s) {
+    move_indices_[s].clear();
+    insertion_list_[s].clear();
+    insertion_Gamma_indices_[s].clear();
+  }
+
+  std::vector<int> aux_spin_type, new_aux_spin_type, move_band;
+
+  SCALAR acceptance_prob_ = 1.0;
+  for (int delay_ind = 0; delay_ind < delayed_moves_.size(); ++delay_ind) {
+    current_move_ = &delayed_moves_[delay_ind];
+    const auto move_type = current_move_->move_type;
+    // there seems to be no need that this be persistent.
+    det_ratio_ = 1.;
+    std::array<int, 2> indices_array;
+
+    if (move_type == INSERTION) {
+      indices_array = current_move_->indices;
+    }
+    else {  // move_type == REMOVAL
+      indices_array = configuration_.randomRemovalCandidate(delayed_moves_[delay_ind].removal_rng);
+    }
+
+    index_.clear();
+    for (auto idx : indices_array) {
+      if (idx >= 0)
+        index_.push_back(idx);
+    }
+
+    // This leads to a bunch of complex branchy and premature looking optimization
+    // The branch predictor must be weeping
+    bool at_least_one_recently_added = false;
+    bool all_recently_added = false;
+    if (move_type == REMOVAL) {
+      // Check if the vertex to remove was inserted during the current submatrix update.
+      const auto recently_added = [=](int id) { return id >= config_size_init_; };
+      all_recently_added = math::util::all(index_, recently_added);
+      at_least_one_recently_added = math::util::any(index_, recently_added);
+    }
+
+    for (int s = 0; s < 2; ++s) {
+      Gamma_indices_[s].clear();
+      new_aux_spin_type.clear();
+      aux_spin_type.clear();
+      move_band.clear();
+
+      findSectorIndices(s);
+
+      if (move_type == INSERTION) {
+        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+          new_aux_spin_type.push_back(
+              configuration_.getSector(s).getAuxFieldType(sector_indices_[s][ind]));
+          aux_spin_type.push_back(0);
+        }
+      }
+      else if (move_type == REMOVAL) {
+        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+          new_aux_spin_type.push_back(0);
+          aux_spin_type.push_back(
+              configuration_.getSector(s).getAuxFieldType(sector_indices_[s][ind]));
+
+          if (recentlyAdded(ind, s)) {
+            // Find pre-existing Gamma_indices_.
+            insertion_list_it_ = std::find(insertion_list_[s].begin(), insertion_list_[s].end(),
+                                           sector_indices_[s][ind]);
+            Gamma_indices_[s].push_back(insertion_Gamma_indices_[s][std::distance(
+                insertion_list_[s].begin(), insertion_list_it_)]);
+          }
+        }
+      }  // endif removal
+      for (int index : sector_indices_[s])
+        move_band.push_back(configuration_.getSector(s).getLeftB(index));
+
+      for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+        if (move_type == INSERTION || !recentlyAdded(ind, s))
+          gamma_[s].push_back(
+              gamma_values_[std::make_pair(aux_spin_type[ind], new_aux_spin_type[ind])][move_band[ind]]);
+        else {
+          // TODO: find instead of adding.
+          gamma_[s].push_back(
+              gamma_values_[std::make_pair(new_aux_spin_type[ind], aux_spin_type[ind])][move_band[ind]]);
+        }
+      }
+
+      if (!at_least_one_recently_added)
+        computeInsertionMatrices(sector_indices_[s], s);
+      else {
+        if (all_recently_added)
+          computeRemovalMatrix(s);
+        else
+          computeMixedInsertionAndRemoval(s);
+      }
+
+      det_ratio_ *= details::smallDeterminant(s_[s]);
+    }  // s loop.
+
+    if (n_ == 0 && move_type == REMOVAL)
+      continue;
+
+    // Compute acceptance probability.
+    auto [acceptance_prob, mc_weight_ratio] = computeAcceptanceProbability();
+    acceptance_prob_ = acceptance_prob;
+
+    // Note: acceptance and rejection can be forced for testing with the appropriate "acceptance_rng".
+    const bool accepted =
+        delayed_moves_[delay_ind].acceptance_rng < std::min(std::abs(acceptance_prob_), Real(1.));
+
+    // NB: recomputeGammaInv is just a inefficient alternative to updateGammaInv. Only for testing
+    // or debbuging.
+    // recomputeGammaInv();
+
+    // Update
+    if (accepted) {
+      ++BaseClass::n_accepted_;
+
+      BaseClass::mc_log_weight_ += std::log(std::abs(mc_weight_ratio));
+
+      // Are we capturing the avg sign properly wrt multiple delayed moves
+      phase_.multiply(acceptance_prob_);
+
+      // Update GammaInv if necessary.
+      if (!at_least_one_recently_added)
+        for (int s = 0; s < 2; ++s)
+          updateGammaInv(s);
+      else {
+        removeRowAndColOfGammaInv();
+        for (int s = 0; s < 2; ++s) {
+          for (int ind = sector_indices_[s].size() - 1; ind >= 0; --ind) {
+            if (!recentlyAdded(ind, s))
+              continue;
+            insertion_list_[s].erase(std::remove(insertion_list_[s].begin(),
+                                                 insertion_list_[s].end(), sector_indices_[s][ind]),
+                                     insertion_list_[s].end());
+          }
+          for (int ind = Gamma_indices_[s].size() - 1; ind >= 0; --ind) {
+            insertion_Gamma_indices_[s].erase(std::remove(insertion_Gamma_indices_[s].begin(),
+                                                          insertion_Gamma_indices_[s].end(),
+                                                          Gamma_indices_[s][ind]),
+                                              insertion_Gamma_indices_[s].end());
+            gamma_[s].erase(gamma_[s].begin() + Gamma_indices_[s][ind]);
+
+            for (int i = 0; i < insertion_Gamma_indices_[s].size(); ++i) {
+              if (insertion_Gamma_indices_[s][i] > Gamma_indices_[s][ind])
+                --insertion_Gamma_indices_[s][i];
+            }
+          }
+        }
+      }
+
+      for (int s = 0; s < 2; ++s) {
+        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+          if (move_type == INSERTION || !recentlyAdded(ind, s)) {
+            move_indices_[s].push_back(sector_indices_[s][ind]);
+          }
+          else {
+            gamma_[s].pop_back();
+            move_indices_[s].erase(std::remove(move_indices_[s].begin(), move_indices_[s].end(),
+                                               sector_indices_[s][ind]),
+                                   move_indices_[s].end());
+          }
+        }
+      }
+
+      if (move_type == INSERTION) {
+        n_ += index_.size();
+        for (auto idx : index_)
+          configuration_.commitInsertion(idx);
+
+        for (int s = 0; s < 2; ++s) {
+          for (int ind = 0; ind < nbr_of_indices_[s]; ++ind) {
+            insertion_list_[s].push_back(sector_indices_[s][ind]);
+            insertion_Gamma_indices_[s].push_back(Gamma_inv_[s].nrRows() - nbr_of_indices_[s] + ind);
+          }
+        }
+
+        // TODO: cleanup
+        for (int idx : index_)
+          conf_removal_list_.erase(
+              std::remove(conf_removal_list_.begin(), conf_removal_list_.end(), idx),
+              conf_removal_list_.end());
+      }
+      else if (move_type == REMOVAL) {
+        n_ -= index_.size();
+        for (auto idx : index_)
+          configuration_.markForRemoval(idx);
+
+        // TODO: cleanup.
+        for (int idx : index_)
+          conf_removal_list_.push_back(idx);
+      }
+    }
+    else {  // The move is rejected:
+      for (int s = 0; s < 2; ++s) {
+        for (int ind = 0; ind < nbr_of_indices_[s]; ++ind)
+          gamma_[s].pop_back();
+      }
+      if (at_least_one_recently_added && !all_recently_added)
+        for (int s = 0; s < 2; ++s) {
+          Gamma_inv_[s].swap(Gamma_inv_cpy_[s]);
+        }
+    }
+  }
+
+  // This seems correct in that we count all steps
+  // just as is done for the non submatrix cpu version
+  BaseClass::n_steps_ += delayed_moves_.size();
+}
+
+}
+}
+}
+}

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/submat_impl.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/submat_impl.hpp
@@ -1,0 +1,51 @@
+#ifndef SUBMATIMPL_HPP
+#define SUBMATIMPL_HPP
+
+#include <array>
+#include <vector>
+#include "dca/linalg/linalg.hpp"
+
+namespace dca {
+namespace phys {
+namespace solver {
+namespace ctint {
+
+template<typename SCALAR>
+class SubmatImpl {
+public:
+  struct DelayedMoveType {
+    Move move_type;
+    std::array<double, 3> removal_rng{1., 1., 1.};
+    Real acceptance_rng;
+    std::array<int, 2> indices{-1, -1};
+  };
+
+private:
+  const DelayedMoveType* current_move_;
+  std::array<int, 2> Gamma_size_;
+  std::array<std::vector<int>, 2> Gamma_indices_;
+  std::array<std::vector<int>, 2> sector_indices_;
+
+  std::array<unsigned, 2> nbr_of_indices_;
+
+  std::vector<int> index_;
+
+  std::vector<DelayedMoveType> delayed_moves_;
+  std::array<linalg::util::HostVector<int>, 2> move_indices;
+  std::array<linalg::util::HostVector<int>, 2> removal_list;
+  std::array<linalg::util::HostVector<int>, 2> source_list;
+  std::array<std::vector<int>, 2> insertion_list;
+  std::array<std::vector<int>, 2> insertion_Gamma_indices;
+  std::vector<int> conf_removal_list;
+  std::vector<int>::iterator insertion_list_it;
+
+public:
+  void mainSubmatrixProcess();
+};
+
+}  // namespace ctint
+}  // namespace solver
+}  // namespace phys
+}  // namespace dca
+
+#endif

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder.hpp
@@ -86,7 +86,7 @@ public:
 #ifdef DCA_HAVE_GPU
   virtual void computeG0(linalg::Matrix<Scalar, linalg::GPU>& /*G0*/,
                          const details::DeviceConfiguration& /*configuration*/, int /*n_init*/,
-                         bool /*right_section*/, GpuStream /*stream*/) const {
+                         bool /*right_section*/, const GpuStream& /*stream*/) const {
     throw(std::runtime_error("Not implemented."));
   }
 #endif  // DCA_HAVE_GPU

--- a/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_gpu.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctint/walker/tools/d_matrix_builder_gpu.hpp
@@ -39,6 +39,7 @@ private:
   using BaseClass = DMatrixBuilder<linalg::CPU, Scalar>;
   using GpuStream = dca::linalg::util::GpuStream;
 public:
+  using BaseClass::setAlphas;
   template <class RDmn>
   DMatrixBuilder(const G0Interpolation<linalg::GPU, Scalar>& g0, int nb, const RDmn& /*rdmn*/);
 

--- a/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/stdthread_qmci/stdthread_qmci_cluster_solver.hpp
@@ -366,7 +366,7 @@ void StdThreadQmciClusterSolver<QmciSolver>::startWalker(int id) {
   const int walker_index = thread_task_handler_.walkerIDToRngIndex(id);
 
   auto walker_log = last_iteration_ ? BaseClass::writer_ : nullptr;
-  Walker walker(parameters_, data_, rng_vector_[walker_index], concurrency_.get_id(), id,
+  Walker walker(parameters_, data_, rng_vector_[walker_index], BaseClass::getResource(), concurrency_.get_id(), id,
                 walker_log, BaseClass::g0_);
 
   std::unique_ptr<std::exception> exception_ptr;
@@ -588,7 +588,7 @@ void StdThreadQmciClusterSolver<QmciSolver>::startWalkerAndAccumulator(int id,
 
   // Create and warm a walker.
   auto walker_log = BaseClass::writer_;
-  Walker walker(parameters_, data_, rng_vector_[id], concurrency_.get_id(), id, walker_log,
+  Walker walker(parameters_, data_, rng_vector_[id], BaseClass::getResource(), concurrency_.get_id(), id, walker_log,
                 BaseClass::g0_);
   initializeAndWarmUp(walker, id, id);
 

--- a/include/dca/phys/models/tight_binding_model.hpp
+++ b/include/dca/phys/models/tight_binding_model.hpp
@@ -28,6 +28,7 @@ namespace models {
 template <typename Lattice>
 class TightBindingModel {
 public:
+  using model_type = TightBindingModel<Lattice>;
   using lattice_type = Lattice;
   using b = func::dmn_0<domains::electron_band_domain>;
   using s = func::dmn_0<domains::electron_spin_domain>;

--- a/src/io/hdf5/hdf5_writer.cpp
+++ b/src/io/hdf5/hdf5_writer.cpp
@@ -27,6 +27,7 @@ void HDF5Writer::open_file(std::string file_name, bool overwrite) {
   if (file_)
     throw std::logic_error(__FUNCTION__);
 
+  try {
   if (overwrite) {
     file_ = std::make_unique<H5::H5File>(file_name.c_str(), H5F_ACC_TRUNC);
   }
@@ -36,7 +37,9 @@ void HDF5Writer::open_file(std::string file_name, bool overwrite) {
     else
       file_ = std::make_unique<H5::H5File>(file_name.c_str(), H5F_ACC_EXCL);
   }
-
+  } catch (const H5::Exception& exc) {
+    std::cerr << exc.getDetailMsg() << '\n';
+  }
   file_id_ = file_->getId();
 }
 

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_submatrix_gpu_complex_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_submatrix_gpu_complex_test.cpp
@@ -39,6 +39,13 @@ constexpr char input_name[] =
 template <typename Scalar>
 using CtintWalkerSubmatrixGpuComplexTest =
   typename dca::testing::G0Setup<Scalar, dca::testing::LatticeRashba, dca::ClusterSolverId::CT_INT, input_name>;
+constexpr int bands = dca::testing::LatticeRashba::BANDS;
+
+template<dca::linalg::DeviceType DEVICE, typename SCALAR>
+using DMatrixBuilder = dca::phys::solver::ctint::DMatrixBuilder<DEVICE, SCALAR>;
+
+using CDA = dca::phys::ClusterDomainAliases<dca::testing::LatticeBilayer::DIMENSION>;
+using RDmn = typename CDA::RClusterDmn;
 
 using namespace dca::phys::solver;
 
@@ -70,10 +77,10 @@ TYPED_TEST(CtintWalkerSubmatrixGpuComplexTest, doSteps) {
   G0Interpolation<GPU, Scalar> g0_gpu(g0_func);
   typename TestFixture::LabelDomain label_dmn;
 
-  DMatrixBuilder<linalg::CPU, Scalar> d_matrix_cpu(g0_cpu, n_bands_, rng);
+  DMatrixBuilder<dca::linalg::CPU, Scalar> d_matrix_cpu(g0_cpu, bands, RDmn());
   SbmWalkerCpu::setInteractionVertices(data, parameters);
   d_matrix_cpu.setAlphas(parameters.getAlphas(), parameters.adjustAlphaDd());
-  DMatrixBuilder<linalg::GPU, Scalar> d_matrix_gpu(g0_gpu, n_bands_, rng);
+  DMatrixBuilder<dca::linalg::GPU, Scalar> d_matrix_gpu(g0_gpu, bands, RDmn());
   d_matrix_gpu.setAlphas(parameters.getAlphas(), parameters.adjustAlphaDd());
   
   // ************************************

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_submatrix_gpu_complex_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_submatrix_gpu_complex_test.cpp
@@ -70,15 +70,12 @@ TYPED_TEST(CtintWalkerSubmatrixGpuComplexTest, doSteps) {
   G0Interpolation<GPU, Scalar> g0_gpu(g0_func);
   typename TestFixture::LabelDomain label_dmn;
 
-  // TODO: improve API.
-  SbmWalkerCpu::setDMatrixBuilder(g0_cpu);
-  SbmWalkerCpu::setDMatrixAlpha(parameters.getAlphas(), false);
-  SbmWalkerGpu::setDMatrixBuilder(g0_gpu);
-  SbmWalkerGpu::setDMatrixAlpha(parameters.getAlphas(), false);
-
+  DMatrixBuilder<linalg::CPU, Scalar> d_matrix_cpu(g0_cpu, n_bands_, rng);
   SbmWalkerCpu::setInteractionVertices(data, parameters);
-  SbmWalkerGpu::setInteractionVertices(data, parameters);
-
+  d_matrix_cpu.setAlphas(parameters.getAlphas(), parameters.adjustAlphaDd());
+  DMatrixBuilder<linalg::GPU, Scalar> d_matrix_gpu(g0_gpu, n_bands_, rng);
+  d_matrix_gpu.setAlphas(parameters.getAlphas(), parameters.adjustAlphaDd());
+  
   // ************************************
   // Test vertex insertion / removal ****
   // ************************************
@@ -105,9 +102,9 @@ TYPED_TEST(CtintWalkerSubmatrixGpuComplexTest, doSteps) {
 
     for (int steps = 1; steps <= 8; ++steps) {
       rng.setNewValues(setup_rngs);
-      SbmWalkerCpu walker_cpu(parameters, rng);
+      SbmWalkerCpu walker_cpu(parameters, rng, d_matrix_cpu);
       rng.setNewValues(setup_rngs);
-      SbmWalkerGpu walker_gpu(parameters, rng);
+      SbmWalkerGpu walker_gpu(parameters, rng, d_matrix_gpu);
 
       rng.setNewValues(rng_vals);
       walker_cpu.doStep(steps);

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_submatrix_gpu_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_submatrix_gpu_test.cpp
@@ -102,9 +102,10 @@ TYPED_TEST(CtintWalkerSubmatrixGpuTest, doSteps) {
 
   DMatrixBuilder<dca::linalg::CPU> d_matrix_cpu(g0_cpu, bands, RDmn());
   SbmWalkerCpu::setInteractionVertices(cpu_data, cpu_parameters);
-  d_matrix_cpu.setAlphas(cpu_parameters.getAlphas(), cpu_parameters.adjustAlphaDd());
+  d_matrix_cpu.setAlphas(cpu_parameters.getAlphas(), false); //cpu_parameters.adjustAlphaDd());
   DMatrixBuilder<dca::linalg::GPU> d_matrix_gpu(g0_gpu, bands, RDmn());
-  d_matrix_gpu.setAlphas(gpu_parameters.getAlphas(), gpu_parameters.adjustAlphaDd());
+  SbmWalkerGpu::setInteractionVertices(cpu_data, gpu_parameters);
+  d_matrix_gpu.setAlphas(gpu_parameters.getAlphas(), false); //gpu_parameters.adjustAlphaDd());
 
   // ************************************
   // Test vertex insertion / removal ****

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_submatrix_gpu_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_submatrix_gpu_test.cpp
@@ -51,6 +51,9 @@ struct CtINTWalkerSubmatrixGPUTestT : public ::testing::Test {
   G0Setup gpu_setup;
 };
 
+using CDA = dca::phys::ClusterDomainAliases<dca::testing::LatticeBilayer::DIMENSION>;
+using RDmn = typename CDA::RClusterDmn;
+
 using namespace dca::phys::solver;
 
 template <typename Scalar>
@@ -98,11 +101,10 @@ TYPED_TEST(CtintWalkerSubmatrixGpuTest, doSteps) {
   constexpr int bands = dca::testing::LatticeBilayer::BANDS;
 
   DMatrixBuilder<dca::linalg::CPU> d_matrix_cpu(g0_cpu, bands, RDmn());
-  SbmWalkerCpu::setInteractionVertices(data, parameters);
-  d_matrix_cpu.setAlphas(parameters.getAlphas(), parameters.adjustAlphaDd());
-  DMatrixBuilder<dca::linalg::GPU> d_matrix_gpu(g0_gpu, n_bands_, RDmn());
-  d_matrix_gpu.setInteractionVertices(data, parameters);
-  d_matrix_gpu.setAlphas(parameters.getAlphas(), parameters.adjustAlphaDd());
+  SbmWalkerCpu::setInteractionVertices(cpu_data, cpu_parameters);
+  d_matrix_cpu.setAlphas(cpu_parameters.getAlphas(), cpu_parameters.adjustAlphaDd());
+  DMatrixBuilder<dca::linalg::GPU> d_matrix_gpu(g0_gpu, bands, RDmn());
+  d_matrix_gpu.setAlphas(gpu_parameters.getAlphas(), gpu_parameters.adjustAlphaDd());
 
   // ************************************
   // Test vertex insertion / removal ****

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_test.cpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/ct_int_walker_test.cpp
@@ -16,7 +16,7 @@
 #include "walker_wrapper.hpp"
 #include "dca/phys/dca_step/cluster_solver/ctint/details/solver_methods.hpp"
 #include "test/unit/phys/dca_step/cluster_solver/test_setup.hpp"
-
+#include "dca/phys/domains/cluster/cluster_domain_aliases.hpp"
 #include "test/mock_mcconfig.hpp"
 namespace dca {
 namespace config {
@@ -70,12 +70,16 @@ TYPED_TEST(CtintWalkerTest, InsertAndRemoveVertex) {
   typename CtintWalkerTest<Scalar>::LabelDomain label_dmn;
 
   using Parameters = typename CtintWalkerTest<Scalar>::Parameters;
+  using CDA = dca::phys::ClusterDomainAliases<Parameters::lattice_type::DIMENSION>;
+  using RDmn = typename CDA::RClusterDmn;
+
   using Walker = testing::phys::solver::ctint::WalkerWrapper<Scalar, Parameters>;
-  Walker::setDMatrixBuilder(g0);
-  Walker::setDMatrixAlpha(parameters.getAlphas(), 0);
+  dca::phys::solver::ctint::DMatrixBuilder<dca::linalg::CPU, Scalar> d_matrix_builder(g0, 1, RDmn());
+  d_matrix_builder.setAlphas(parameters.getAlphas(), parameters.adjustAlphaDd());
+
   Walker::setInteractionVertices(data, parameters);
 
-  Walker walker(parameters, rng);
+  Walker walker(parameters, rng, d_matrix_builder);
 
   // *******************************
   // Test vertex removal ***********

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/walker_wrapper.hpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/walker_wrapper.hpp
@@ -33,8 +33,8 @@ public:
   using Real = dca::util::RealAlias<Scalar>;
   using Rng = typename Base::Rng;
 
-  WalkerWrapper(Parameters& parameters_ref, Rng& rng_ref)
-      : Base(parameters_ref, dca::phys::DcaData<Parameters>(parameters_ref), rng_ref, 0) {
+    WalkerWrapper(Parameters& parameters_ref, Rng& rng_ref, DMatrixBuilder<dca::linalg::CPU, Scalar>& d_matrix_builder)
+      : Base(parameters_ref, dca::phys::DcaData<Parameters>(parameters_ref), rng_ref, d_matrix_builder, 0) {
     Base::initialize(0);
   }
 

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/walker_wrapper_submatrix.hpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/walker_wrapper_submatrix.hpp
@@ -58,8 +58,8 @@ struct WalkerWrapperSubmatrix : public WalkerSelector<Parameters, device_t, DIST
   using Rng = typename BaseClass::Rng;
   using Data = typename BaseClass::Data;
 
-  WalkerWrapperSubmatrix(/*const*/ Parameters& parameters_ref, Rng& rng_ref)
-      : BaseClass(parameters_ref, dca::phys::DcaData<Parameters>(parameters_ref), rng_ref, 0),
+    WalkerWrapperSubmatrix(/*const*/ Parameters& parameters_ref, Rng& rng_ref, DMatrixBuilder<device_t, Scalar>& d_matrix_builder)
+      : BaseClass(parameters_ref, dca::phys::DcaData<Parameters>(parameters_ref), rng_ref, d_matrix_builder, 0),
         streams_(3) {
     BaseClass::initialize(0);
 
@@ -84,8 +84,6 @@ struct WalkerWrapperSubmatrix : public WalkerSelector<Parameters, device_t, DIST
     std::array<dca::linalg::Matrix<Scalar, CPU>, 2> M_copy{M[0], M[1]};
     return M_copy;
   }
-
-  using BaseClass::setMFromConfig;
 
   const auto& getWalkerConfiguration() const {
     return BaseClass::configuration_;

--- a/test/unit/phys/dca_step/cluster_solver/ctint/walker/walker_wrapper_submatrix.hpp
+++ b/test/unit/phys/dca_step/cluster_solver/ctint/walker/walker_wrapper_submatrix.hpp
@@ -57,6 +57,7 @@ struct WalkerWrapperSubmatrix : public WalkerSelector<Parameters, device_t, DIST
   using Real = dca::util::RealAlias<Scalar>;
   using Rng = typename BaseClass::Rng;
   using Data = typename BaseClass::Data;
+  using BaseClass::setMFromConfig;
 
     WalkerWrapperSubmatrix(/*const*/ Parameters& parameters_ref, Rng& rng_ref, DMatrixBuilder<device_t, Scalar>& d_matrix_builder)
       : BaseClass(parameters_ref, dca::phys::DcaData<Parameters>(parameters_ref), rng_ref, d_matrix_builder, 0),
@@ -67,7 +68,7 @@ struct WalkerWrapperSubmatrix : public WalkerSelector<Parameters, device_t, DIST
 
   // This purposefully shadows
   void doStep(const int n_steps_to_delay) {
-    BaseClass::doStep(n_steps_to_delay);
+    BaseClass::SubmatrixBase::doStep(n_steps_to_delay);
   }
 
   using Matrix = dca::linalg::Matrix<Scalar, CPU>;


### PR DESCRIPTION
Make the DMatrixBuilder into a  proper objects owned by a cluster solver.  They are no longer global static horrors.  This makes better testing possible and ends confusing issues with there state across iterations and between CPU and GPU implementations.

There is still an issue with the GPU DMatrixBuilder though to CTINT is broken for GPU at the moment. 