### PR TITLE
Fix cpu only fast test build

### DIFF
--- a/test/unit/phys/parameters/four_point_parameters/CMakeLists.txt
+++ b/test/unit/phys/parameters/four_point_parameters/CMakeLists.txt
@@ -1,10 +1,15 @@
 # Four-point parameters' unit tests
 
 # why this test pulls in a bunch of magma references is a mystery
-dca_add_gtest(four_point_parameters_test
-  GTEST_MAIN
-  LIBS json enumerations ${DCA_GPU_LIBS})
+# Define the libraries this test should link against
+set(FOUR_POINT_PARAMETERS_LIBS json enumerations ${DCA_GPU_LIBS})
+
 # Conditional linking for MAGMA (only link if MAGMA is available)
 if (MAGMA_FOUND)
-  target_link_libraries(four_point_parameters_test PRIVATE magma::magma)
+  list(APPEND FOUR_POINT_PARAMETERS_LIBS magma::magma)
 endif()
+
+# Create the test, passing the library list via the LIBS option
+dca_add_gtest(four_point_parameters_test
+  GTEST_MAIN
+  LIBS ${FOUR_POINT_PARAMETERS_LIBS})

--- a/test/unit/phys/parameters/four_point_parameters/CMakeLists.txt
+++ b/test/unit/phys/parameters/four_point_parameters/CMakeLists.txt
@@ -3,4 +3,8 @@
 # why this test pulls in a bunch of magma references is a mystery
 dca_add_gtest(four_point_parameters_test
   GTEST_MAIN
-  LIBS json enumerations ${DCA_GPU_LIBS} magma::magma)
+  LIBS json enumerations ${DCA_GPU_LIBS})
+# Conditional linking for MAGMA (only link if MAGMA is available)
+if (MAGMA_FOUND)
+  target_link_libraries(four_point_parameters_test PRIVATE magma::magma)
+endif()

--- a/test/unit/phys/parameters/four_point_parameters/CMakeLists.txt
+++ b/test/unit/phys/parameters/four_point_parameters/CMakeLists.txt
@@ -1,11 +1,12 @@
 # Four-point parameters' unit tests
 
-# why this test pulls in a bunch of magma references is a mystery
-# Define the libraries this test should link against
 set(FOUR_POINT_PARAMETERS_LIBS json enumerations ${DCA_GPU_LIBS})
 
 # Conditional linking for MAGMA (only link if MAGMA is available)
 if (MAGMA_FOUND)
+# This is only required for cuda 12.8 but harmless for earlier cuda
+# and rocm
+# why this test pulls in a bunch of magma references is a mystery
   list(APPEND FOUR_POINT_PARAMETERS_LIBS magma::magma)
 endif()
 


### PR DESCRIPTION
The CPU only build with -DDCA_WITH_TESTS_FAST failed on this link.  Now made conditional.