### PR TITLE
Add CPU-only CI flavor for self-hosted runner

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobname: [LLVM21-MPI-CUDA-Real-Full]
+        jobname: [LLVM21-MPI-CUDA-Real-Full,
+                  LLVM21-MPI-Real-CPU-Fast]
 
     #            GCC12-MPI-NoMPI-CUDA-Real-Full,
     #            GCC12-MPI-NoMPI-CUDA-Real-Debug-Full,

--- a/test/test_automation/ci/run_step.sh
+++ b/test/test_automation/ci/run_step.sh
@@ -89,6 +89,19 @@ case "$1" in
 	      -DDCA_WITH_TESTS_FAST=1 \
               ${GITHUB_WORKSPACE}
       ;;
+      *"LLVM21-MPI-Real-CPU-Fast"*)
+        echo 'Configure for CPU-only build with LLVM/Clang and MPI'
+        cmake -GNinja \
+              -DCMAKE_C_COMPILER=mpicc \
+              -DCMAKE_CXX_COMPILER=mpic++ \
+              -DDCA_WITH_MPI=1 \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DTEST_RUNNER="mpiexec" \
+              -DMPIEXEC_NUMPROC_FLAG="-n" \
+              -DMPIEXEC_PREFLAGS="-mca btl self,tcp" \
+              -DDCA_WITH_TESTS_FAST=1 \
+              ${GITHUB_WORKSPACE}
+      ;;
     esac
     ;;
 


### PR DESCRIPTION
Add LLVM21-MPI-Real-CPU-Fast job to the self-hosted CI matrix:
- New workflow matrix entry in ci-github-actions-self-hosted.yaml
- New configure case in run_step.sh for CPU-only build with:
  - LLVM/Clang compilers (mpicc/mpic++)
  - MPI enabled
  - Release build
  - Fast tests only
  - No CUDA or MAGMA dependencies

This runs on the same A30 self-hosted runner alongside the existing CUDA build, giving CPU-only coverage on the ORNL CI system.